### PR TITLE
refactor: make collection properties on model classes read-only (Finding 3.4)

### DIFF
--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -190,9 +190,11 @@ public static class CanOpenFile
             },
             ObjectDictionary = CloneObjectDictionary(eds.ObjectDictionary),
             Comments = CloneComments(eds.Comments),
-            SupportedModules = CloneSupportedModules(eds.SupportedModules),
-            AdditionalSections = CloneAdditionalSections(eds.AdditionalSections)
         };
+
+        dcf.SupportedModules.AddRange(CloneSupportedModules(eds.SupportedModules));
+        foreach (var kvp in CloneAdditionalSections(eds.AdditionalSections))
+            dcf.AdditionalSections[kvp.Key] = kvp.Value;
 
         return dcf;
     }
@@ -233,13 +235,12 @@ public static class CanOpenFile
 
     private static ObjectDictionary CloneObjectDictionary(ObjectDictionary source)
     {
-        var clone = new ObjectDictionary
-        {
-            MandatoryObjects = new List<ushort>(source.MandatoryObjects),
-            OptionalObjects = new List<ushort>(source.OptionalObjects),
-            ManufacturerObjects = new List<ushort>(source.ManufacturerObjects),
-            DummyUsage = new Dictionary<ushort, bool>(source.DummyUsage)
-        };
+        var clone = new ObjectDictionary();
+        clone.MandatoryObjects.AddRange(source.MandatoryObjects);
+        clone.OptionalObjects.AddRange(source.OptionalObjects);
+        clone.ManufacturerObjects.AddRange(source.ManufacturerObjects);
+        foreach (var kvp in source.DummyUsage)
+            clone.DummyUsage[kvp.Key] = kvp.Value;
 
         foreach (var kvp in source.Objects)
         {
@@ -265,7 +266,6 @@ public static class CanOpenFile
             ObjFlags = source.ObjFlags,
             SubNumber = source.SubNumber,
             CompactSubObj = source.CompactSubObj,
-            ObjectLinks = new List<ushort>(source.ObjectLinks),
             ParameterValue = source.ParameterValue,
             Denotation = source.Denotation,
             UploadFile = source.UploadFile,
@@ -274,6 +274,8 @@ public static class CanOpenFile
             InvertedSrad = source.InvertedSrad,
             ParamRefd = source.ParamRefd
         };
+
+        clone.ObjectLinks.AddRange(source.ObjectLinks);
 
         foreach (var kvp in source.SubObjects)
         {
@@ -307,11 +309,10 @@ public static class CanOpenFile
     private static Comments? CloneComments(Comments? source)
     {
         if (source == null) return null;
-        return new Comments
-        {
-            Lines = source.Lines,
-            CommentLines = new Dictionary<int, string>(source.CommentLines)
-        };
+        var clone = new Comments { Lines = source.Lines };
+        foreach (var kvp in source.CommentLines)
+            clone.CommentLines[kvp.Key] = kvp.Value;
+        return clone;
     }
 
     private static List<ModuleInfo> CloneSupportedModules(List<ModuleInfo> source)
@@ -326,10 +327,11 @@ public static class CanOpenFile
                 ProductVersion = module.ProductVersion,
                 ProductRevision = module.ProductRevision,
                 OrderCode = module.OrderCode,
-                FixedObjects = new List<ushort>(module.FixedObjects),
-                SubExtends = new List<ushort>(module.SubExtends),
                 Comments = CloneComments(module.Comments)
             };
+
+            clonedModule.FixedObjects.AddRange(module.FixedObjects);
+            clonedModule.SubExtends.AddRange(module.SubExtends);
 
             foreach (var kvp in module.FixedObjectDefinitions)
             {

--- a/src/EdsDcfNet/Models/Comments.cs
+++ b/src/EdsDcfNet/Models/Comments.cs
@@ -15,5 +15,5 @@ public class Comments
     /// List of comment lines (max 249 characters each).
     /// Key is the line number (1-based), value is the comment text.
     /// </summary>
-    public Dictionary<int, string> CommentLines { get; set; } = new();
+    public Dictionary<int, string> CommentLines { get; } = new();
 }

--- a/src/EdsDcfNet/Models/DeviceConfigurationFile.cs
+++ b/src/EdsDcfNet/Models/DeviceConfigurationFile.cs
@@ -36,12 +36,12 @@ public class DeviceConfigurationFile
     /// Connected modules (for modular devices).
     /// List of module indices referring to SupportedModules.
     /// </summary>
-    public List<int> ConnectedModules { get; set; } = new();
+    public List<int> ConnectedModules { get; } = new();
 
     /// <summary>
     /// Supported extension modules (copied from EDS).
     /// </summary>
-    public List<ModuleInfo> SupportedModules { get; set; } = new();
+    public List<ModuleInfo> SupportedModules { get; } = new();
 
     /// <summary>
     /// Dynamic channels configuration for CiA 302-4 programmable devices.
@@ -51,11 +51,11 @@ public class DeviceConfigurationFile
     /// <summary>
     /// Tool definitions from [Tools]/[ToolX] sections.
     /// </summary>
-    public List<ToolInfo> Tools { get; set; } = new();
+    public List<ToolInfo> Tools { get; } = new();
 
     /// <summary>
     /// Additional sections not covered by standard specification.
     /// Key is section name, value is dictionary of key-value pairs.
     /// </summary>
-    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; set; } = new();
+    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; } = new();
 }

--- a/src/EdsDcfNet/Models/DynamicChannels.cs
+++ b/src/EdsDcfNet/Models/DynamicChannels.cs
@@ -9,7 +9,7 @@ public class DynamicChannels
     /// <summary>
     /// List of dynamic channel segments.
     /// </summary>
-    public List<DynamicChannelSegment> Segments { get; set; } = new();
+    public List<DynamicChannelSegment> Segments { get; } = new();
 }
 
 /// <summary>

--- a/src/EdsDcfNet/Models/ElectronicDataSheet.cs
+++ b/src/EdsDcfNet/Models/ElectronicDataSheet.cs
@@ -29,7 +29,7 @@ public class ElectronicDataSheet
     /// <summary>
     /// Supported extension modules (for modular devices).
     /// </summary>
-    public List<ModuleInfo> SupportedModules { get; set; } = new();
+    public List<ModuleInfo> SupportedModules { get; } = new();
 
     /// <summary>
     /// Dynamic channels configuration for CiA 302-4 programmable devices.
@@ -39,11 +39,11 @@ public class ElectronicDataSheet
     /// <summary>
     /// Tool definitions from [Tools]/[ToolX] sections.
     /// </summary>
-    public List<ToolInfo> Tools { get; set; } = new();
+    public List<ToolInfo> Tools { get; } = new();
 
     /// <summary>
     /// Additional sections not covered by standard specification.
     /// Key is section name, value is dictionary of key-value pairs.
     /// </summary>
-    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; set; } = new();
+    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; } = new();
 }

--- a/src/EdsDcfNet/Models/ModuleInfo.cs
+++ b/src/EdsDcfNet/Models/ModuleInfo.cs
@@ -34,22 +34,22 @@ public class ModuleInfo
     /// <summary>
     /// Fixed objects that are instantiated when at least one module of this type is connected.
     /// </summary>
-    public List<ushort> FixedObjects { get; set; } = new();
+    public List<ushort> FixedObjects { get; } = new();
 
     /// <summary>
     /// Objects indexed by their index that are created once per device.
     /// </summary>
-    public Dictionary<ushort, CanOpenObject> FixedObjectDefinitions { get; set; } = new();
+    public Dictionary<ushort, CanOpenObject> FixedObjectDefinitions { get; } = new();
 
     /// <summary>
     /// Objects that instantiate new sub-indexes per module.
     /// </summary>
-    public List<ushort> SubExtends { get; set; } = new();
+    public List<ushort> SubExtends { get; } = new();
 
     /// <summary>
     /// Sub-extension object definitions.
     /// </summary>
-    public Dictionary<ushort, ModuleSubExtension> SubExtensionDefinitions { get; set; } = new();
+    public Dictionary<ushort, ModuleSubExtension> SubExtensionDefinitions { get; } = new();
 
     /// <summary>
     /// Optional module comments.

--- a/src/EdsDcfNet/Models/NetworkTopology.cs
+++ b/src/EdsDcfNet/Models/NetworkTopology.cs
@@ -23,5 +23,5 @@ public class NetworkTopology
     /// <summary>
     /// Gets or sets the nodes in this network, keyed by their node ID (1-127).
     /// </summary>
-    public Dictionary<byte, NetworkNode> Nodes { get; set; } = new();
+    public Dictionary<byte, NetworkNode> Nodes { get; } = new();
 }

--- a/src/EdsDcfNet/Models/NodelistProject.cs
+++ b/src/EdsDcfNet/Models/NodelistProject.cs
@@ -8,11 +8,11 @@ public class NodelistProject
     /// <summary>
     /// Gets or sets the list of network topologies defined in this project.
     /// </summary>
-    public List<NetworkTopology> Networks { get; set; } = new();
+    public List<NetworkTopology> Networks { get; } = new();
 
     /// <summary>
     /// Gets or sets additional sections not recognized as topology sections.
     /// Key is the section name, value is a dictionary of key-value pairs.
     /// </summary>
-    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; set; } = new();
+    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; } = new();
 }

--- a/src/EdsDcfNet/Models/ObjectDictionary.cs
+++ b/src/EdsDcfNet/Models/ObjectDictionary.cs
@@ -9,27 +9,27 @@ public class ObjectDictionary
     /// <summary>
     /// Mandatory objects (at least 1000h and 1001h).
     /// </summary>
-    public List<ushort> MandatoryObjects { get; set; } = new();
+    public List<ushort> MandatoryObjects { get; } = new();
 
     /// <summary>
     /// Optional objects (area 1000h-1FFFh and 6000h-FFFFh).
     /// </summary>
-    public List<ushort> OptionalObjects { get; set; } = new();
+    public List<ushort> OptionalObjects { get; } = new();
 
     /// <summary>
     /// Manufacturer specific objects (area 2000h-5FFFh).
     /// </summary>
-    public List<ushort> ManufacturerObjects { get; set; } = new();
+    public List<ushort> ManufacturerObjects { get; } = new();
 
     /// <summary>
     /// All objects indexed by their index.
     /// </summary>
-    public Dictionary<ushort, CanOpenObject> Objects { get; set; } = new();
+    public Dictionary<ushort, CanOpenObject> Objects { get; } = new();
 
     /// <summary>
     /// Dummy usage for mapping (data type index -> supported).
     /// </summary>
-    public Dictionary<ushort, bool> DummyUsage { get; set; } = new();
+    public Dictionary<ushort, bool> DummyUsage { get; } = new();
 }
 
 /// <summary>
@@ -100,7 +100,7 @@ public class CanOpenObject
     /// <summary>
     /// Sub-objects if this is a DEFSTRUCT, ARRAY, or RECORD.
     /// </summary>
-    public Dictionary<byte, CanOpenSubObject> SubObjects { get; set; } = new();
+    public Dictionary<byte, CanOpenSubObject> SubObjects { get; } = new();
 
     /// <summary>
     /// For compact sub-object storage: number of sub-indexes with equal description.
@@ -110,7 +110,7 @@ public class CanOpenObject
     /// <summary>
     /// Object links (related objects grouped together).
     /// </summary>
-    public List<ushort> ObjectLinks { get; set; } = new();
+    public List<ushort> ObjectLinks { get; } = new();
 
     /// <summary>
     /// For DCF files: configured parameter value.

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -58,13 +58,13 @@ public class DcfReader : CanOpenReaderBase
         // Parse connected modules if present
         if (IniParser.HasSection(sections, "ConnectedModules"))
         {
-            dcf.ConnectedModules = ParseConnectedModules(sections);
+            dcf.ConnectedModules.AddRange(ParseConnectedModules(sections));
         }
 
         // Parse supported modules if present
         if (IniParser.HasSection(sections, "SupportedModules"))
         {
-            dcf.SupportedModules = ParseSupportedModules(sections);
+            dcf.SupportedModules.AddRange(ParseSupportedModules(sections));
         }
 
         // Parse dynamic channels if present
@@ -76,7 +76,7 @@ public class DcfReader : CanOpenReaderBase
         // Parse tools if present
         if (IniParser.HasSection(sections, "Tools"))
         {
-            dcf.Tools = ParseTools(sections);
+            dcf.Tools.AddRange(ParseTools(sections));
         }
 
         // Parse any additional unknown sections

--- a/src/EdsDcfNet/Parsers/EdsReader.cs
+++ b/src/EdsDcfNet/Parsers/EdsReader.cs
@@ -52,7 +52,7 @@ public class EdsReader : CanOpenReaderBase
         // Parse supported modules if present
         if (IniParser.HasSection(sections, "SupportedModules"))
         {
-            eds.SupportedModules = ParseSupportedModules(sections);
+            eds.SupportedModules.AddRange(ParseSupportedModules(sections));
         }
 
         // Parse dynamic channels if present
@@ -64,7 +64,7 @@ public class EdsReader : CanOpenReaderBase
         // Parse tools if present
         if (IniParser.HasSection(sections, "Tools"))
         {
-            eds.Tools = ParseTools(sections);
+            eds.Tools.AddRange(ParseTools(sections));
         }
 
         // Parse any additional unknown sections

--- a/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
@@ -497,12 +497,9 @@ PDOMapping=0
             FileInfo = new EdsFileInfo { FileName = "test.eds" },
             DeviceInfo = new DeviceInfo { ProductName = "Test" },
             ObjectDictionary = new ObjectDictionary(),
-            Comments = new Comments
-            {
-                Lines = 1,
-                CommentLines = new Dictionary<int, string> { { 1, "Original comment" } }
-            }
+            Comments = new Comments { Lines = 1 }
         };
+        eds.Comments.CommentLines[1] = "Original comment";
 
         var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 5);
 
@@ -664,12 +661,9 @@ PDOMapping=0
         {
             ModuleNumber = 1,
             ProductName = "Module With Comments",
-            Comments = new Comments
-            {
-                Lines = 1,
-                CommentLines = new Dictionary<int, string> { { 1, "Module comment" } }
-            }
+            Comments = new Comments { Lines = 1 }
         };
+        module.Comments!.CommentLines[1] = "Module comment";
         eds.SupportedModules.Add(module);
 
         // Act

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -809,26 +809,21 @@ public class DcfWriterTests
     {
         // Arrange
         var dcf = CreateMinimalDcf();
-        dcf.DynamicChannels = new DynamicChannels
+        dcf.DynamicChannels = new DynamicChannels();
+        dcf.DynamicChannels.Segments.Add(new DynamicChannelSegment
         {
-            Segments = new List<DynamicChannelSegment>
-            {
-                new DynamicChannelSegment
-                {
-                    Type = 0x0007,
-                    Dir = AccessType.ReadOnly,
-                    Range = "0xA080-0xA0BF",
-                    PPOffset = 0
-                },
-                new DynamicChannelSegment
-                {
-                    Type = 0x0005,
-                    Dir = AccessType.ReadWriteOutput,
-                    Range = "0xA0C0-0xA0FF",
-                    PPOffset = 64
-                }
-            }
-        };
+            Type = 0x0007,
+            Dir = AccessType.ReadOnly,
+            Range = "0xA080-0xA0BF",
+            PPOffset = 0
+        });
+        dcf.DynamicChannels.Segments.Add(new DynamicChannelSegment
+        {
+            Type = 0x0005,
+            Dir = AccessType.ReadWriteOutput,
+            Range = "0xA0C0-0xA0FF",
+            PPOffset = 64
+        });
 
         // Act
         var result = _writer.GenerateString(dcf);
@@ -864,19 +859,14 @@ public class DcfWriterTests
     {
         // Arrange
         var dcf = CreateMinimalDcf();
-        dcf.DynamicChannels = new DynamicChannels
+        dcf.DynamicChannels = new DynamicChannels();
+        dcf.DynamicChannels.Segments.Add(new DynamicChannelSegment
         {
-            Segments = new List<DynamicChannelSegment>
-            {
-                new DynamicChannelSegment
-                {
-                    Type = 0x0007,
-                    Dir = AccessType.ReadOnly,
-                    Range = "0xA080-0xA0BF",
-                    PPOffset = 0
-                }
-            }
-        };
+            Type = 0x0007,
+            Dir = AccessType.ReadOnly,
+            Range = "0xA080-0xA0BF",
+            PPOffset = 0
+        });
 
         // Act
         var output = _writer.GenerateString(dcf);
@@ -901,11 +891,8 @@ public class DcfWriterTests
     {
         // Arrange
         var dcf = CreateMinimalDcf();
-        dcf.Tools = new List<ToolInfo>
-        {
-            new ToolInfo { Name = "EDS Checker", Command = "checker.exe $EDS" },
-            new ToolInfo { Name = "Configurator", Command = "config.exe $DCF $NODEID" }
-        };
+        dcf.Tools.Add(new ToolInfo { Name = "EDS Checker", Command = "checker.exe $EDS" });
+        dcf.Tools.Add(new ToolInfo { Name = "Configurator", Command = "config.exe $DCF $NODEID" });
 
         // Act
         var result = _writer.GenerateString(dcf);
@@ -939,11 +926,8 @@ public class DcfWriterTests
     {
         // Arrange
         var dcf = CreateMinimalDcf();
-        dcf.Tools = new List<ToolInfo>
-        {
-            new ToolInfo { Name = "EDS Checker", Command = "checker.exe $EDS" },
-            new ToolInfo { Name = "Configurator", Command = "config.exe $DCF $NODEID" }
-        };
+        dcf.Tools.Add(new ToolInfo { Name = "EDS Checker", Command = "checker.exe $EDS" });
+        dcf.Tools.Add(new ToolInfo { Name = "Configurator", Command = "config.exe $DCF $NODEID" });
 
         // Act
         var output = _writer.GenerateString(dcf);


### PR DESCRIPTION
## Summary

- Removes public `set` accessors from all collection-typed properties in the model layer (`ObjectDictionary`, `CanOpenObject`, `ModuleInfo`, `Comments`, `DynamicChannels`, `NetworkTopology`, `NodelistProject`, `ElectronicDataSheet`, `DeviceConfigurationFile`)
- Callers can still mutate collection contents via `.Add()` / indexer — they just cannot replace the collection instance, preventing accidental null-assignment or reference-sharing bugs
- Parsers (`DcfReader`, `EdsReader`) updated to use `.AddRange()` instead of direct assignment
- Clone helpers in `CanOpenFile` refactored from object-initializer syntax to explicit post-construction mutation
- Test code adapted to use `.Add()` / indexer where object initializers previously replaced collection properties

Addresses **Finding 3.4** — Model-Properties: alles öffentlich mutable, keine Invarianten.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 466/466 tests pass