### PR TITLE
refactor: make IniParser a static class for consistent member access

### DIFF
--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -13,8 +13,6 @@ using EdsDcfNet.Utilities;
 /// </summary>
 public abstract class CanOpenReaderBase
 {
-    private readonly IniParser _iniParser = new();
-
     /// <summary>
     /// Section names that are considered "known" for this file format.
     /// Unknown sections are preserved in AdditionalSections for round-trip fidelity.
@@ -25,13 +23,13 @@ public abstract class CanOpenReaderBase
     /// Parses INI sections from a file path.
     /// </summary>
     protected Dictionary<string, Dictionary<string, string>> ParseSectionsFromFile(string filePath)
-        => _iniParser.ParseFile(filePath);
+        => IniParser.ParseFile(filePath);
 
     /// <summary>
     /// Parses INI sections from a string.
     /// </summary>
     protected Dictionary<string, Dictionary<string, string>> ParseSectionsFromString(string content)
-        => _iniParser.ParseString(content);
+        => IniParser.ParseString(content);
 
     /// <summary>
     /// Parses the <c>[FileInfo]</c> section into an <see cref="EdsFileInfo"/> object.

--- a/src/EdsDcfNet/Parsers/CpjReader.cs
+++ b/src/EdsDcfNet/Parsers/CpjReader.cs
@@ -9,8 +9,6 @@ using EdsDcfNet.Utilities;
 /// </summary>
 public class CpjReader
 {
-    private readonly IniParser _iniParser = new();
-
     /// <summary>
     /// Reads a CPJ file from the specified path.
     /// </summary>
@@ -18,7 +16,7 @@ public class CpjReader
     /// <returns>Parsed NodelistProject object</returns>
     public NodelistProject ReadFile(string filePath)
     {
-        var sections = _iniParser.ParseFile(filePath);
+        var sections = IniParser.ParseFile(filePath);
         return ParseCpj(sections);
     }
 
@@ -29,7 +27,7 @@ public class CpjReader
     /// <returns>Parsed NodelistProject object</returns>
     public NodelistProject ReadString(string content)
     {
-        var sections = _iniParser.ParseString(content);
+        var sections = IniParser.ParseString(content);
         return ParseCpj(sections);
     }
 

--- a/src/EdsDcfNet/Parsers/IniParser.cs
+++ b/src/EdsDcfNet/Parsers/IniParser.cs
@@ -7,8 +7,9 @@ using EdsDcfNet.Exceptions;
 /// <summary>
 /// Low-level INI file parser for EDS/DCF files.
 /// Parses INI-style files with sections and key-value pairs.
+/// All members are static; no instantiation is required.
 /// </summary>
-public class IniParser
+public static class IniParser
 {
     /// <summary>
     /// Default maximum input size (10 MB) used by <see cref="ParseFile"/> and
@@ -16,46 +17,30 @@ public class IniParser
     /// </summary>
     public const long DefaultMaxInputSize = 10L * 1024 * 1024;
 
-    private readonly long _maxInputSize;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="IniParser"/> with the default size limit.
-    /// </summary>
-    public IniParser() : this(DefaultMaxInputSize)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="IniParser"/> with a custom size limit.
-    /// </summary>
-    /// <param name="maxInputSize">
-    /// Maximum file size in bytes (for <see cref="ParseFile"/>) or content length in
-    /// characters (for <see cref="ParseString"/>) before an <see cref="EdsParseException"/>
-    /// is thrown.
-    /// </param>
-    public IniParser(long maxInputSize)
-    {
-        _maxInputSize = maxInputSize;
-    }
-
     /// <summary>
     /// Parses an EDS/DCF file and returns sections with their key-value pairs.
     /// </summary>
     /// <param name="filePath">Path to the EDS/DCF file</param>
-    /// <returns>Dictionary where key is section name (lowercase) and value is key-value pairs</returns>
+    /// <param name="maxInputSize">
+    /// Maximum file size in bytes before an <see cref="EdsParseException"/> is thrown.
+    /// Defaults to <see cref="DefaultMaxInputSize"/> (10 MB).
+    /// </param>
+    /// <returns>Dictionary where key is section name and value is key-value pairs</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     /// <exception cref="EdsParseException">Thrown when the file exceeds the configured size limit.</exception>
-    public Dictionary<string, Dictionary<string, string>> ParseFile(string filePath)
+    public static Dictionary<string, Dictionary<string, string>> ParseFile(
+        string filePath,
+        long maxInputSize = DefaultMaxInputSize)
     {
         if (!File.Exists(filePath))
             throw new FileNotFoundException($"EDS/DCF file not found: {filePath}");
 
         var fileInfo = new FileInfo(filePath);
-        if (fileInfo.Length > _maxInputSize)
+        if (fileInfo.Length > maxInputSize)
             throw new EdsParseException(
                 string.Format(CultureInfo.InvariantCulture,
                     "File '{0}' is too large ({1:N0} bytes). Maximum supported size is {2:N0} bytes.",
-                    filePath, fileInfo.Length, _maxInputSize));
+                    filePath, fileInfo.Length, maxInputSize));
 
         return ParseLines(File.ReadLines(filePath));
     }
@@ -64,70 +49,24 @@ public class IniParser
     /// Parses EDS/DCF content from a string.
     /// </summary>
     /// <param name="content">EDS/DCF file content as string</param>
-    /// <returns>Dictionary where key is section name (lowercase) and value is key-value pairs</returns>
+    /// <param name="maxInputSize">
+    /// Maximum content length in characters before an <see cref="EdsParseException"/> is thrown.
+    /// Defaults to <see cref="DefaultMaxInputSize"/> (10 MB).
+    /// </param>
+    /// <returns>Dictionary where key is section name and value is key-value pairs</returns>
     /// <exception cref="EdsParseException">Thrown when the content length exceeds the configured size limit.</exception>
-    public Dictionary<string, Dictionary<string, string>> ParseString(string content)
+    public static Dictionary<string, Dictionary<string, string>> ParseString(
+        string content,
+        long maxInputSize = DefaultMaxInputSize)
     {
-        if (content.Length > _maxInputSize)
+        if (content.Length > maxInputSize)
             throw new EdsParseException(
                 string.Format(CultureInfo.InvariantCulture,
                     "Content is too large ({0:N0} characters). Maximum supported size is {1:N0} characters.",
-                    content.Length, _maxInputSize));
+                    content.Length, maxInputSize));
 
         var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         return ParseLines(lines);
-    }
-
-    /// <summary>
-    /// Parses lines of an EDS/DCF file.
-    /// </summary>
-    private Dictionary<string, Dictionary<string, string>> ParseLines(IEnumerable<string> lines)
-    {
-        var sections = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-        string? currentSection = null;
-        var lineNumber = 0;
-
-        foreach (var rawLine in lines)
-        {
-            lineNumber++;
-            var line = rawLine.Trim();
-
-            // Skip empty lines and comments
-            if (string.IsNullOrWhiteSpace(line) || line.StartsWith(";"))
-                continue;
-
-            // Check for section header
-            if (line.StartsWith("[") && line.EndsWith("]"))
-            {
-                currentSection = line.Substring(1, line.Length - 2).Trim();
-
-                if (!sections.ContainsKey(currentSection))
-                {
-                    sections[currentSection] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                }
-
-                continue;
-            }
-
-            // Parse key-value pair
-            var equalIndex = line.IndexOf('=');
-            if (equalIndex > 0)
-            {
-                if (currentSection == null)
-                {
-                    throw new EdsParseException($"Key-value pair found outside of any section at line {lineNumber}", lineNumber);
-                }
-
-                var key = line.Substring(0, equalIndex).Trim();
-                var value = equalIndex < line.Length - 1
-                    ? line.Substring(equalIndex + 1).Trim()
-                    : string.Empty;
-
-                sections[currentSection][key] = value;
-            }
-        }
-
-        return sections;
     }
 
     /// <summary>
@@ -182,5 +121,54 @@ public class IniParser
             return section.Keys;
         }
         return Enumerable.Empty<string>();
+    }
+
+    private static Dictionary<string, Dictionary<string, string>> ParseLines(IEnumerable<string> lines)
+    {
+        var sections = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        string? currentSection = null;
+        var lineNumber = 0;
+
+        foreach (var rawLine in lines)
+        {
+            lineNumber++;
+            var line = rawLine.Trim();
+
+            // Skip empty lines and comments
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith(";"))
+                continue;
+
+            // Check for section header
+            if (line.StartsWith("[") && line.EndsWith("]"))
+            {
+                currentSection = line.Substring(1, line.Length - 2).Trim();
+
+                if (!sections.ContainsKey(currentSection))
+                {
+                    sections[currentSection] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                continue;
+            }
+
+            // Parse key-value pair
+            var equalIndex = line.IndexOf('=');
+            if (equalIndex > 0)
+            {
+                if (currentSection == null)
+                {
+                    throw new EdsParseException($"Key-value pair found outside of any section at line {lineNumber}", lineNumber);
+                }
+
+                var key = line.Substring(0, equalIndex).Trim();
+                var value = equalIndex < line.Length - 1
+                    ? line.Substring(equalIndex + 1).Trim()
+                    : string.Empty;
+
+                sections[currentSection][key] = value;
+            }
+        }
+
+        return sections;
     }
 }

--- a/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
@@ -18,10 +18,8 @@ public class IniParserTests
 Key1=Value1
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("Section1");
@@ -41,10 +39,8 @@ Key1=Value1
 Key2=Value2
 Key3=Value3
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().HaveCount(2);
@@ -67,10 +63,8 @@ Key1=Value1
 ; Comment in the middle
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("Section1");
@@ -94,10 +88,8 @@ Key1=Value1
 Key2=Value2
 
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("Section1");
@@ -113,10 +105,8 @@ Key2=Value2
   Key1  =  Value1
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("Section1");
@@ -132,10 +122,8 @@ Key2=Value2
 [Section1]
 Key1=Value1
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("section1");
@@ -151,10 +139,8 @@ Key1=Value1
 [Section1]
 Key1=Value1
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result["Section1"].Should().ContainKey("key1");
@@ -171,10 +157,8 @@ Key1=Value1
 Key1=
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result["Section1"]["Key1"].Should().Be(string.Empty);
@@ -189,10 +173,8 @@ Key2=Value2
 [Section1]
 Key1=Value=With=Equals
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result["Section1"]["Key1"].Should().Be("Value=With=Equals");
@@ -208,10 +190,8 @@ Key1=0xFF
 Key2=0x1000
 Key3=$NODEID+0x200
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result["Section1"]["Key1"].Should().Be("0xFF");
@@ -228,10 +208,8 @@ Key1=Value1
 [Section1]
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var act = () => parser.ParseString(content);
+        var act = () => IniParser.ParseString(content);
 
         // Assert
         act.Should().Throw<EdsParseException>()
@@ -249,10 +227,8 @@ Key1=Value1
 [Section1]
 Key2=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("Section1");
@@ -270,10 +246,8 @@ Key2=Value2
 Key1=Value1
 Key1=Value2
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result["Section1"]["Key1"].Should().Be("Value2");
@@ -288,10 +262,8 @@ Key1=Value2
 ParameterName=Number of Entries
 DataType=0x0005
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().ContainKey("1018sub0");
@@ -304,10 +276,8 @@ DataType=0x0005
     {
         // Arrange
         var content = string.Empty;
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().BeEmpty();
@@ -322,10 +292,8 @@ DataType=0x0005
 ; Comment 2
 ; Comment 3
 ";
-        var parser = new IniParser();
-
         // Act
-        var result = parser.ParseString(content);
+        var result = IniParser.ParseString(content);
 
         // Assert
         result.Should().BeEmpty();
@@ -335,11 +303,10 @@ DataType=0x0005
     public void ParseString_ContentTooLarge_ThrowsEdsParseException()
     {
         // Arrange
-        var parser = new IniParser(maxInputSize: 10);
         var content = "[Section1]\nKey1=Value1"; // 22 chars > 10
 
         // Act
-        var act = () => parser.ParseString(content);
+        var act = () => IniParser.ParseString(content, maxInputSize: 10);
 
         // Assert
         act.Should().Throw<EdsParseException>()
@@ -354,11 +321,10 @@ DataType=0x0005
     public void ParseFile_ValidFile_ParsesCorrectly()
     {
         // Arrange
-        var parser = new IniParser();
         var filePath = "Fixtures/sample_device.eds";
 
         // Act
-        var result = parser.ParseFile(filePath);
+        var result = IniParser.ParseFile(filePath);
 
         // Assert
         result.Should().NotBeEmpty();
@@ -371,11 +337,10 @@ DataType=0x0005
     public void ParseFile_NonExistentFile_ThrowsFileNotFoundException()
     {
         // Arrange
-        var parser = new IniParser();
         var filePath = "NonExistent.eds";
 
         // Act
-        var act = () => parser.ParseFile(filePath);
+        var act = () => IniParser.ParseFile(filePath);
 
         // Assert
         act.Should().Throw<FileNotFoundException>()
@@ -386,7 +351,6 @@ DataType=0x0005
     public void ParseFile_FileTooLarge_ThrowsEdsParseException()
     {
         // Arrange
-        var parser = new IniParser(maxInputSize: 10);
         var tempFile = Path.GetTempFileName();
 
         try
@@ -394,7 +358,7 @@ DataType=0x0005
             File.WriteAllText(tempFile, "[Section1]\nKey1=Value1"); // 22 bytes > 10
 
             // Act
-            var act = () => parser.ParseFile(tempFile);
+            var act = () => IniParser.ParseFile(tempFile, maxInputSize: 10);
 
             // Assert
             act.Should().Throw<EdsParseException>()


### PR DESCRIPTION
## Summary

`IniParser` mixed instance methods (`ParseFile`, `ParseString`) with static utility methods (`GetValue`, `HasSection`, `GetKeys`). This forced every reader to hold a `private readonly IniParser _iniParser = new()` field purely for the instance calls, while still calling `IniParser.GetValue(...)` statically — inconsistent API.

- `IniParser` is now a `static class`; no instantiation required
- `ParseFile` and `ParseString` are static with an optional `maxInputSize` parameter (defaults to `DefaultMaxInputSize`) — replacing the constructor from the previous size-guard fix
- `private readonly IniParser _iniParser` removed from `CanOpenReaderBase` and `CpjReader`; all calls are now `IniParser.ParseFile(...)` / `IniParser.ParseString(...)` directly
- All `IniParserTests` updated to use static call syntax

## Test plan

- [x] All 466 tests pass
- [x] No `new IniParser()` calls remain anywhere in source or tests
- [x] Size-limit tests use `IniParser.ParseFile(path, maxInputSize: 10)` / `IniParser.ParseString(content, maxInputSize: 10)`
- [x] `GetValue`, `HasSection`, `GetKeys` call syntax unchanged