### PR TITLE
docs(parser): document why FileInfo is optional and DeviceInfo is mandatory (Finding 3.6)

### DIFF
--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -314,6 +314,26 @@ SupportedObjects=0
         result.DeviceInfo.CANopenSafetySupported.Should().BeFalse();
     }
 
+    [Fact]
+    public void ReadString_MissingDeviceInfo_ThrowsEdsParseException()
+    {
+        // Arrange – no [DeviceInfo] section; [DeviceInfo] is mandatory per CiA 306-1 §5.2
+        var content = @"
+[FileInfo]
+FileName=test.eds
+
+[MandatoryObjects]
+SupportedObjects=0
+";
+
+        // Act
+        var act = () => _reader.ReadString(content);
+
+        // Assert
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*DeviceInfo*");
+    }
+
     #endregion
 
     #region Object Dictionary Parsing Tests


### PR DESCRIPTION
## Summary

Addresses **Finding 3.6** — `ParseFileInfo` vs. `ParseDeviceInfo`: inconsistent error handling without explanation.

The behavior difference (silent default vs. hard exception) is intentional and correct; it was just not documented anywhere.

**Changes:**

- **`CanOpenReaderBase.cs`** — added `<remarks>` XML-doc blocks and inline comments to both methods:
  - `ParseFileInfo`: `[FileInfo]` is *optional* — CiA 306 recommends but does not mandate the section; many real-world files omit fields or the section entirely → returns defaults when absent
  - `ParseDeviceInfo`: `[DeviceInfo]` is *mandatory* per **CiA 306-1 §5.2** — without it the device identity (vendor, product, baud rates) is unknown → throws `EdsParseException` so callers get a clear error instead of a silent empty object
- **`EdsReaderTests.cs`** — adds `ReadString_MissingDeviceInfo_ThrowsEdsParseException` to close the test coverage gap (this test already existed for `DcfReader` but was missing for `EdsReader`)

No behavior changes.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 467/467 tests pass (1 new test added)