### PR TITLE
ci: use RELEASE_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -60,7 +61,7 @@ jobs:
 
       - name: Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: semantic-release-bot@users.noreply.github.com


### PR DESCRIPTION
## Summary

- Use fine-grained PAT (`RELEASE_TOKEN`) instead of `GITHUB_TOKEN` for semantic-release
- Fixes `GH013: Repository rule violations` when pushing version bump and CHANGELOG commits to `main`

## Prerequisites

Before merging, create the `RELEASE_TOKEN` secret:

1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
2. Generate token with repository access to `eds-dcf-net`, permission **Contents: Read and write**
3. Add as repository secret: Settings → Secrets and variables → Actions → `RELEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)