### PR TITLE
fix: wrap FormatException and OverflowException in ValueConverter as EdsParseException

### DIFF
--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -1,6 +1,7 @@
 namespace EdsDcfNet.Utilities;
 
 using System.Globalization;
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 
 /// <summary>
@@ -34,21 +35,28 @@ public static class ValueConverter
             return EvaluateNodeIdFormula(value, nodeId.Value);
         }
 
-        // Hexadecimal (0x prefix)
-        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
-            value.StartsWith("0X", StringComparison.OrdinalIgnoreCase))
+        try
         {
-            return Convert.ToUInt32(value.Substring(2), 16);
-        }
+            // Hexadecimal (0x prefix)
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
+                value.StartsWith("0X", StringComparison.OrdinalIgnoreCase))
+            {
+                return Convert.ToUInt32(value.Substring(2), 16);
+            }
 
-        // Octal (leading 0, but not 0x)
-        if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            // Octal (leading 0, but not 0x)
+            if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            {
+                return Convert.ToUInt32(value, 8);
+            }
+
+            // Decimal
+            return uint.Parse(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is FormatException || ex is OverflowException)
         {
-            return Convert.ToUInt32(value, 8);
+            throw new EdsParseException($"Invalid integer value: '{value}'", ex);
         }
-
-        // Decimal
-        return uint.Parse(value, CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -76,20 +84,27 @@ public static class ValueConverter
         if (string.IsNullOrEmpty(value))
             return 0;
 
-        // Hexadecimal
-        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        try
         {
-            return Convert.ToByte(value.Substring(2), 16);
-        }
+            // Hexadecimal
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return Convert.ToByte(value.Substring(2), 16);
+            }
 
-        // Octal
-        if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            // Octal
+            if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            {
+                return Convert.ToByte(value, 8);
+            }
+
+            // Decimal
+            return byte.Parse(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is FormatException || ex is OverflowException)
         {
-            return Convert.ToByte(value, 8);
+            throw new EdsParseException($"Invalid byte value: '{value}'", ex);
         }
-
-        // Decimal
-        return byte.Parse(value, CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -102,20 +117,27 @@ public static class ValueConverter
         if (string.IsNullOrEmpty(value))
             return 0;
 
-        // Hexadecimal
-        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        try
         {
-            return Convert.ToUInt16(value.Substring(2), 16);
-        }
+            // Hexadecimal
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return Convert.ToUInt16(value.Substring(2), 16);
+            }
 
-        // Octal
-        if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            // Octal
+            if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
+            {
+                return Convert.ToUInt16(value, 8);
+            }
+
+            // Decimal
+            return ushort.Parse(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is FormatException || ex is OverflowException)
         {
-            return Convert.ToUInt16(value, 8);
+            throw new EdsParseException($"Invalid UInt16 value: '{value}'", ex);
         }
-
-        // Decimal
-        return ushort.Parse(value, CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -256,7 +256,7 @@ SupportedObjects=0
     }
 
     [Fact]
-    public void ReadString_FileInfo_InvalidNumericFields_ThrowsFormatException()
+    public void ReadString_FileInfo_InvalidNumericFields_ThrowsEdsParseException()
     {
         // Arrange – invalid numeric values in FileInfo
         var content = @"
@@ -281,7 +281,7 @@ SupportedObjects=0
         var act = () => _reader.ReadString(content);
 
         // Assert
-        act.Should().Throw<FormatException>();
+        act.Should().Throw<EdsParseException>();
     }
 
     #endregion
@@ -1673,7 +1673,7 @@ PDOMapping=0
     }
 
     [Fact]
-    public void ReadString_NonHexObjectIndex_ThrowsFormatException()
+    public void ReadString_NonHexObjectIndex_ThrowsEdsParseException()
     {
         // Arrange – Non-hex index in object list
         var content = BuildMinimalDcf(extraSections: @"
@@ -1686,12 +1686,11 @@ SupportedObjects=1
         var act = () => _reader.ReadString(content);
 
         // Assert
-        // ValueConverter.ParseUInt16 throws FormatException for non-hex
-        act.Should().Throw<FormatException>();
+        act.Should().Throw<EdsParseException>();
     }
 
     [Fact]
-    public void ReadString_OverflowObjectIndex_ThrowsOverflowException()
+    public void ReadString_OverflowObjectIndex_ThrowsEdsParseException()
     {
         // Arrange – Value exceeds ushort range
         var content = BuildMinimalDcf(extraSections: @"
@@ -1704,8 +1703,7 @@ SupportedObjects=1
         var act = () => _reader.ReadString(content);
 
         // Assert
-        // ValueConverter.ParseUInt16 throws OverflowException
-        act.Should().Throw<OverflowException>();
+        act.Should().Throw<EdsParseException>();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet.Tests.Utilities;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Utilities;
 using FluentAssertions;
@@ -563,6 +564,52 @@ public class ValueConverterTests
 
         // Assert
         parsed.Should().Be(input);
+    }
+
+    #endregion
+
+    #region Invalid Value Tests
+
+    [Theory]
+    [InlineData("0xZZZZ")]
+    [InlineData("0x1FFFFFFFF")]
+    [InlineData("not_a_number")]
+    [InlineData("999999999999")]
+    public void ParseInteger_InvalidValue_ThrowsEdsParseException(string input)
+    {
+        var act = () => ValueConverter.ParseInteger(input);
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage($"*'{input}'*")
+            .WithInnerException<Exception>();
+    }
+
+    [Theory]
+    [InlineData("0xZZ")]
+    [InlineData("0x1FF")]
+    [InlineData("not_a_byte")]
+    [InlineData("256")]
+    public void ParseByte_InvalidValue_ThrowsEdsParseException(string input)
+    {
+        var act = () => ValueConverter.ParseByte(input);
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage($"*'{input}'*")
+            .WithInnerException<Exception>();
+    }
+
+    [Theory]
+    [InlineData("0xZZZZ")]
+    [InlineData("0x1FFFF")]
+    [InlineData("not_a_ushort")]
+    [InlineData("65536")]
+    public void ParseUInt16_InvalidValue_ThrowsEdsParseException(string input)
+    {
+        var act = () => ValueConverter.ParseUInt16(input);
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage($"*'{input}'*")
+            .WithInnerException<Exception>();
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- `ValueConverter.ParseInteger`, `ParseByte`, and `ParseUInt16` now catch `FormatException` and `OverflowException` and rethrow them as `EdsParseException` with the invalid value in the message and the original exception as `InnerException`
- Updated 3 existing `DcfReaderTests` that expected bare `FormatException`/`OverflowException` to expect `EdsParseException` instead
- Added 12 new tests covering invalid hex, overflow, and non-numeric inputs for all three methods

## Test plan

- [x] All 458 tests pass
- [x] Invalid values (e.g. `"0xZZZZ"`, `"not_a_number"`, overflow values) throw `EdsParseException` with the offending value in the message
- [x] `InnerException` is the original `FormatException` or `OverflowException`