### PR TITLE
ci: enforce minimum line coverage in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,14 @@ jobs:
           exit 1
         fi
 
-        line_rate="$(sed -n 's/.*line-rate="\([^"]*\)".*/\1/p; q' "$coverage_file")"
+        line_rate="$(awk '
+          /line-rate="/ {
+            match($0, /line-rate="[^"]+"/)
+            value = substr($0, RSTART + 11, RLENGTH - 12)
+            print value
+            exit
+          }
+        ' "$coverage_file")"
         if [[ -z "$line_rate" ]]; then
           echo "Could not read line-rate from $coverage_file"
           exit 1

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -64,7 +64,14 @@ jobs:
             exit 1
           fi
 
-          line_rate="$(sed -n 's/.*line-rate="\([^"]*\)".*/\1/p; q' "$coverage_file")"
+          line_rate="$(awk '
+            /line-rate="/ {
+              match($0, /line-rate="[^"]+"/)
+              value = substr($0, RSTART + 11, RLENGTH - 12)
+              print value
+              exit
+            }
+          ' "$coverage_file")"
           if [[ -z "$line_rate" ]]; then
             echo "Could not read line-rate from $coverage_file"
             exit 1


### PR DESCRIPTION
## Summary
- add workflow-level minimum line coverage threshold (`COVERAGE_MIN_PERCENT=95.0`)
- fail build if Cobertura line-rate is below threshold or coverage file is missing
- apply the same gate to build and semantic-release workflows

## Notes
- AccessType parsing behavior was intentionally left unchanged (tolerant mode)

## Validation
- local coverage parsing check passed (99.43% >= 95.0)