### PR TITLE
fix: use UTF-8 encoding in DcfWriter and CpjWriter instead of ASCII

### DIFF
--- a/src/EdsDcfNet/Writers/CpjWriter.cs
+++ b/src/EdsDcfNet/Writers/CpjWriter.cs
@@ -17,7 +17,7 @@ public class CpjWriter
     public void WriteFile(NodelistProject cpj, string filePath)
     {
         var content = GenerateCpjContent(cpj);
-        File.WriteAllText(filePath, content, Encoding.ASCII);
+        File.WriteAllText(filePath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Writers/DcfWriter.cs
+++ b/src/EdsDcfNet/Writers/DcfWriter.cs
@@ -21,7 +21,7 @@ public class DcfWriter
         try
         {
             var content = GenerateDcfContent(dcf);
-            File.WriteAllText(filePath, content, Encoding.ASCII);
+            File.WriteAllText(filePath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
         catch (Exception ex)
         {

--- a/tests/EdsDcfNet.Tests/Writers/CpjWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/CpjWriterTests.cs
@@ -202,4 +202,31 @@ EDSBaseName=/eds/
         result.Should().Contain("Key1=Value1");
         result.Should().Contain("Key2=Value2");
     }
+
+    [Fact]
+    public void WriteFile_NonAsciiCharacters_PreservesCharacters()
+    {
+        // Arrange
+        var project = new NodelistProject();
+        var network = new NetworkTopology { NetName = "Netzwerk Süd" };
+        network.Nodes[1] = new NetworkNode { NodeId = 1, Present = true, Name = "Antrieb Ü1" };
+        project.Networks.Add(network);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            _writer.WriteFile(project, tempFile);
+
+            // Assert
+            var content = File.ReadAllText(tempFile, System.Text.Encoding.UTF8);
+            content.Should().Contain("Netzwerk Süd");
+            content.Should().Contain("Antrieb Ü1");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
 }

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -774,6 +774,32 @@ public class DcfWriterTests
             .WithMessage("*Failed to write DCF file*");
     }
 
+    [Fact]
+    public void WriteFile_NonAsciiCharacters_PreservesCharacters()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.DeviceInfo.VendorName = "Müller GmbH & Söhne";
+        dcf.DeviceInfo.ProductName = "Schütz-Relä Ä5";
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            _writer.WriteFile(dcf, tempFile);
+
+            // Assert
+            var content = File.ReadAllText(tempFile, System.Text.Encoding.UTF8);
+            content.Should().Contain("Müller GmbH & Söhne");
+            content.Should().Contain("Schütz-Relä Ä5");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
     #endregion
 
     #region DynamicChannels Tests


### PR DESCRIPTION
## Summary

- `DcfWriter.WriteFile` and `CpjWriter.WriteFile` previously wrote files with `Encoding.ASCII`, silently replacing any non-ASCII characters (umlauts, special characters in fields like `VendorName`, `ProductName`, node names, etc.) with `?`
- The reader uses `File.ReadAllLines` without an explicit encoding, which defaults to UTF-8 in .NET — so read→write was asymmetric
- Both writers now use `new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)` (UTF-8 without BOM), matching the reader's default behaviour

## Test plan

- [x] All 464 tests pass
- [x] `DcfWriter.WriteFile` with `VendorName = "Müller GmbH & Söhne"` preserves the umlauts in the written file
- [x] `CpjWriter.WriteFile` with `NetName = "Netzwerk Süd"` and a node named `"Antrieb Ü1"` preserves the umlauts in the written file
- [x] No BOM is written (verified by reading the file back with `Encoding.UTF8`)