### PR TITLE
test: close coverage gaps from findings 6.1–6.4 audit

### DIFF
--- a/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
@@ -313,6 +313,41 @@ DataType=0x0005
             .WithMessage("*too large*");
     }
 
+    [Fact]
+    public void ParseString_VeryLongLineValue_ParsesCorrectly()
+    {
+        // Arrange – a value of 10 000 characters; no line-length limit is defined
+        var longValue = new string('X', 10_000);
+        var content = $"[Section1]\nKey1={longValue}\n";
+
+        // Act
+        var result = IniParser.ParseString(content);
+
+        // Assert
+        result["Section1"]["Key1"].Should().Be(longValue);
+    }
+
+    [Fact]
+    public void ParseString_ManySections_AllParsedCorrectly()
+    {
+        // Arrange – 500 sections; the parser must not degrade or lose data
+        var sb = new System.Text.StringBuilder();
+        const int count = 500;
+        for (int i = 0; i < count; i++)
+        {
+            sb.AppendLine($"[Sec{i}]");
+            sb.AppendLine($"Key=Value{i}");
+        }
+
+        // Act
+        var result = IniParser.ParseString(sb.ToString());
+
+        // Assert
+        result.Should().HaveCount(count);
+        result["Sec0"]["Key"].Should().Be("Value0");
+        result["Sec499"]["Key"].Should().Be("Value499");
+    }
+
     #endregion
 
     #region ParseFile Tests


### PR DESCRIPTION
## Summary

Audit of findings 6.1–6.4 against the current test suite. Two tests were genuinely missing; the remaining findings were already fully covered.

## What was added

**Finding 6.1 — two missing IniParser robustness tests** (`IniParserTests.cs`):

| Test | What it verifies |
|---|---|
| `ParseString_VeryLongLineValue_ParsesCorrectly` | A value of 10 000 characters parses without truncation (no line-length limit is defined in the spec) |
| `ParseString_ManySections_AllParsedCorrectly` | 500 sections are all parsed correctly, first and last verified by value |

## Findings already covered — confirmed during audit

| Finding | Existing test(s) |
|---|---|
| **6.1** invalid hex `0xZZZZ` → `EdsParseException` | `ParseInteger_InvalidValue_ThrowsEdsParseException`, `ParseByte_InvalidValue_ThrowsEdsParseException`, `ParseUInt16_InvalidValue_ThrowsEdsParseException` |
| **6.1** overflow `"99999999999999"` in ParseByte / ParseUInt16 | Same tests above (`256`, `65536`, `0x1FF`, `0x1FFFF`) |
| **6.1** content size guard | `ParseString_ContentTooLarge_ThrowsEdsParseException`, `ParseFile_FileTooLarge_ThrowsEdsParseException` |
| **6.2** `EdsToDcf` shared-reference bug (Bug 1.1, fixed in PR #38) | 8 dedicated mutation-isolation tests: `EdsToDcf_MutatingDcfObjectDictionary_DoesNotAffectEds`, `EdsToDcf_TwoDcfsFromSameEds_AreMutuallyIsolated`, `EdsToDcf_MutatingDcfDeviceInfo_DoesNotAffectEds`, `EdsToDcf_MutatingDcfSubObjects_DoesNotAffectEds`, `EdsToDcf_MutatingDcfComments_DoesNotAffectEds`, `EdsToDcf_MutatingDcfSupportedModules_DoesNotAffectEds`, `EdsToDcf_MutatingDcfAdditionalSections_DoesNotAffectEds`, and a two-DCF isolation test |
| **6.3** `$NODEID+0xFFFFFFFF` with nodeId=255 | `ParseInteger_NodeIdFormulaAdditionOverflows_ThrowsEdsParseException` (exact scenario tested) |
| **6.3** `$NODEID` underflow | `ParseInteger_NodeIdFormulaSubtractionUnderflows_ThrowsEdsParseException` |
| **6.4** CPJ write → read round-trip | `RoundTrip_ParseWriteParse_PreservesAllData`, `RoundTrip_MultipleNetworks_PreservesAllData` |

## Test plan

- [x] `dotnet build --configuration Release` — 0 errors, 0 warnings
- [x] `dotnet test --configuration Release` — 470/470 tests pass (2 new)