### PR TITLE
Add comprehensive unit tests with XUnit and FluentAssertions

### DIFF
--- a/EdsDcfNet.sln
+++ b/EdsDcfNet.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdsDcfNet", "src\EdsDcfNet\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdsDcfNet.Examples", "examples\EdsDcfNet.Examples\EdsDcfNet.Examples.csproj", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdsDcfNet.Tests", "tests\EdsDcfNet.Tests\EdsDcfNet.Tests.csproj", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC944}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,5 +23,9 @@ Global
 		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC944}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC944}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC944}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC944}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj
+++ b/tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EdsDcfNet\EdsDcfNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/EdsDcfNet.Tests/Extensions/ObjectDictionaryExtensionsTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/ObjectDictionaryExtensionsTests.cs
@@ -1,0 +1,543 @@
+namespace EdsDcfNet.Tests.Extensions;
+
+using EdsDcfNet.Extensions;
+using EdsDcfNet.Models;
+using FluentAssertions;
+using Xunit;
+
+public class ObjectDictionaryExtensionsTests
+{
+    private ObjectDictionary CreateTestDictionary()
+    {
+        var dict = new ObjectDictionary();
+
+        // Add mandatory object
+        dict.MandatoryObjects.Add(0x1000);
+        dict.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0x00000191",
+            PdoMapping = false
+        };
+
+        // Add optional object
+        dict.OptionalObjects.Add(0x1008);
+        dict.Objects[0x1008] = new CanOpenObject
+        {
+            Index = 0x1008,
+            ParameterName = "Manufacturer Device Name",
+            ObjectType = 0x7,
+            DataType = 0x0009,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "Test Device",
+            PdoMapping = false
+        };
+
+        // Add manufacturer object
+        dict.ManufacturerObjects.Add(0x2000);
+        dict.Objects[0x2000] = new CanOpenObject
+        {
+            Index = 0x2000,
+            ParameterName = "Custom Object",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "100",
+            PdoMapping = true
+        };
+
+        // Add object with sub-objects (Identity Object 0x1018)
+        dict.MandatoryObjects.Add(0x1018);
+        dict.Objects[0x1018] = new CanOpenObject
+        {
+            Index = 0x1018,
+            ParameterName = "Identity Object",
+            ObjectType = 0x9,
+            SubNumber = 4
+        };
+
+        dict.Objects[0x1018].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "Number of Entries",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "4",
+            PdoMapping = false
+        };
+
+        dict.Objects[0x1018].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "Vendor ID",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0x00000100",
+            PdoMapping = false
+        };
+
+        // Add RPDO communication parameter (0x1400)
+        dict.Objects[0x1400] = new CanOpenObject
+        {
+            Index = 0x1400,
+            ParameterName = "RPDO Communication Parameter",
+            ObjectType = 0x9,
+            SubNumber = 2
+        };
+
+        // Add RPDO mapping parameter (0x1600)
+        dict.Objects[0x1600] = new CanOpenObject
+        {
+            Index = 0x1600,
+            ParameterName = "RPDO Mapping Parameter",
+            ObjectType = 0x9,
+            SubNumber = 0
+        };
+
+        // Add TPDO communication parameter (0x1800)
+        dict.Objects[0x1800] = new CanOpenObject
+        {
+            Index = 0x1800,
+            ParameterName = "TPDO Communication Parameter",
+            ObjectType = 0x9,
+            SubNumber = 2
+        };
+
+        // Add TPDO mapping parameter (0x1A00)
+        dict.Objects[0x1A00] = new CanOpenObject
+        {
+            Index = 0x1A00,
+            ParameterName = "TPDO Mapping Parameter",
+            ObjectType = 0x9,
+            SubNumber = 0
+        };
+
+        return dict;
+    }
+
+    #region GetObject Tests
+
+    [Fact]
+    public void GetObject_ExistingObject_ReturnsObject()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetObject(0x1000);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.ParameterName.Should().Be("Device Type");
+        result.Index.Should().Be(0x1000);
+    }
+
+    [Fact]
+    public void GetObject_NonExistentObject_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetObject(0x9999);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetSubObject Tests
+
+    [Fact]
+    public void GetSubObject_ExistingSubObject_ReturnsSubObject()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetSubObject(0x1018, 0);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.ParameterName.Should().Be("Number of Entries");
+        result.SubIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetSubObject_NonExistentObject_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetSubObject(0x9999, 0);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSubObject_NonExistentSubIndex_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetSubObject(0x1018, 99);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSubObject_ObjectWithoutSubObjects_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetSubObject(0x1000, 0);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region SetParameterValue Tests
+
+    [Fact]
+    public void SetParameterValue_ExistingObject_SetsValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        dict.SetParameterValue(0x1000, "0x12345678");
+
+        // Assert
+        dict.Objects[0x1000].ParameterValue.Should().Be("0x12345678");
+    }
+
+    [Fact]
+    public void SetParameterValue_NonExistentObject_DoesNothing()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var act = () => dict.SetParameterValue(0x9999, "value");
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SetParameterValue_SubObject_SetsValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        dict.SetParameterValue(0x1018, 1, "0xABCD");
+
+        // Assert
+        dict.Objects[0x1018].SubObjects[1].ParameterValue.Should().Be("0xABCD");
+    }
+
+    [Fact]
+    public void SetParameterValue_NonExistentSubObject_DoesNothing()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var act = () => dict.SetParameterValue(0x1018, 99, "value");
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region GetParameterValue Tests
+
+    [Fact]
+    public void GetParameterValue_ObjectWithParameterValue_ReturnsParameterValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+        dict.SetParameterValue(0x1000, "0xABCD");
+
+        // Act
+        var result = dict.GetParameterValue(0x1000);
+
+        // Assert
+        result.Should().Be("0xABCD");
+    }
+
+    [Fact]
+    public void GetParameterValue_ObjectWithoutParameterValue_ReturnsDefaultValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetParameterValue(0x1000);
+
+        // Assert
+        result.Should().Be("0x00000191"); // Default value
+    }
+
+    [Fact]
+    public void GetParameterValue_NonExistentObject_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetParameterValue(0x9999);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetParameterValue_SubObjectWithParameterValue_ReturnsParameterValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+        dict.SetParameterValue(0x1018, 1, "0xFFFF");
+
+        // Act
+        var result = dict.GetParameterValue(0x1018, 1);
+
+        // Assert
+        result.Should().Be("0xFFFF");
+    }
+
+    [Fact]
+    public void GetParameterValue_SubObjectWithoutParameterValue_ReturnsDefaultValue()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetParameterValue(0x1018, 1);
+
+        // Assert
+        result.Should().Be("0x00000100"); // Default value
+    }
+
+    [Fact]
+    public void GetParameterValue_NonExistentSubObject_ReturnsNull()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetParameterValue(0x1018, 99);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetObjectsByType Tests
+
+    [Fact]
+    public void GetObjectsByType_Mandatory_ReturnsMandatoryObjects()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetObjectsByType(ObjectCategory.Mandatory).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(obj => obj.Index == 0x1000);
+        result.Should().Contain(obj => obj.Index == 0x1018);
+    }
+
+    [Fact]
+    public void GetObjectsByType_Optional_ReturnsOptionalObjects()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetObjectsByType(ObjectCategory.Optional).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Should().Contain(obj => obj.Index == 0x1008);
+    }
+
+    [Fact]
+    public void GetObjectsByType_Manufacturer_ReturnsManufacturerObjects()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetObjectsByType(ObjectCategory.Manufacturer).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Should().Contain(obj => obj.Index == 0x2000);
+    }
+
+    [Fact]
+    public void GetObjectsByType_EmptyCategory_ReturnsEmptyEnumerable()
+    {
+        // Arrange
+        var dict = new ObjectDictionary();
+
+        // Act
+        var result = dict.GetObjectsByType(ObjectCategory.Mandatory).ToList();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region GetPdoCommunicationParameters Tests
+
+    [Fact]
+    public void GetPdoCommunicationParameters_Transmit_ReturnsTPDOCommParameters()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetPdoCommunicationParameters(transmit: true).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Index.Should().Be(0x1800);
+        result[0].ParameterName.Should().Contain("TPDO");
+    }
+
+    [Fact]
+    public void GetPdoCommunicationParameters_Receive_ReturnsRPDOCommParameters()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetPdoCommunicationParameters(transmit: false).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Index.Should().Be(0x1400);
+        result[0].ParameterName.Should().Contain("RPDO");
+    }
+
+    [Fact]
+    public void GetPdoCommunicationParameters_MultipleTPDOs_ReturnsAllInOrder()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+        dict.Objects[0x1801] = new CanOpenObject { Index = 0x1801, ParameterName = "TPDO 2" };
+        dict.Objects[0x1802] = new CanOpenObject { Index = 0x1802, ParameterName = "TPDO 3" };
+
+        // Act
+        var result = dict.GetPdoCommunicationParameters(transmit: true).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].Index.Should().Be(0x1800);
+        result[1].Index.Should().Be(0x1801);
+        result[2].Index.Should().Be(0x1802);
+    }
+
+    [Fact]
+    public void GetPdoCommunicationParameters_NoPDOs_ReturnsEmpty()
+    {
+        // Arrange
+        var dict = new ObjectDictionary();
+
+        // Act
+        var result = dict.GetPdoCommunicationParameters(transmit: true).ToList();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region GetPdoMappingParameters Tests
+
+    [Fact]
+    public void GetPdoMappingParameters_Transmit_ReturnsTPDOMappingParameters()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetPdoMappingParameters(transmit: true).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Index.Should().Be(0x1A00);
+        result[0].ParameterName.Should().Contain("TPDO");
+    }
+
+    [Fact]
+    public void GetPdoMappingParameters_Receive_ReturnsRPDOMappingParameters()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+
+        // Act
+        var result = dict.GetPdoMappingParameters(transmit: false).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Index.Should().Be(0x1600);
+        result[0].ParameterName.Should().Contain("RPDO");
+    }
+
+    [Fact]
+    public void GetPdoMappingParameters_MultipleRPDOs_ReturnsAllInOrder()
+    {
+        // Arrange
+        var dict = CreateTestDictionary();
+        dict.Objects[0x1601] = new CanOpenObject { Index = 0x1601, ParameterName = "RPDO 2 Mapping" };
+        dict.Objects[0x1602] = new CanOpenObject { Index = 0x1602, ParameterName = "RPDO 3 Mapping" };
+
+        // Act
+        var result = dict.GetPdoMappingParameters(transmit: false).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].Index.Should().Be(0x1600);
+        result[1].Index.Should().Be(0x1601);
+        result[2].Index.Should().Be(0x1602);
+    }
+
+    [Fact]
+    public void GetPdoMappingParameters_NoPDOs_ReturnsEmpty()
+    {
+        // Arrange
+        var dict = new ObjectDictionary();
+
+        // Act
+        var result = dict.GetPdoMappingParameters(transmit: true).ToList();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+}

--- a/tests/EdsDcfNet.Tests/Fixtures/sample_device.eds
+++ b/tests/EdsDcfNet.Tests/Fixtures/sample_device.eds
@@ -1,0 +1,278 @@
+;*****************************************************************************
+; Sample CANopen Electronic Data Sheet (EDS)
+; Created by: EdsDcfNet Library
+; Date: 2025-12-16
+;*****************************************************************************
+
+[FileInfo]
+FileName=sample_device.eds
+FileVersion=1
+FileRevision=0
+EDSVersion=4.0
+Description=Sample CANopen I/O Device
+CreationTime=10:00AM
+CreationDate=12-16-2025
+CreatedBy=EdsDcfNet Example
+
+[DeviceInfo]
+VendorName=Example Automation Inc.
+VendorNumber=0x00000100
+ProductName=IO-Module 16x16
+ProductNumber=0x00001001
+RevisionNumber=0x00010000
+OrderCode=IO-16X16-001
+BaudRate_10=1
+BaudRate_20=1
+BaudRate_50=1
+BaudRate_125=1
+BaudRate_250=1
+BaudRate_500=1
+BaudRate_800=0
+BaudRate_1000=1
+SimpleBootUpMaster=0
+SimpleBootUpSlave=1
+Granularity=8
+DynamicChannelsSupported=0
+GroupMessaging=0
+NrOfRXPDO=4
+NrOfTXPDO=4
+LSS_Supported=0
+
+[DummyUsage]
+Dummy0002=1
+Dummy0003=1
+Dummy0004=1
+Dummy0005=1
+Dummy0006=1
+Dummy0007=1
+
+[MandatoryObjects]
+SupportedObjects=2
+1=0x1000
+2=0x1001
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000191
+PDOMapping=0
+
+[1001]
+ParameterName=Error Register
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=1
+
+[OptionalObjects]
+SupportedObjects=10
+1=0x1008
+2=0x1009
+3=0x100A
+4=0x1018
+5=0x1400
+6=0x1600
+7=0x1800
+8=0x1A00
+9=0x6000
+10=0x6200
+
+[1008]
+ParameterName=Manufacturer Device Name
+ObjectType=0x7
+DataType=0x0009
+AccessType=ro
+DefaultValue=IO-Module 16x16
+PDOMapping=0
+
+[1009]
+ParameterName=Manufacturer Hardware Version
+ObjectType=0x7
+DataType=0x0009
+AccessType=ro
+DefaultValue=1.0
+PDOMapping=0
+
+[100A]
+ParameterName=Manufacturer Software Version
+ObjectType=0x7
+DataType=0x0009
+AccessType=ro
+DefaultValue=1.0.0
+PDOMapping=0
+
+[1018]
+ParameterName=Identity Object
+SubNumber=4
+ObjectType=0x9
+
+[1018sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=4
+PDOMapping=0
+
+[1018sub1]
+ParameterName=Vendor ID
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000100
+PDOMapping=0
+
+[1018sub2]
+ParameterName=Product Code
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00001001
+PDOMapping=0
+
+[1018sub3]
+ParameterName=Revision Number
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00010000
+PDOMapping=0
+
+[1018sub4]
+ParameterName=Serial Number
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000001
+PDOMapping=0
+
+[1400]
+ParameterName=RPDO Communication Parameter
+SubNumber=2
+ObjectType=0x9
+
+[1400sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=2
+PDOMapping=0
+
+[1400sub1]
+ParameterName=COB-ID
+ObjectType=0x7
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x200
+PDOMapping=0
+
+[1400sub2]
+ParameterName=Transmission Type
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=255
+PDOMapping=0
+
+[1600]
+ParameterName=RPDO Mapping Parameter
+SubNumber=0
+ObjectType=0x9
+CompactSubObj=8
+
+[1600sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=2
+PDOMapping=0
+
+[1800]
+ParameterName=TPDO Communication Parameter
+SubNumber=2
+ObjectType=0x9
+
+[1800sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=2
+PDOMapping=0
+
+[1800sub1]
+ParameterName=COB-ID
+ObjectType=0x7
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x180
+PDOMapping=0
+
+[1800sub2]
+ParameterName=Transmission Type
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=255
+PDOMapping=0
+
+[1A00]
+ParameterName=TPDO Mapping Parameter
+SubNumber=0
+ObjectType=0x9
+CompactSubObj=8
+
+[1A00sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=2
+PDOMapping=0
+
+[6000]
+ParameterName=Digital Input 8-Bit
+SubNumber=16
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=1
+CompactSubObj=16
+
+[6000sub0]
+ParameterName=Number of Elements
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=16
+PDOMapping=0
+
+[6200]
+ParameterName=Digital Output 8-Bit
+SubNumber=16
+ObjectType=0x8
+DataType=0x0005
+AccessType=rww
+DefaultValue=0
+PDOMapping=1
+CompactSubObj=16
+
+[6200sub0]
+ParameterName=Number of Elements
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=16
+PDOMapping=0
+
+[Comments]
+Lines=3
+Line1=Sample EDS file for demonstration purposes
+Line2=This device is a 16x16 digital I/O module
+Line3=Created with EdsDcfNet library

--- a/tests/EdsDcfNet.Tests/GlobalUsings.cs
+++ b/tests/EdsDcfNet.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
@@ -1,0 +1,410 @@
+namespace EdsDcfNet.Tests.Integration;
+
+using EdsDcfNet;
+using EdsDcfNet.Models;
+using FluentAssertions;
+using Xunit;
+
+public class CanOpenFileTests
+{
+    #region ReadEds Tests
+
+    [Fact]
+    public void ReadEds_ValidFile_ReturnsElectronicDataSheet()
+    {
+        // Arrange
+        var filePath = "Fixtures/sample_device.eds";
+
+        // Act
+        var result = CanOpenFile.ReadEds(filePath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<ElectronicDataSheet>();
+        result.FileInfo.FileName.Should().Be("sample_device.eds");
+        result.DeviceInfo.ProductName.Should().Be("IO-Module 16x16");
+    }
+
+    [Fact]
+    public void ReadEds_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var filePath = "NonExistent.eds";
+
+        // Act
+        var act = () => CanOpenFile.ReadEds(filePath);
+
+        // Assert
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    #endregion
+
+    #region ReadEdsFromString Tests
+
+    [Fact]
+    public void ReadEdsFromString_ValidContent_ReturnsElectronicDataSheet()
+    {
+        // Arrange
+        var content = @"
+[FileInfo]
+FileName=test.eds
+FileVersion=1
+FileRevision=0
+
+[DeviceInfo]
+VendorName=Test Vendor
+ProductName=Test Product
+VendorNumber=0x100
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+";
+
+        // Act
+        var result = CanOpenFile.ReadEdsFromString(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileInfo.FileName.Should().Be("test.eds");
+        result.DeviceInfo.VendorName.Should().Be("Test Vendor");
+        result.DeviceInfo.ProductName.Should().Be("Test Product");
+    }
+
+    #endregion
+
+    #region ReadDcfFromString Tests
+
+    [Fact]
+    public void ReadDcfFromString_ValidContent_ReturnsDeviceConfigurationFile()
+    {
+        // Arrange
+        var content = @"
+[FileInfo]
+FileName=test.dcf
+FileVersion=1
+FileRevision=0
+
+[DeviceInfo]
+VendorName=Test Vendor
+ProductName=Test Product
+
+[DeviceCommissioning]
+NodeID=5
+NodeName=TestNode
+Baudrate=500
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+";
+
+        // Act
+        var result = CanOpenFile.ReadDcfFromString(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<DeviceConfigurationFile>();
+        result.DeviceCommissioning.NodeId.Should().Be(5);
+        result.DeviceCommissioning.NodeName.Should().Be("TestNode");
+        result.DeviceCommissioning.Baudrate.Should().Be(500);
+    }
+
+    #endregion
+
+    #region WriteDcfToString Tests
+
+    [Fact]
+    public void WriteDcfToString_ValidDcf_GeneratesString()
+    {
+        // Arrange
+        var dcf = new DeviceConfigurationFile
+        {
+            FileInfo = new EdsFileInfo
+            {
+                FileName = "test.dcf",
+                FileVersion = 1,
+                FileRevision = 0,
+                EdsVersion = "4.0"
+            },
+            DeviceInfo = new DeviceInfo
+            {
+                VendorName = "Test Vendor",
+                ProductName = "Test Product",
+                VendorNumber = 0x100,
+                ProductNumber = 0x1001
+            },
+            DeviceCommissioning = new DeviceCommissioning
+            {
+                NodeId = 5,
+                Baudrate = 500,
+                NodeName = "TestNode"
+            },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        dcf.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        dcf.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0x191",
+            PdoMapping = false
+        };
+
+        // Act
+        var result = CanOpenFile.WriteDcfToString(dcf);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("[FileInfo]");
+        result.Should().Contain("[DeviceInfo]");
+        result.Should().Contain("[DeviceCommissioning]");
+        result.Should().Contain("NodeID=5");
+        result.Should().Contain("Baudrate=500");
+    }
+
+    #endregion
+
+    #region EdsToDcf Tests
+
+    [Fact]
+    public void EdsToDcf_ValidEds_CreatesDcfWithCommissioning()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo
+            {
+                FileName = "test.eds",
+                FileVersion = 1,
+                FileRevision = 0,
+                EdsVersion = "4.0"
+            },
+            DeviceInfo = new DeviceInfo
+            {
+                VendorName = "Test Vendor",
+                ProductName = "Test Product",
+                VendorNumber = 0x100
+            },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5, baudrate: 500, nodeName: "MyDevice");
+
+        // Assert
+        dcf.Should().NotBeNull();
+        dcf.Should().BeOfType<DeviceConfigurationFile>();
+        dcf.DeviceCommissioning.NodeId.Should().Be(5);
+        dcf.DeviceCommissioning.Baudrate.Should().Be(500);
+        dcf.DeviceCommissioning.NodeName.Should().Be("MyDevice");
+        dcf.FileInfo.FileName.Should().Be("test.dcf");
+    }
+
+    [Fact]
+    public void EdsToDcf_DefaultBaudrate_Uses250()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo { FileName = "test.eds" },
+            DeviceInfo = new DeviceInfo { ProductName = "Test Product" },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.DeviceCommissioning.Baudrate.Should().Be(250);
+    }
+
+    [Fact]
+    public void EdsToDcf_NoNodeName_GeneratesDefault()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo { FileName = "test.eds" },
+            DeviceInfo = new DeviceInfo { ProductName = "Test Product" },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.DeviceCommissioning.NodeName.Should().Be("Test Product_Node5");
+    }
+
+    [Fact]
+    public void EdsToDcf_IncrementsFileRevision()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo
+            {
+                FileName = "test.eds",
+                FileVersion = 2,
+                FileRevision = 3
+            },
+            DeviceInfo = new DeviceInfo { ProductName = "Test" },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.FileInfo.FileVersion.Should().Be(2);
+        dcf.FileInfo.FileRevision.Should().Be(4); // Incremented
+    }
+
+    [Fact]
+    public void EdsToDcf_PreservesDeviceInfo()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo { FileName = "test.eds" },
+            DeviceInfo = new DeviceInfo
+            {
+                VendorName = "Test Vendor",
+                ProductName = "Test Product",
+                VendorNumber = 0x100,
+                ProductNumber = 0x1001,
+                OrderCode = "TEST-001"
+            },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.DeviceInfo.Should().BeSameAs(eds.DeviceInfo);
+        dcf.DeviceInfo.VendorName.Should().Be("Test Vendor");
+        dcf.DeviceInfo.ProductName.Should().Be("Test Product");
+        dcf.DeviceInfo.VendorNumber.Should().Be(0x100);
+    }
+
+    [Fact]
+    public void EdsToDcf_PreservesObjectDictionary()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo { FileName = "test.eds" },
+            DeviceInfo = new DeviceInfo { ProductName = "Test" },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        eds.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type"
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.ObjectDictionary.Should().BeSameAs(eds.ObjectDictionary);
+        dcf.ObjectDictionary.Objects.Should().ContainKey(0x1000);
+    }
+
+    [Fact]
+    public void EdsToDcf_SetsLastEds()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet
+        {
+            FileInfo = new EdsFileInfo { FileName = "original.eds" },
+            DeviceInfo = new DeviceInfo { ProductName = "Test" },
+            ObjectDictionary = new ObjectDictionary()
+        };
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
+
+        // Assert
+        dcf.FileInfo.LastEds.Should().Be("original.eds");
+    }
+
+    #endregion
+
+    #region Round-trip Tests
+
+    [Fact]
+    public void RoundTrip_EdsToString_PreservesData()
+    {
+        // Arrange
+        var filePath = "Fixtures/sample_device.eds";
+        var originalEds = CanOpenFile.ReadEds(filePath);
+
+        // Convert to DCF
+        var dcf = CanOpenFile.EdsToDcf(originalEds, nodeId: 5, baudrate: 500);
+
+        // Write to string
+        var dcfString = CanOpenFile.WriteDcfToString(dcf);
+
+        // Act - Read back from string
+        var parsedDcf = CanOpenFile.ReadDcfFromString(dcfString);
+
+        // Assert
+        parsedDcf.DeviceInfo.VendorName.Should().Be(originalEds.DeviceInfo.VendorName);
+        parsedDcf.DeviceInfo.ProductName.Should().Be(originalEds.DeviceInfo.ProductName);
+        parsedDcf.DeviceCommissioning.NodeId.Should().Be(5);
+        parsedDcf.DeviceCommissioning.Baudrate.Should().Be(500);
+        parsedDcf.ObjectDictionary.MandatoryObjects.Should().BeEquivalentTo(originalEds.ObjectDictionary.MandatoryObjects);
+    }
+
+    [Fact]
+    public void RoundTrip_EdsToDcfWriteRead_PreservesObjects()
+    {
+        // Arrange
+        var filePath = "Fixtures/sample_device.eds";
+        var originalEds = CanOpenFile.ReadEds(filePath);
+
+        // Act
+        var dcf = CanOpenFile.EdsToDcf(originalEds, nodeId: 10, baudrate: 250);
+        var dcfString = CanOpenFile.WriteDcfToString(dcf);
+        var parsedDcf = CanOpenFile.ReadDcfFromString(dcfString);
+
+        // Assert - Check specific objects are preserved
+        parsedDcf.ObjectDictionary.Objects.Should().ContainKey(0x1000);
+        parsedDcf.ObjectDictionary.Objects[0x1000].ParameterName.Should().Be("Device Type");
+        parsedDcf.ObjectDictionary.Objects[0x1000].DefaultValue.Should().Be(originalEds.ObjectDictionary.Objects[0x1000].DefaultValue);
+    }
+
+    #endregion
+}

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -1,0 +1,627 @@
+namespace EdsDcfNet.Tests.Parsers;
+
+using EdsDcfNet.Exceptions;
+using EdsDcfNet.Models;
+using EdsDcfNet.Parsers;
+using FluentAssertions;
+using Xunit;
+
+public class EdsReaderTests
+{
+    private readonly EdsReader _reader = new();
+
+    #region ReadFile Tests
+
+    [Fact]
+    public void ReadFile_ValidEdsFile_ParsesSuccessfully()
+    {
+        // Arrange
+        var filePath = "Fixtures/sample_device.eds";
+
+        // Act
+        var result = _reader.ReadFile(filePath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileInfo.Should().NotBeNull();
+        result.DeviceInfo.Should().NotBeNull();
+        result.ObjectDictionary.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ReadFile_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var filePath = "NonExistent.eds";
+
+        // Act
+        var act = () => _reader.ReadFile(filePath);
+
+        // Assert
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    #endregion
+
+    #region ReadString Tests
+
+    [Fact]
+    public void ReadString_ValidEdsContent_ParsesSuccessfully()
+    {
+        // Arrange
+        var content = @"
+[FileInfo]
+FileName=test.eds
+FileVersion=1
+FileRevision=0
+EDSVersion=4.0
+
+[DeviceInfo]
+VendorName=Test Vendor
+VendorNumber=0x100
+ProductName=Test Product
+ProductNumber=0x1001
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000191
+PDOMapping=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileInfo.FileName.Should().Be("test.eds");
+        result.DeviceInfo.VendorName.Should().Be("Test Vendor");
+    }
+
+    [Fact]
+    public void ReadString_MissingDeviceInfo_ThrowsException()
+    {
+        // Arrange
+        var content = @"
+[FileInfo]
+FileName=test.eds
+";
+
+        // Act
+        var act = () => _reader.ReadString(content);
+
+        // Assert
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*DeviceInfo*");
+    }
+
+    #endregion
+
+    #region FileInfo Parsing Tests
+
+    [Fact]
+    public void ReadString_FileInfo_ParsesAllFields()
+    {
+        // Arrange
+        var content = @"
+[FileInfo]
+FileName=test.eds
+FileVersion=2
+FileRevision=5
+EDSVersion=4.0
+Description=Test Description
+CreationTime=10:30AM
+CreationDate=01-15-2025
+CreatedBy=Test User
+ModificationTime=11:00AM
+ModificationDate=01-16-2025
+ModifiedBy=Another User
+
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.FileInfo.FileName.Should().Be("test.eds");
+        result.FileInfo.FileVersion.Should().Be(2);
+        result.FileInfo.FileRevision.Should().Be(5);
+        result.FileInfo.EdsVersion.Should().Be("4.0");
+        result.FileInfo.Description.Should().Be("Test Description");
+        result.FileInfo.CreationTime.Should().Be("10:30AM");
+        result.FileInfo.CreationDate.Should().Be("01-15-2025");
+        result.FileInfo.CreatedBy.Should().Be("Test User");
+        result.FileInfo.ModificationTime.Should().Be("11:00AM");
+        result.FileInfo.ModificationDate.Should().Be("01-16-2025");
+        result.FileInfo.ModifiedBy.Should().Be("Another User");
+    }
+
+    [Fact]
+    public void ReadString_MissingFileInfo_UsesDefaults()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.FileInfo.Should().NotBeNull();
+        result.FileInfo.FileVersion.Should().Be(1);
+        result.FileInfo.FileRevision.Should().Be(0);
+        result.FileInfo.EdsVersion.Should().Be("4.0");
+    }
+
+    #endregion
+
+    #region DeviceInfo Parsing Tests
+
+    [Fact]
+    public void ReadString_DeviceInfo_ParsesAllFields()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Example Automation Inc.
+VendorNumber=0x00000100
+ProductName=IO-Module 16x16
+ProductNumber=0x00001001
+RevisionNumber=0x00010000
+OrderCode=IO-16X16-001
+BaudRate_10=1
+BaudRate_20=1
+BaudRate_50=1
+BaudRate_125=1
+BaudRate_250=1
+BaudRate_500=1
+BaudRate_800=0
+BaudRate_1000=1
+SimpleBootUpMaster=0
+SimpleBootUpSlave=1
+Granularity=8
+DynamicChannelsSupported=0
+GroupMessaging=0
+NrOfRXPDO=4
+NrOfTXPDO=4
+LSS_Supported=0
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.DeviceInfo.VendorName.Should().Be("Example Automation Inc.");
+        result.DeviceInfo.VendorNumber.Should().Be(0x00000100);
+        result.DeviceInfo.ProductName.Should().Be("IO-Module 16x16");
+        result.DeviceInfo.ProductNumber.Should().Be(0x00001001);
+        result.DeviceInfo.RevisionNumber.Should().Be(0x00010000);
+        result.DeviceInfo.OrderCode.Should().Be("IO-16X16-001");
+        result.DeviceInfo.SimpleBootUpMaster.Should().BeFalse();
+        result.DeviceInfo.SimpleBootUpSlave.Should().BeTrue();
+        result.DeviceInfo.Granularity.Should().Be(8);
+        result.DeviceInfo.DynamicChannelsSupported.Should().BeFalse();
+        result.DeviceInfo.GroupMessaging.Should().BeFalse();
+        result.DeviceInfo.NrOfRXPDO.Should().Be(4);
+        result.DeviceInfo.NrOfTXPDO.Should().Be(4);
+        result.DeviceInfo.LSS_Supported.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReadString_DeviceInfo_ParsesBaudRates()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+BaudRate_10=1
+BaudRate_20=0
+BaudRate_50=1
+BaudRate_125=1
+BaudRate_250=1
+BaudRate_500=1
+BaudRate_800=0
+BaudRate_1000=1
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.DeviceInfo.SupportedBaudRates.BaudRate_10.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_20.Should().BeFalse();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_50.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_125.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_250.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_500.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_800.Should().BeFalse();
+        result.DeviceInfo.SupportedBaudRates.BaudRate_1000.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Object Dictionary Parsing Tests
+
+    [Fact]
+    public void ReadString_ObjectDictionary_ParsesMandatoryObjects()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=2
+1=0x1000
+2=0x1001
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000191
+PDOMapping=0
+
+[1001]
+ParameterName=Error Register
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=1
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.ObjectDictionary.MandatoryObjects.Should().HaveCount(2);
+        result.ObjectDictionary.MandatoryObjects.Should().Contain(0x1000);
+        result.ObjectDictionary.MandatoryObjects.Should().Contain(0x1001);
+        result.ObjectDictionary.Objects.Should().ContainKey(0x1000);
+        result.ObjectDictionary.Objects.Should().ContainKey(0x1001);
+    }
+
+    [Fact]
+    public void ReadString_ObjectDictionary_ParsesOptionalObjects()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+
+[OptionalObjects]
+SupportedObjects=2
+1=0x1008
+2=0x1009
+
+[1008]
+ParameterName=Manufacturer Device Name
+ObjectType=0x7
+DataType=0x0009
+AccessType=ro
+DefaultValue=Test Device
+PDOMapping=0
+
+[1009]
+ParameterName=Manufacturer Hardware Version
+ObjectType=0x7
+DataType=0x0009
+AccessType=ro
+DefaultValue=1.0
+PDOMapping=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.ObjectDictionary.OptionalObjects.Should().HaveCount(2);
+        result.ObjectDictionary.OptionalObjects.Should().Contain(0x1008);
+        result.ObjectDictionary.OptionalObjects.Should().Contain(0x1009);
+    }
+
+    [Fact]
+    public void ReadString_Object_ParsesAllProperties()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000191
+PDOMapping=0
+LowLimit=0
+HighLimit=0xFFFFFFFF
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x1000];
+        obj.Index.Should().Be(0x1000);
+        obj.ParameterName.Should().Be("Device Type");
+        obj.ObjectType.Should().Be(0x7);
+        obj.DataType.Should().Be(0x0007);
+        obj.AccessType.Should().Be(AccessType.ReadOnly);
+        obj.DefaultValue.Should().Be("0x00000191");
+        obj.PdoMapping.Should().BeFalse();
+        obj.LowLimit.Should().Be("0");
+        obj.HighLimit.Should().Be("0xFFFFFFFF");
+    }
+
+    [Fact]
+    public void ReadString_ObjectWithSubObjects_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+Dummy0005=1
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1018
+
+[1018]
+ParameterName=Identity Object
+SubNumber=2
+ObjectType=0x9
+
+[1018sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=2
+PDOMapping=0
+
+[1018sub1]
+ParameterName=Vendor ID
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000100
+PDOMapping=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x1018];
+        obj.SubNumber.Should().Be(2);
+        obj.SubObjects.Should().ContainKey(0);
+        obj.SubObjects.Should().ContainKey(1);
+        obj.SubObjects[0].ParameterName.Should().Be("Number of Entries");
+        obj.SubObjects[1].ParameterName.Should().Be("Vendor ID");
+    }
+
+    [Fact]
+    public void ReadString_AccessTypes_ParsesAllTypes()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+Dummy0003=1
+Dummy0004=1
+Dummy0005=1
+Dummy0006=1
+Dummy0007=1
+
+[MandatoryObjects]
+SupportedObjects=6
+1=0x2000
+2=0x2001
+3=0x2002
+4=0x2003
+5=0x2004
+6=0x2005
+
+[2000]
+ParameterName=ReadOnly Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+[2001]
+ParameterName=WriteOnly Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=wo
+DefaultValue=0
+PDOMapping=0
+
+[2002]
+ParameterName=ReadWrite Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+
+[2003]
+ParameterName=ReadWriteInput Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=rwr
+DefaultValue=0
+PDOMapping=0
+
+[2004]
+ParameterName=ReadWriteOutput Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=rww
+DefaultValue=0
+PDOMapping=0
+
+[2005]
+ParameterName=Constant Object
+ObjectType=0x7
+DataType=0x0005
+AccessType=const
+DefaultValue=0
+PDOMapping=0
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.ObjectDictionary.Objects[0x2000].AccessType.Should().Be(AccessType.ReadOnly);
+        result.ObjectDictionary.Objects[0x2001].AccessType.Should().Be(AccessType.WriteOnly);
+        result.ObjectDictionary.Objects[0x2002].AccessType.Should().Be(AccessType.ReadWrite);
+        result.ObjectDictionary.Objects[0x2003].AccessType.Should().Be(AccessType.ReadWriteInput);
+        result.ObjectDictionary.Objects[0x2004].AccessType.Should().Be(AccessType.ReadWriteOutput);
+        result.ObjectDictionary.Objects[0x2005].AccessType.Should().Be(AccessType.Constant);
+    }
+
+    #endregion
+
+    #region Comments Parsing Tests
+
+    [Fact]
+    public void ReadString_Comments_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[DummyUsage]
+Dummy0002=1
+
+[MandatoryObjects]
+SupportedObjects=0
+
+[Comments]
+Lines=3
+Line1=First comment line
+Line2=Second comment line
+Line3=Third comment line
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.Comments.Should().NotBeNull();
+        result.Comments.Lines.Should().Be(3);
+        result.Comments.CommentLines.Should().HaveCount(3);
+        result.Comments.CommentLines[1].Should().Be("First comment line");
+        result.Comments.CommentLines[2].Should().Be("Second comment line");
+        result.Comments.CommentLines[3].Should().Be("Third comment line");
+    }
+
+    #endregion
+
+    #region Sample File Integration Test
+
+    [Fact]
+    public void ReadFile_SampleDeviceEds_ParsesCompletely()
+    {
+        // Arrange
+        var filePath = "Fixtures/sample_device.eds";
+
+        // Act
+        var result = _reader.ReadFile(filePath);
+
+        // Assert - FileInfo
+        result.FileInfo.FileName.Should().Be("sample_device.eds");
+        result.FileInfo.FileVersion.Should().Be(1);
+        result.FileInfo.FileRevision.Should().Be(0);
+        result.FileInfo.EdsVersion.Should().Be("4.0");
+
+        // Assert - DeviceInfo
+        result.DeviceInfo.VendorName.Should().Be("Example Automation Inc.");
+        result.DeviceInfo.ProductName.Should().Be("IO-Module 16x16");
+        result.DeviceInfo.VendorNumber.Should().Be(0x00000100);
+        result.DeviceInfo.ProductNumber.Should().Be(0x00001001);
+
+        // Assert - ObjectDictionary
+        result.ObjectDictionary.MandatoryObjects.Should().Contain(0x1000);
+        result.ObjectDictionary.MandatoryObjects.Should().Contain(0x1001);
+        result.ObjectDictionary.OptionalObjects.Should().Contain(0x1008);
+        result.ObjectDictionary.OptionalObjects.Should().Contain(0x1018);
+
+        // Assert - Specific Objects
+        result.ObjectDictionary.Objects[0x1000].ParameterName.Should().Be("Device Type");
+        result.ObjectDictionary.Objects[0x1001].ParameterName.Should().Be("Error Register");
+
+        // Assert - Comments
+        result.Comments.Lines.Should().Be(3);
+        result.Comments.CommentLines[1].Should().Contain("Sample EDS file");
+    }
+
+    #endregion
+}

--- a/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
@@ -1,0 +1,578 @@
+namespace EdsDcfNet.Tests.Parsers;
+
+using EdsDcfNet.Exceptions;
+using EdsDcfNet.Parsers;
+using FluentAssertions;
+using Xunit;
+
+public class IniParserTests
+{
+    #region ParseString Tests
+
+    [Fact]
+    public void ParseString_SimpleSectionWithKeyValue_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("Section1");
+        result["Section1"].Should().ContainKey("Key1").WhoseValue.Should().Be("Value1");
+        result["Section1"].Should().ContainKey("Key2").WhoseValue.Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_MultipleSections_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+
+[Section2]
+Key2=Value2
+Key3=Value3
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().ContainKey("Section1");
+        result.Should().ContainKey("Section2");
+        result["Section1"]["Key1"].Should().Be("Value1");
+        result["Section2"]["Key2"].Should().Be("Value2");
+        result["Section2"]["Key3"].Should().Be("Value3");
+    }
+
+    [Fact]
+    public void ParseString_CommentsAreIgnored()
+    {
+        // Arrange
+        var content = @"
+; This is a comment
+[Section1]
+; Another comment
+Key1=Value1
+; Comment in the middle
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("Section1");
+        result["Section1"].Should().HaveCount(2);
+        result["Section1"]["Key1"].Should().Be("Value1");
+        result["Section1"]["Key2"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_EmptyLinesAreIgnored()
+    {
+        // Arrange
+        var content = @"
+
+
+[Section1]
+
+Key1=Value1
+
+
+Key2=Value2
+
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("Section1");
+        result["Section1"].Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ParseString_WhitespaceIsTrimmed()
+    {
+        // Arrange
+        var content = @"
+[  Section1  ]
+  Key1  =  Value1
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("Section1");
+        result["Section1"]["Key1"].Should().Be("Value1");
+        result["Section1"]["Key2"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_SectionNameIsCaseInsensitive()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("section1");
+        result.Should().ContainKey("SECTION1");
+        result.Should().ContainKey("Section1");
+    }
+
+    [Fact]
+    public void ParseString_KeyNameIsCaseInsensitive()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result["Section1"].Should().ContainKey("key1");
+        result["Section1"].Should().ContainKey("KEY1");
+        result["Section1"].Should().ContainKey("Key1");
+    }
+
+    [Fact]
+    public void ParseString_EmptyValue_ParsesAsEmptyString()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result["Section1"]["Key1"].Should().Be(string.Empty);
+        result["Section1"]["Key2"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_ValueWithEqualSign_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value=With=Equals
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result["Section1"]["Key1"].Should().Be("Value=With=Equals");
+    }
+
+    [Fact]
+    public void ParseString_HexadecimalValues_PreservesFormat()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=0xFF
+Key2=0x1000
+Key3=$NODEID+0x200
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result["Section1"]["Key1"].Should().Be("0xFF");
+        result["Section1"]["Key2"].Should().Be("0x1000");
+        result["Section1"]["Key3"].Should().Be("$NODEID+0x200");
+    }
+
+    [Fact]
+    public void ParseString_KeyValueOutsideSection_ThrowsException()
+    {
+        // Arrange
+        var content = @"
+Key1=Value1
+[Section1]
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var act = () => parser.ParseString(content);
+
+        // Assert
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*Key-value pair found outside of any section*");
+    }
+
+    [Fact]
+    public void ParseString_DuplicateSection_MergesKeys()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+
+[Section1]
+Key2=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("Section1");
+        result["Section1"].Should().HaveCount(2);
+        result["Section1"]["Key1"].Should().Be("Value1");
+        result["Section1"]["Key2"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_DuplicateKey_UsesLastValue()
+    {
+        // Arrange
+        var content = @"
+[Section1]
+Key1=Value1
+Key1=Value2
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result["Section1"]["Key1"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public void ParseString_SubObjectSyntax_ParsesCorrectly()
+    {
+        // Arrange
+        var content = @"
+[1018sub0]
+ParameterName=Number of Entries
+DataType=0x0005
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().ContainKey("1018sub0");
+        result["1018sub0"]["ParameterName"].Should().Be("Number of Entries");
+        result["1018sub0"]["DataType"].Should().Be("0x0005");
+    }
+
+    [Fact]
+    public void ParseString_EmptyInput_ReturnsEmptyDictionary()
+    {
+        // Arrange
+        var content = string.Empty;
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseString_OnlyComments_ReturnsEmptyDictionary()
+    {
+        // Arrange
+        var content = @"
+; Comment 1
+; Comment 2
+; Comment 3
+";
+        var parser = new IniParser();
+
+        // Act
+        var result = parser.ParseString(content);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ParseFile Tests
+
+    [Fact]
+    public void ParseFile_ValidFile_ParsesCorrectly()
+    {
+        // Arrange
+        var parser = new IniParser();
+        var filePath = "Fixtures/sample_device.eds";
+
+        // Act
+        var result = parser.ParseFile(filePath);
+
+        // Assert
+        result.Should().NotBeEmpty();
+        result.Should().ContainKey("FileInfo");
+        result.Should().ContainKey("DeviceInfo");
+        result.Should().ContainKey("1000");
+    }
+
+    [Fact]
+    public void ParseFile_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var parser = new IniParser();
+        var filePath = "NonExistent.eds";
+
+        // Act
+        var act = () => parser.ParseFile(filePath);
+
+        // Assert
+        act.Should().Throw<FileNotFoundException>()
+            .WithMessage("*EDS/DCF file not found*");
+    }
+
+    #endregion
+
+    #region GetValue Tests
+
+    [Fact]
+    public void GetValue_ExistingKey_ReturnsValue()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>
+            {
+                ["Key1"] = "Value1"
+            }
+        };
+
+        // Act
+        var result = IniParser.GetValue(sections, "Section1", "Key1");
+
+        // Assert
+        result.Should().Be("Value1");
+    }
+
+    [Fact]
+    public void GetValue_NonExistentKey_ReturnsDefaultValue()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>
+            {
+                ["Key1"] = "Value1"
+            }
+        };
+
+        // Act
+        var result = IniParser.GetValue(sections, "Section1", "NonExistentKey", "Default");
+
+        // Assert
+        result.Should().Be("Default");
+    }
+
+    [Fact]
+    public void GetValue_NonExistentSection_ReturnsDefaultValue()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>
+            {
+                ["Key1"] = "Value1"
+            }
+        };
+
+        // Act
+        var result = IniParser.GetValue(sections, "NonExistentSection", "Key1", "Default");
+
+        // Assert
+        result.Should().Be("Default");
+    }
+
+    [Fact]
+    public void GetValue_NoDefaultValue_ReturnsEmptyString()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>()
+        };
+
+        // Act
+        var result = IniParser.GetValue(sections, "Section1", "NonExistentKey");
+
+        // Assert
+        result.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void GetValue_CaseInsensitive_ReturnsValue()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Section1"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Key1"] = "Value1"
+            }
+        };
+
+        // Act
+        var result1 = IniParser.GetValue(sections, "section1", "key1");
+        var result2 = IniParser.GetValue(sections, "SECTION1", "KEY1");
+
+        // Assert
+        result1.Should().Be("Value1");
+        result2.Should().Be("Value1");
+    }
+
+    #endregion
+
+    #region HasSection Tests
+
+    [Fact]
+    public void HasSection_ExistingSection_ReturnsTrue()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>()
+        };
+
+        // Act
+        var result = IniParser.HasSection(sections, "Section1");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSection_NonExistentSection_ReturnsFalse()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>()
+        };
+
+        // Act
+        var result = IniParser.HasSection(sections, "NonExistentSection");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSection_EmptySections_ReturnsFalse()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>();
+
+        // Act
+        var result = IniParser.HasSection(sections, "Section1");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region GetKeys Tests
+
+    [Fact]
+    public void GetKeys_ExistingSection_ReturnsAllKeys()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>
+            {
+                ["Key1"] = "Value1",
+                ["Key2"] = "Value2",
+                ["Key3"] = "Value3"
+            }
+        };
+
+        // Act
+        var result = IniParser.GetKeys(sections, "Section1");
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Should().Contain("Key1");
+        result.Should().Contain("Key2");
+        result.Should().Contain("Key3");
+    }
+
+    [Fact]
+    public void GetKeys_NonExistentSection_ReturnsEmptyEnumerable()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>()
+        };
+
+        // Act
+        var result = IniParser.GetKeys(sections, "NonExistentSection");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetKeys_EmptySection_ReturnsEmptyEnumerable()
+    {
+        // Arrange
+        var sections = new Dictionary<string, Dictionary<string, string>>
+        {
+            ["Section1"] = new Dictionary<string, string>()
+        };
+
+        // Act
+        var result = IniParser.GetKeys(sections, "Section1");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+}

--- a/tests/EdsDcfNet.Tests/README.md
+++ b/tests/EdsDcfNet.Tests/README.md
@@ -1,0 +1,154 @@
+# EdsDcfNet.Tests
+
+Comprehensive unit and integration tests for the EdsDcfNet library using XUnit and FluentAssertions.
+
+## Test Structure
+
+### Unit Tests
+
+#### Utilities/ValueConverterTests.cs
+Tests for the `ValueConverter` utility class:
+- Parsing integers (decimal, hexadecimal, octal formats)
+- Parsing $NODEID formulas with arithmetic operations
+- Parsing booleans (1/0, true/false, yes/no)
+- Parsing bytes and ushort values
+- Parsing and converting AccessType enum values
+- Formatting integers and booleans for output
+- Round-trip conversion tests
+
+#### Parsers/IniParserTests.cs
+Tests for the `IniParser` class:
+- Parsing INI sections and key-value pairs
+- Handling comments and empty lines
+- Case-insensitive section and key names
+- Parsing whitespace and special characters
+- Error handling for malformed content
+- Helper methods (GetValue, HasSection, GetKeys)
+
+#### Parsers/EdsReaderTests.cs
+Tests for the `EdsReader` class:
+- Reading EDS files from disk and strings
+- Parsing FileInfo section
+- Parsing DeviceInfo section with baud rates
+- Parsing ObjectDictionary (mandatory, optional, manufacturer objects)
+- Parsing objects with sub-objects
+- Parsing all AccessType values
+- Parsing Comments section
+- Integration test with sample_device.eds
+
+#### Extensions/ObjectDictionaryExtensionsTests.cs
+Tests for `ObjectDictionary` extension methods:
+- GetObject and GetSubObject
+- SetParameterValue for objects and sub-objects
+- GetParameterValue (configured vs default values)
+- GetObjectsByType (filtering by category)
+- GetPdoCommunicationParameters (RPDO/TPDO)
+- GetPdoMappingParameters (RPDO/TPDO)
+
+#### Writers/DcfWriterTests.cs
+Tests for the `DcfWriter` class:
+- Generating DCF content as strings
+- Writing FileInfo, DeviceInfo, DeviceCommissioning sections
+- Writing object lists and objects
+- Writing objects with sub-objects
+- Formatting hexadecimal values
+- Formatting AccessType values
+- Writing Comments section
+- Writing to files with error handling
+
+### Integration Tests
+
+#### Integration/CanOpenFileTests.cs
+Tests for the `CanOpenFile` API:
+- ReadEds and ReadEdsFromString
+- ReadDcf and ReadDcfFromString
+- WriteDcf and WriteDcfToString
+- EdsToDcf conversion with commissioning parameters
+- Round-trip tests (EDS → DCF → String → DCF)
+- Data preservation through conversions
+
+## Running Tests
+
+### Using .NET CLI
+
+```bash
+# Run all tests
+dotnet test
+
+# Run with detailed output
+dotnet test --verbosity normal
+
+# Run specific test class
+dotnet test --filter "FullyQualifiedName~ValueConverterTests"
+
+# Run with coverage
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+### Using Visual Studio
+1. Open the solution in Visual Studio
+2. Open Test Explorer (Test → Test Explorer)
+3. Click "Run All" to execute all tests
+
+### Using Visual Studio Code
+1. Install the .NET Core Test Explorer extension
+2. Tests will appear in the Test Explorer sidebar
+3. Click the play button to run tests
+
+## Test Coverage
+
+The test suite provides comprehensive coverage of:
+- ✅ All value parsing and formatting functions
+- ✅ INI file parsing with various edge cases
+- ✅ EDS file reading and structure parsing
+- ✅ DCF file writing and formatting
+- ✅ Object dictionary manipulation
+- ✅ Main API entry points
+- ✅ Round-trip conversion scenarios
+- ✅ Error handling and validation
+
+## Test Fixtures
+
+The `Fixtures/` directory contains:
+- `sample_device.eds` - Sample CANopen Electronic Data Sheet used for integration tests
+
+## Dependencies
+
+- **xunit** (v2.6.2) - Test framework
+- **FluentAssertions** (v7.0.0) - Fluent assertion library
+- **Microsoft.NET.Test.Sdk** (v17.8.0) - Test platform
+- **coverlet.collector** (v6.0.0) - Code coverage collector
+
+## Conventions
+
+- Test class names end with `Tests` (e.g., `ValueConverterTests`)
+- Test method names follow the pattern: `MethodName_Scenario_ExpectedBehavior`
+- FluentAssertions is used for all assertions for better readability
+- Arrange-Act-Assert (AAA) pattern is used consistently
+- Each test is independent and doesn't rely on test execution order
+
+## Examples
+
+```csharp
+// Example test structure
+[Fact]
+public void ParseInteger_HexadecimalValue_ParsesCorrectly()
+{
+    // Arrange
+    var input = "0xFF";
+
+    // Act
+    var result = ValueConverter.ParseInteger(input);
+
+    // Assert
+    result.Should().Be(255);
+}
+```
+
+## Contributing
+
+When adding new features to the library:
+1. Add corresponding unit tests for new functionality
+2. Update integration tests if the API changes
+3. Ensure all tests pass before submitting changes
+4. Aim for high test coverage of new code

--- a/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
@@ -1,0 +1,568 @@
+namespace EdsDcfNet.Tests.Utilities;
+
+using EdsDcfNet.Models;
+using EdsDcfNet.Utilities;
+using FluentAssertions;
+using Xunit;
+
+public class ValueConverterTests
+{
+    #region ParseInteger Tests
+
+    [Theory]
+    [InlineData("0", 0u)]
+    [InlineData("1", 1u)]
+    [InlineData("123", 123u)]
+    [InlineData("65535", 65535u)]
+    [InlineData("4294967295", 4294967295u)]
+    public void ParseInteger_DecimalValues_ParsesCorrectly(string input, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0x0", 0u)]
+    [InlineData("0x1", 1u)]
+    [InlineData("0xFF", 255u)]
+    [InlineData("0x100", 256u)]
+    [InlineData("0x1000", 4096u)]
+    [InlineData("0xFFFF", 65535u)]
+    [InlineData("0x00000191", 401u)]
+    [InlineData("0X1A", 26u)] // Uppercase X
+    public void ParseInteger_HexadecimalValues_ParsesCorrectly(string input, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("00", 0u)]
+    [InlineData("01", 1u)]
+    [InlineData("010", 8u)]
+    [InlineData("0377", 255u)]
+    [InlineData("01000", 512u)]
+    public void ParseInteger_OctalValues_ParsesCorrectly(string input, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("  123  ", 123u)]
+    [InlineData("  0xFF  ", 255u)]
+    [InlineData("  010  ", 8u)]
+    public void ParseInteger_WithWhitespace_TrimsAndParses(string input, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", 0u)]
+    [InlineData("   ", 0u)]
+    public void ParseInteger_EmptyOrWhitespace_ReturnsZero(string input, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("$NODEID", 5, 5u)]
+    [InlineData("$nodeid", 10, 10u)] // Case insensitive
+    [InlineData("$NODEID+0x200", 5, 517u)] // 5 + 512
+    [InlineData("$NODEID+0x180", 5, 389u)] // 5 + 384
+    [InlineData("$NODEID+512", 10, 522u)] // 10 + 512
+    [InlineData("$NODEID-0x100", 300, 44u)] // 300 - 256
+    public void ParseInteger_NodeIdFormula_EvaluatesCorrectly(string formula, byte nodeId, uint expected)
+    {
+        // Act
+        var result = ValueConverter.ParseInteger(formula, nodeId);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseInteger_NodeIdFormulaWithoutNodeId_ThrowsNotSupportedException()
+    {
+        // Arrange
+        var formula = "$NODEID+0x200";
+
+        // Act
+        var act = () => ValueConverter.ParseInteger(formula);
+
+        // Assert
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*Cannot evaluate $NODEID formula*");
+    }
+
+    #endregion
+
+    #region ParseBoolean Tests
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("yes", true)]
+    [InlineData("Yes", true)]
+    [InlineData("YES", true)]
+    public void ParseBoolean_TrueValues_ReturnsTrue(string input, bool expected)
+    {
+        // Act
+        var result = ValueConverter.ParseBoolean(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData("no", false)]
+    [InlineData("No", false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("2", false)]
+    [InlineData("random", false)]
+    public void ParseBoolean_FalseValues_ReturnsFalse(string input, bool expected)
+    {
+        // Act
+        var result = ValueConverter.ParseBoolean(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("  1  ", true)]
+    [InlineData("  true  ", true)]
+    [InlineData("  0  ", false)]
+    public void ParseBoolean_WithWhitespace_TrimsAndParses(string input, bool expected)
+    {
+        // Act
+        var result = ValueConverter.ParseBoolean(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region ParseByte Tests
+
+    [Theory]
+    [InlineData("0", (byte)0)]
+    [InlineData("1", (byte)1)]
+    [InlineData("255", (byte)255)]
+    public void ParseByte_DecimalValues_ParsesCorrectly(string input, byte expected)
+    {
+        // Act
+        var result = ValueConverter.ParseByte(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0x0", (byte)0)]
+    [InlineData("0xFF", (byte)255)]
+    [InlineData("0x10", (byte)16)]
+    public void ParseByte_HexadecimalValues_ParsesCorrectly(string input, byte expected)
+    {
+        // Act
+        var result = ValueConverter.ParseByte(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("00", (byte)0)]
+    [InlineData("010", (byte)8)]
+    [InlineData("0377", (byte)255)]
+    public void ParseByte_OctalValues_ParsesCorrectly(string input, byte expected)
+    {
+        // Act
+        var result = ValueConverter.ParseByte(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", (byte)0)]
+    [InlineData("   ", (byte)0)]
+    public void ParseByte_EmptyOrWhitespace_ReturnsZero(string input, byte expected)
+    {
+        // Act
+        var result = ValueConverter.ParseByte(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region ParseUInt16 Tests
+
+    [Theory]
+    [InlineData("0", (ushort)0)]
+    [InlineData("1", (ushort)1)]
+    [InlineData("65535", (ushort)65535)]
+    public void ParseUInt16_DecimalValues_ParsesCorrectly(string input, ushort expected)
+    {
+        // Act
+        var result = ValueConverter.ParseUInt16(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0x0", (ushort)0)]
+    [InlineData("0xFFFF", (ushort)65535)]
+    [InlineData("0x1000", (ushort)4096)]
+    public void ParseUInt16_HexadecimalValues_ParsesCorrectly(string input, ushort expected)
+    {
+        // Act
+        var result = ValueConverter.ParseUInt16(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("00", (ushort)0)]
+    [InlineData("010", (ushort)8)]
+    [InlineData("0177777", (ushort)65535)]
+    public void ParseUInt16_OctalValues_ParsesCorrectly(string input, ushort expected)
+    {
+        // Act
+        var result = ValueConverter.ParseUInt16(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", (ushort)0)]
+    [InlineData("   ", (ushort)0)]
+    public void ParseUInt16_EmptyOrWhitespace_ReturnsZero(string input, ushort expected)
+    {
+        // Act
+        var result = ValueConverter.ParseUInt16(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region ParseAccessType Tests
+
+    [Theory]
+    [InlineData("ro", AccessType.ReadOnly)]
+    [InlineData("RO", AccessType.ReadOnly)]
+    [InlineData("Ro", AccessType.ReadOnly)]
+    [InlineData("  ro  ", AccessType.ReadOnly)]
+    public void ParseAccessType_ReadOnly_ReturnsReadOnly(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("wo", AccessType.WriteOnly)]
+    [InlineData("WO", AccessType.WriteOnly)]
+    public void ParseAccessType_WriteOnly_ReturnsWriteOnly(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("rw", AccessType.ReadWrite)]
+    [InlineData("RW", AccessType.ReadWrite)]
+    public void ParseAccessType_ReadWrite_ReturnsReadWrite(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("rwr", AccessType.ReadWriteInput)]
+    [InlineData("RWR", AccessType.ReadWriteInput)]
+    public void ParseAccessType_ReadWriteInput_ReturnsReadWriteInput(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("rww", AccessType.ReadWriteOutput)]
+    [InlineData("RWW", AccessType.ReadWriteOutput)]
+    public void ParseAccessType_ReadWriteOutput_ReturnsReadWriteOutput(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("const", AccessType.Constant)]
+    [InlineData("CONST", AccessType.Constant)]
+    [InlineData("Const", AccessType.Constant)]
+    public void ParseAccessType_Constant_ReturnsConstant(string input, AccessType expected)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ParseAccessType_InvalidOrEmpty_ReturnsReadOnly(string? input)
+    {
+        // Act
+        var result = ValueConverter.ParseAccessType(input!);
+
+        // Assert
+        result.Should().Be(AccessType.ReadOnly);
+    }
+
+    #endregion
+
+    #region AccessTypeToString Tests
+
+    [Fact]
+    public void AccessTypeToString_ReadOnly_ReturnsRo()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.ReadOnly);
+
+        // Assert
+        result.Should().Be("ro");
+    }
+
+    [Fact]
+    public void AccessTypeToString_WriteOnly_ReturnsWo()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.WriteOnly);
+
+        // Assert
+        result.Should().Be("wo");
+    }
+
+    [Fact]
+    public void AccessTypeToString_ReadWrite_ReturnsRw()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.ReadWrite);
+
+        // Assert
+        result.Should().Be("rw");
+    }
+
+    [Fact]
+    public void AccessTypeToString_ReadWriteInput_ReturnsRwr()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.ReadWriteInput);
+
+        // Assert
+        result.Should().Be("rwr");
+    }
+
+    [Fact]
+    public void AccessTypeToString_ReadWriteOutput_ReturnsRww()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.ReadWriteOutput);
+
+        // Assert
+        result.Should().Be("rww");
+    }
+
+    [Fact]
+    public void AccessTypeToString_Constant_ReturnsConst()
+    {
+        // Act
+        var result = ValueConverter.AccessTypeToString(AccessType.Constant);
+
+        // Assert
+        result.Should().Be("const");
+    }
+
+    #endregion
+
+    #region FormatInteger Tests
+
+    [Theory]
+    [InlineData(0u, true, "0x0")]
+    [InlineData(1u, true, "0x1")]
+    [InlineData(255u, true, "0xFF")]
+    [InlineData(256u, true, "0x100")]
+    [InlineData(4096u, true, "0x1000")]
+    [InlineData(65535u, true, "0xFFFF")]
+    public void FormatInteger_WithHex_FormatsCorrectly(uint value, bool useHex, string expected)
+    {
+        // Act
+        var result = ValueConverter.FormatInteger(value, useHex);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0u, false, "0")]
+    [InlineData(1u, false, "1")]
+    [InlineData(255u, false, "255")]
+    [InlineData(65535u, false, "65535")]
+    public void FormatInteger_WithoutHex_FormatsDecimal(uint value, bool useHex, string expected)
+    {
+        // Act
+        var result = ValueConverter.FormatInteger(value, useHex);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0u, "0x0")]
+    [InlineData(255u, "0xFF")]
+    public void FormatInteger_DefaultParameter_UsesHex(uint value, string expected)
+    {
+        // Act
+        var result = ValueConverter.FormatInteger(value);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region FormatBoolean Tests
+
+    [Fact]
+    public void FormatBoolean_True_ReturnsOne()
+    {
+        // Act
+        var result = ValueConverter.FormatBoolean(true);
+
+        // Assert
+        result.Should().Be("1");
+    }
+
+    [Fact]
+    public void FormatBoolean_False_ReturnsZero()
+    {
+        // Act
+        var result = ValueConverter.FormatBoolean(false);
+
+        // Assert
+        result.Should().Be("0");
+    }
+
+    #endregion
+
+    #region Round-trip Tests
+
+    [Theory]
+    [InlineData("ro")]
+    [InlineData("wo")]
+    [InlineData("rw")]
+    [InlineData("rwr")]
+    [InlineData("rww")]
+    [InlineData("const")]
+    public void AccessType_RoundTrip_PreservesValue(string input)
+    {
+        // Act
+        var accessType = ValueConverter.ParseAccessType(input);
+        var output = ValueConverter.AccessTypeToString(accessType);
+
+        // Assert
+        output.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Boolean_RoundTrip_PreservesValue(bool input)
+    {
+        // Act
+        var formatted = ValueConverter.FormatBoolean(input);
+        var parsed = ValueConverter.ParseBoolean(formatted);
+
+        // Assert
+        parsed.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(255u)]
+    [InlineData(65535u)]
+    [InlineData(4294967295u)]
+    public void Integer_HexRoundTrip_PreservesValue(uint input)
+    {
+        // Act
+        var formatted = ValueConverter.FormatInteger(input, useHex: true);
+        var parsed = ValueConverter.ParseInteger(formatted);
+
+        // Assert
+        parsed.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(255u)]
+    [InlineData(65535u)]
+    public void Integer_DecimalRoundTrip_PreservesValue(uint input)
+    {
+        // Act
+        var formatted = ValueConverter.FormatInteger(input, useHex: false);
+        var parsed = ValueConverter.ParseInteger(formatted);
+
+        // Assert
+        parsed.Should().Be(input);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Created a complete test suite for the EdsDcfNet library with the following test coverage:

Unit Tests:
- ValueConverterTests: Tests for parsing integers (decimal/hex/octal), $NODEID formulas,
  booleans, access types, and formatting functions
- IniParserTests: Tests for INI file parsing, sections, key-value pairs, comments,
  and helper methods
- EdsReaderTests: Tests for reading EDS files, parsing FileInfo, DeviceInfo,
  ObjectDictionary, objects with sub-objects, and comments
- ObjectDictionaryExtensionsTests: Tests for extension methods including GetObject,
  SetParameterValue, GetParameterValue, and PDO filtering
- DcfWriterTests: Tests for writing DCF files, formatting sections, objects,
  and round-trip conversions

Integration Tests:
- CanOpenFileTests: Tests for the main API including ReadEds, ReadDcf, WriteDcf,
  EdsToDcf conversion, and round-trip data preservation

Test Infrastructure:
- Added XUnit test project with FluentAssertions dependency
- Included sample_device.eds fixture for integration tests
- Added comprehensive test documentation in README.md
- Updated solution file to include test project
- Created GlobalUsings.cs for common imports

All tests follow AAA (Arrange-Act-Assert) pattern and use FluentAssertions
for readable assertions.