### PR TITLE
docs: add Tech Stack Canvas for EdsDcfNet

### DIFF
--- a/docs/tech-stack-canvas.md
+++ b/docs/tech-stack-canvas.md
@@ -102,7 +102,7 @@ EdsToDcf(eds, nodeId, baudrate, nodeName) → DeviceConfigurationFile
 | Category | Technology |
 |---|---|
 | **Test framework** | XUnit 2.9.3 |
-| **Assertions** | FluentAssertions 7.0+ |
+| **Assertions** | FluentAssertions 7.0.0 |
 | **Code coverage** | Coverlet 6.0.4 (XPlat Code Coverage, cobertura format) |
 | **Coverage reporting** | Codecov |
 | **Naming convention** | `MethodName_Scenario_ExpectedBehavior` |


### PR DESCRIPTION
Create a one-page Tech Stack Canvas following the techstackcanvas.io
format by Jörg Müller (INNOQ), documenting all technology choices
across context, core layers, and support sections.