### PR TITLE
docs: align README and architecture docs with current format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/dborgards/eds-dcf-net/branch/main/graph/badge.svg)](https://codecov.io/gh/dborgards/eds-dcf-net)
 
-A comprehensive, easy-to-use C# .NET library for CiA DS 306 - Electronic Data Sheet (EDS), Device Configuration File (DCF) and Nodelist Project (CPJ) for CANopen devices.
+A comprehensive, easy-to-use C# .NET library for CANopen file formats:
+CiA DS 306 (EDS, DCF, CPJ) and CiA 311 (XDD, XDC).
 
 ## Features
 
@@ -18,6 +19,8 @@ A comprehensive, easy-to-use C# .NET library for CiA DS 306 - Electronic Data Sh
 📝 **Read & Write DCF** - Process and create Device Configuration Files
 
 🌐 **Read & Write CPJ** - Parse and create Nodelist Project files (CiA 306-3 network topologies)
+
+🧩 **Read & Write XDD/XDC** - Parse and generate CiA 311 XML device descriptions/configurations
 
 🔄 **EDS to DCF Conversion** - Easy conversion with configuration parameters
 
@@ -43,6 +46,18 @@ Console.WriteLine($"Vendor: {eds.DeviceInfo.VendorName}");
 Console.WriteLine($"Product Number: 0x{eds.DeviceInfo.ProductNumber:X}");
 ```
 
+### Reading an XDD File (CiA 311 XML)
+
+```csharp
+using EdsDcfNet;
+
+// Read XDD file
+var xdd = CanOpenFile.ReadXdd("device.xdd");
+
+Console.WriteLine($"Device: {xdd.DeviceInfo.ProductName}");
+Console.WriteLine($"Vendor: {xdd.DeviceInfo.VendorName}");
+```
+
 ### Reading a DCF File
 
 ```csharp
@@ -53,6 +68,18 @@ var dcf = CanOpenFile.ReadDcf("configured_device.dcf");
 
 Console.WriteLine($"Node ID: {dcf.DeviceCommissioning.NodeId}");
 Console.WriteLine($"Baudrate: {dcf.DeviceCommissioning.Baudrate} kbit/s");
+```
+
+### Reading an XDC File (CiA 311 XML)
+
+```csharp
+using EdsDcfNet;
+
+// Read XDC file
+var xdc = CanOpenFile.ReadXdc("configured_device.xdc");
+
+Console.WriteLine($"Node ID: {xdc.DeviceCommissioning.NodeId}");
+Console.WriteLine($"Baudrate: {xdc.DeviceCommissioning.Baudrate} kbit/s");
 ```
 
 ### Converting EDS to DCF
@@ -144,6 +171,22 @@ NodelistProject ReadCpjFromString(string content)
 void WriteCpj(NodelistProject cpj, string filePath)
 string WriteCpjToString(NodelistProject cpj)
 
+// Read XDD (CiA 311 XML Device Description)
+ElectronicDataSheet ReadXdd(string filePath)
+ElectronicDataSheet ReadXddFromString(string content)
+
+// Write XDD
+void WriteXdd(ElectronicDataSheet xdd, string filePath)
+string WriteXddToString(ElectronicDataSheet xdd)
+
+// Read XDC (CiA 311 XML Device Configuration)
+DeviceConfigurationFile ReadXdc(string filePath)
+DeviceConfigurationFile ReadXdcFromString(string content)
+
+// Write XDC
+void WriteXdc(DeviceConfigurationFile xdc, string filePath)
+string WriteXdcToString(DeviceConfigurationFile xdc)
+
 // Convert EDS to DCF
 DeviceConfigurationFile EdsToDcf(ElectronicDataSheet eds, byte nodeId,
                                   ushort baudrate = 250, string? nodeName = null)
@@ -154,6 +197,8 @@ DeviceConfigurationFile EdsToDcf(ElectronicDataSheet eds, byte nodeId,
 - ✅ Complete EDS parsing
 - ✅ Complete DCF parsing and writing
 - ✅ CPJ nodelist project parsing and writing (CiA 306-3 network topologies)
+- ✅ XDD parsing and writing (CiA 311 XML device description)
+- ✅ XDC parsing and writing (CiA 311 XML device configuration)
 - ✅ All Object Types (NULL, DOMAIN, DEFTYPE, DEFSTRUCT, VAR, ARRAY, RECORD)
 - ✅ Sub-objects and sub-indexes
 - ✅ Compact Storage (CompactSubObj, CompactPDO)
@@ -175,8 +220,8 @@ eds-dcf-net/
 ├── src/
 │   └── EdsDcfNet/              # Main library
 │       ├── Models/             # Data models
-│       ├── Parsers/            # EDS/DCF/CPJ parsers
-│       ├── Writers/            # DCF/CPJ writers
+│       ├── Parsers/            # EDS/DCF/CPJ/XDD/XDC parsers
+│       ├── Writers/            # DCF/CPJ/XDD/XDC writers
 │       ├── Utilities/          # Helper classes
 │       ├── Exceptions/         # Custom exceptions
 │       └── Extensions/         # Extension methods
@@ -205,8 +250,9 @@ MIT License - see [LICENSE](LICENSE) file
 
 ## Specification
 
-Based on **CiA DS 306 Version 1.4.0** (December 15, 2021)
-"Electronic data sheet specification for CANopen"
+Based on:
+- **CiA DS 306 Version 1.4.0** (December 15, 2021)
+- **CiA 311** XML device description/configuration concepts (XDD/XDC)
 
 ## Support
 
@@ -215,4 +261,4 @@ For questions or issues:
 
 ---
 
-**EdsDcfNet** - Professional CANopen EDS/DCF processing in C# .NET
+**EdsDcfNet** - Professional CANopen EDS/DCF/CPJ/XDD/XDC processing in C# .NET

--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -2,7 +2,8 @@
 
 ## 1.1 Requirements Overview
 
-EdsDcfNet is a C# library for reading and writing **CiA DS 306 EDS** (Electronic Data Sheet), **DCF** (Device Configuration File) and **CPJ** (Nodelist Project) files for CANopen devices.
+EdsDcfNet is a C# library for reading and writing CANopen configuration formats:
+**CiA DS 306** (`.eds`, `.dcf`, `.cpj`) and **CiA 311** (`.xdd`, `.xdc`).
 
 CANopen is a communication protocol for industrial automation systems based on the CAN bus. Every CANopen device is described by an EDS file that defines its communication capabilities and configurable parameters. A DCF file is a configured instance of an EDS file containing concrete values for a specific network node.
 
@@ -13,10 +14,11 @@ CANopen is a communication protocol for industrial automation systems based on t
 | Read EDS                    | Complete parsing of Electronic Data Sheets                      |
 | Read and write DCF          | Processing and generation of Device Configuration Files         |
 | Read and write CPJ          | Parsing and generation of CiA 306-3 Nodelist Project files (network topologies) |
+| Read and write XDD/XDC      | Parsing and generation of CiA 311 XML device descriptions/configurations |
 | EDS-to-DCF conversion       | Conversion with configuration parameters (node ID, baud rate)   |
 | Type safety                 | Fully typed models for all CANopen objects                      |
 | Modular devices             | Support for bus couplers with pluggable modules                 |
-| CiA DS 306 v1.4 compliant   | Implementation according to official specification              |
+| CiA DS 306 / CiA 311 support| Implementation aligned with current supported standards          |
 
 ## 1.2 Quality Goals
 
@@ -24,7 +26,7 @@ The following table describes the core quality goals, sorted by priority:
 
 | Priority | Quality Goal            | Description                                                                    |
 |----------|-------------------------|--------------------------------------------------------------------------------|
-| 1        | **Correctness**         | Specification-compliant processing of EDS/DCF/CPJ per CiA DS 306 v1.4         |
+| 1        | **Correctness**         | Specification-compliant processing of EDS/DCF/CPJ (CiA DS 306) and XDD/XDC (CiA 311 subset) |
 | 2        | **Portability**         | Runs on all .NET platforms via `netstandard2.0` and `net10.0`                  |
 | 3        | **Simplicity**          | Intuitive, easy-to-understand API with minimal learning curve                  |
 | 4        | **Reliability**         | Robust error handling with meaningful error messages                           |
@@ -34,8 +36,8 @@ The following table describes the core quality goals, sorted by priority:
 
 | Role                          | Expectation / Interest                                                      |
 |-------------------------------|-----------------------------------------------------------------------------|
-| **CANopen device developers**  | Reliable tool for reading and validating EDS/DCF files                     |
-| **System integrators**         | Programmatic creation and modification of DCF files for networks           |
+| **CANopen device developers**  | Reliable tool for reading and validating EDS/DCF/XDD/XDC files             |
+| **System integrators**         | Programmatic creation and modification of DCF/XDC files for networks       |
 | **Tool vendors**               | Embeddable library for CANopen configuration tools                         |
 | **Library maintainers**        | Maintainable, extensible codebase with clear architecture                  |
 | **NuGet consumers**            | Stable API, semantic versioning, easy integration via package manager      |

--- a/docs/architecture/02-constraints.md
+++ b/docs/architecture/02-constraints.md
@@ -7,9 +7,10 @@
 | **.NET Standard 2.0 compatibility** | The library must compile against `netstandard2.0` for maximum platform coverage (.NET Framework 4.6.1+, .NET Core 2.0+, Mono, Xamarin, Unity). |
 | **.NET 10.0 dual target**          | Additional target `net10.0` for access to current .NET APIs and optimizations.                   |
 | **No external dependencies**       | The main library must not reference any third-party NuGet packages (zero dependencies).          |
+| **BCL-only XML processing**        | CiA 311 XDD/XDC support must use built-in .NET XML APIs (`System.Xml.Linq`) only.                |
 | **C# latest language version**     | Use of current C# language features where compatible with `netstandard2.0`.                      |
 | **Nullable reference types**       | Nullable annotations are enabled (`<Nullable>enable</Nullable>`).                                |
-| **InvariantCulture**               | All numeric and date formatting/parsing must use `CultureInfo.InvariantCulture`, as EDS/DCF files are culture-independent. |
+| **InvariantCulture**               | All numeric and date formatting/parsing must use `CultureInfo.InvariantCulture` across INI and XML format handling. |
 
 ### Unavailable APIs (netstandard2.0)
 

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -8,13 +8,15 @@ The following diagram shows how EdsDcfNet fits into its business environment:
 C4Context
     title Business Context -- EdsDcfNet
 
-    Person(developer, "Application Developer", "Uses the library to process EDS/DCF files")
+    Person(developer, "Application Developer", "Uses the library to process CANopen INI/XML files")
 
-    System(edsdcfnet, "EdsDcfNet", "C# library for reading and writing CiA DS 306 EDS, DCF and CPJ files")
+    System(edsdcfnet, "EdsDcfNet", "C# library for CiA DS 306 (EDS/DCF/CPJ) and CiA 311 (XDD/XDC)")
 
     System_Ext(eds_files, "EDS Files", "Device descriptions per CiA DS 306 (INI format)")
     System_Ext(dcf_files, "DCF Files", "Configured device instances per CiA DS 306 (INI format)")
     System_Ext(cpj_files, "CPJ Files", "Nodelist projects per CiA 306-3 (INI format, network topologies)")
+    System_Ext(xdd_files, "XDD Files", "XML device descriptions per CiA 311")
+    System_Ext(xdc_files, "XDC Files", "XML device configurations per CiA 311")
     System_Ext(canopen_tools, "CANopen Configuration Tools", "e.g. CANopen Architect, Lenze Engineer, Vector CANopen")
     System_Ext(canopen_devices, "CANopen Devices", "Physical devices on the CAN network")
 
@@ -22,10 +24,16 @@ C4Context
     Rel(edsdcfnet, eds_files, "Reads")
     Rel(edsdcfnet, dcf_files, "Reads / Writes")
     Rel(edsdcfnet, cpj_files, "Reads / Writes")
+    Rel(edsdcfnet, xdd_files, "Reads / Writes")
+    Rel(edsdcfnet, xdc_files, "Reads / Writes")
     Rel(canopen_tools, eds_files, "Creates / Exports")
     Rel(canopen_tools, cpj_files, "Creates / Exports")
+    Rel(canopen_tools, xdd_files, "Creates / Exports")
+    Rel(canopen_tools, xdc_files, "Creates / Exports")
     Rel(canopen_devices, eds_files, "Described by")
+    Rel(canopen_devices, xdd_files, "Described by")
     Rel(dcf_files, canopen_devices, "Configures")
+    Rel(xdc_files, canopen_devices, "Configures")
 ```
 
 ### External Interfaces
@@ -35,6 +43,8 @@ C4Context
 | **EDS files**        | Input: INI-formatted device descriptions per CiA DS 306. Provided by device manufacturers. |
 | **DCF files**        | Input/Output: Configured device instances. Can be read, created, and written. |
 | **CPJ files**        | Input/Output: CiA 306-3 nodelist projects describing network topologies. Can be read, created, and written. |
+| **XDD files**        | Input/Output: XML device descriptions per CiA 311. Can be read and written. |
+| **XDC files**        | Input/Output: XML device configurations per CiA 311. Can be read and written. |
 | **NuGet consumers**  | The library is distributed as a NuGet package and used through the public API (`CanOpenFile`). |
 
 ## 3.2 Technical Context
@@ -45,7 +55,7 @@ C4Context
 
     System(edsdcfnet, "EdsDcfNet", "NuGet package (netstandard2.0 / net10.0)")
 
-    System_Ext(filesystem, "File System", "EDS/DCF/CPJ files as text files (reads UTF-8, writes UTF-8 without BOM)")
+    System_Ext(filesystem, "File System", "EDS/DCF/CPJ (INI) and XDD/XDC (XML) files")
     System_Ext(dotnet_host, ".NET Host Application", "Any .NET application referencing the NuGet package")
     System_Ext(nuget, "NuGet.org", "Package distribution")
 
@@ -58,6 +68,6 @@ C4Context
 
 | Channel                | Protocol / Format                              | Description                                                              |
 |------------------------|------------------------------------------------|--------------------------------------------------------------------------|
-| **File system**        | System.IO (UTF-8 read/write, no BOM on write)  | Reading EDS/DCF/CPJ as UTF-8 text, writing DCF/CPJ as UTF-8 (without BOM) |
-| **String API**         | In-memory UTF-16 strings                       | `ReadEdsFromString` / `WriteDcfToString` / `ReadCpjFromString` / `WriteCpjToString` for scenarios without file system access |
+| **File system**        | System.IO (UTF-8 read/write, no BOM on write)  | Reading/writing EDS/DCF/CPJ (INI) and XDD/XDC (XML) as UTF-8 text (without BOM on writes) |
+| **String API**         | In-memory UTF-16 strings                       | `Read*FromString` / `Write*ToString` variants for EDS/DCF/CPJ/XDD/XDC in scenarios without file system access |
 | **NuGet package**      | `.nupkg` + `.snupkg`                           | Distribution via nuget.org with Source Link                              |

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -9,6 +9,7 @@
 | **No external dependencies**   | Minimizes risk of version conflicts, simplifies deployment and auditing.         |
 | **Static facade (`CanOpenFile`)** | Simple entry point that hides internal complexity.                            |
 | **INI parser as foundation**   | EDS/DCF/CPJ files are based on the INI format; a custom parser avoids external dependencies. |
+| **BCL XML stack for CiA 311**  | XDD/XDC are implemented with `System.Xml.Linq` and `XDocument` (no third-party XML stack). |
 
 ## 4.2 Architecture Patterns and Style
 
@@ -20,9 +21,11 @@ The library follows a clean **layered architecture**:
 graph TD
     A["<b>API Layer</b><br/>CanOpenFile (static facade)"] --> B
     A --> D
-    B["<b>Parser Layer</b><br/>EdsReader / DcfReader / CpjReader"] --> C
+    B["<b>Parser Layer</b><br/>EdsReader / DcfReader / CpjReader / XddReader / XdcReader"] --> C
     C["<b>INI Layer</b><br/>IniParser"]
-    D["<b>Writer Layer</b><br/>DcfWriter / CpjWriter"]
+    B --> G["<b>XML Layer</b><br/>XDocument / XElement"]
+    D["<b>Writer Layer</b><br/>DcfWriter / CpjWriter / XddWriter / XdcWriter"]
+    D --> G
     B --> E["<b>Utilities</b><br/>ValueConverter"]
     D --> E
     B --> F["<b>Model Layer</b><br/>ElectronicDataSheet / DeviceConfigurationFile / NodelistProject<br/>ObjectDictionary / NetworkTopology / ..."]
@@ -34,6 +37,7 @@ graph TD
     style D fill:#7AB648,color:#fff
     style E fill:#9B59B6,color:#fff
     style F fill:#E74C3C,color:#fff
+    style G fill:#16A085,color:#fff
 ```
 
 ### Facade Pattern
@@ -47,6 +51,7 @@ Processing follows a linear pipeline:
 ```
 EDS/DCF file --> IniParser --> EdsReader/DcfReader --> Models --> DcfWriter --> DCF file
 CPJ file -----> IniParser --> CpjReader ------------> Models --> CpjWriter --> CPJ file
+XDD/XDC file --> XDocument -> XddReader/XdcReader -> Models -> XddWriter/XdcWriter -> XDD/XDC file
 ```
 
 ## 4.3 Key Design Decisions
@@ -55,6 +60,7 @@ CPJ file -----> IniParser --> CpjReader ------------> Models --> CpjWriter --> C
 |---------------------------------------|--------------------------------------------------------------------------|
 | **Separate EDS/DCF models**           | EDS (template) and DCF (configured instance) have different semantics. DCF extends EDS with `DeviceCommissioning` and `ParameterValue`. |
 | **Round-trip fidelity**               | Unknown sections are preserved as `AdditionalSections` to avoid losing information during write-back. |
+| **Format-specific parsing stacks**    | INI and XML formats use dedicated parsing/writing paths while sharing common domain models. |
 | **Culture-independent processing**    | Consistent use of `InvariantCulture` ensures files are processed identically on all systems. |
 | **Static methods over instances**     | Since the library holds no state between calls, static methods are the natural choice. |
 | **Extension methods for convenience** | `ObjectDictionaryExtensions` provide commonly needed access patterns without bloating the core model. |

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -6,8 +6,8 @@
 graph LR
     subgraph EdsDcfNet ["EdsDcfNet (NuGet Package)"]
         API["CanOpenFile<br/><i>Static Facade</i>"]
-        Parsers["Parsers<br/><i>IniParser, EdsReader, DcfReader, CpjReader</i>"]
-        Writers["Writers<br/><i>DcfWriter, CpjWriter</i>"]
+        Parsers["Parsers<br/><i>IniParser, CanOpenReaderBase,<br/>EdsReader, DcfReader, CpjReader,<br/>XddReader, XdcReader</i>"]
+        Writers["Writers<br/><i>DcfWriter, CpjWriter, XddWriter, XdcWriter</i>"]
         Models["Models<br/><i>Domain Models</i>"]
         Utilities["Utilities<br/><i>ValueConverter</i>"]
         Extensions["Extensions<br/><i>ObjectDictionaryExtensions</i>"]
@@ -17,8 +17,12 @@ graph LR
     EDS["EDS File"] --> API
     DCF_In["DCF File"] --> API
     CPJ_In["CPJ File"] --> API
+    XDD_In["XDD File"] --> API
+    XDC_In["XDC File"] --> API
     API --> DCF_Out["DCF File"]
     API --> CPJ_Out["CPJ File"]
+    API --> XDD_Out["XDD File"]
+    API --> XDC_Out["XDC File"]
     API --> Parsers
     API --> Writers
     Parsers --> Models
@@ -38,15 +42,15 @@ graph LR
 
 ### Building Block Overview
 
-| Building Block        | Responsibility                                                            |
-|-----------------------|---------------------------------------------------------------------------|
-| `CanOpenFile`         | Public API facade; coordinates parsers and writers                        |
-| `Parsers/`            | Reading and interpreting EDS/DCF/CPJ files                                |
-| `Writers/`            | Serializing models back to DCF and CPJ file formats                       |
-| `Models/`             | Domain models representing the structure of EDS/DCF/CPJ files             |
-| `Utilities/`          | Helper functions for type conversion (numbers, booleans, formulas)        |
-| `Extensions/`         | Extension methods for convenient ObjectDictionary access                  |
-| `Exceptions/`         | Specific exception types for parse and write errors                       |
+| Building Block        | Responsibility                                                                    |
+|-----------------------|-----------------------------------------------------------------------------------|
+| `CanOpenFile`         | Public API facade; coordinates parsers and writers                                |
+| `Parsers/`            | Reading and interpreting EDS/DCF/CPJ (INI) and XDD/XDC (XML) files               |
+| `Writers/`            | Serializing models back to DCF/CPJ (INI) and XDD/XDC (XML)                        |
+| `Models/`             | Domain models representing the structure of CANopen description/configuration data |
+| `Utilities/`          | Helper functions for type conversion (numbers, booleans, formulas)                |
+| `Extensions/`         | Extension methods for convenient ObjectDictionary access                           |
+| `Exceptions/`         | Specific exception types for parse and write errors                                |
 
 ## 5.2 Level 2: Detailed Building Blocks
 
@@ -55,59 +59,60 @@ graph LR
 ```mermaid
 classDiagram
     class IniParser {
-        +ParseFile(string filePath) Dictionary~string, Dictionary~string, string~~
-        +ParseString(string content) Dictionary~string, Dictionary~string, string~~
+        +ParseFile(string filePath) Dictionary~string, Dictionary~string, string~~$
+        +ParseString(string content) Dictionary~string, Dictionary~string, string~~$
         +GetValue(sections, sectionName, key, defaultValue) string$
         +HasSection(sections, sectionName) bool$
         +GetKeys(sections, sectionName) IEnumerable~string~$
     }
 
+    class CanOpenReaderBase {
+        #ParseSectionsFromFile(string filePath) Dictionary~string, Dictionary~string, string~~
+        #ParseSectionsFromString(string content) Dictionary~string, Dictionary~string, string~~
+        #ParseObjectDictionary(sections) ObjectDictionary
+        #ParseObject(sections, ushort index) CanOpenObject?
+        #ParseSubObject(sections, ushort index, byte subIndex) CanOpenSubObject?
+    }
+
     class EdsReader {
-        -IniParser _iniParser
         +ReadFile(string filePath) ElectronicDataSheet
         +ReadString(string content) ElectronicDataSheet
-        -ParseEds(sections) ElectronicDataSheet
-        -ParseFileInfo(sections) EdsFileInfo
-        -ParseDeviceInfo(sections) DeviceInfo
-        -ParseObjectDictionary(sections) ObjectDictionary
-        -ParseObject(sections, ushort index) CanOpenObject?
-        -ParseComments(sections) Comments?
-        -ParseSupportedModules(sections) List~ModuleInfo~
-        -ParseDynamicChannels(sections) DynamicChannels?
-        -ParseTools(sections) List~ToolInfo~
     }
 
     class DcfReader {
-        -IniParser _iniParser
-        -EdsReader _edsReader
         +ReadFile(string filePath) DeviceConfigurationFile
         +ReadString(string content) DeviceConfigurationFile
-        -ParseDcf(sections) DeviceConfigurationFile
-        -ParseDeviceCommissioning(sections) DeviceCommissioning
-        -ParseConnectedModules(sections) List~int~
     }
 
     class CpjReader {
-        -IniParser _iniParser
         +ReadFile(string filePath) NodelistProject
         +ReadString(string content) NodelistProject
-        -ParseCpj(sections) NodelistProject
-        -ParseTopology(sections, sectionName) NetworkTopology
     }
 
-    IniParser <-- EdsReader : uses
-    IniParser <-- DcfReader : uses
-    IniParser <-- CpjReader : uses
-    EdsReader <-- DcfReader : delegates shared parsing
+    class XddReader {
+        +ReadFile(string filePath) ElectronicDataSheet
+        +ReadString(string content) ElectronicDataSheet
+    }
+
+    class XdcReader {
+        +ReadFile(string filePath) DeviceConfigurationFile
+        +ReadString(string content) DeviceConfigurationFile
+    }
+
+    IniParser <-- CanOpenReaderBase : uses static methods
+    CanOpenReaderBase <|-- EdsReader
+    CanOpenReaderBase <|-- DcfReader
 ```
 
-**IniParser** is the base component that transforms raw INI text into a sections dictionary (`Dictionary<string, Dictionary<string, string>>`) that preserves section names as they appear in the file while using a case-insensitive comparer (`StringComparer.OrdinalIgnoreCase`) for lookups. It provides instance methods (`ParseFile`, `ParseString`) for parsing and static helper methods (`GetValue`, `HasSection`, `GetKeys`) for querying the resulting dictionary.
+**IniParser** is a static component that transforms raw INI text into a sections dictionary (`Dictionary<string, Dictionary<string, string>>`). It uses a case-insensitive comparer for section/key lookups.
 
-**EdsReader** holds an internal `IniParser` instance. Its public methods (`ReadFile`, `ReadString`) parse the input into a sections dictionary and then build a complete `ElectronicDataSheet` model from it. Unknown sections are preserved in `AdditionalSections`.
+**CanOpenReaderBase** centralizes shared EDS/DCF parsing logic (object dictionary, modules, comments, dynamic channels) and is specialized by `EdsReader` and `DcfReader`.
 
-**DcfReader** holds its own `IniParser` and an `EdsReader` instance (for delegating shared parsing like `ParseDeviceInfo` and `ParseDynamicChannels`). It adds DCF-specific sections (`DeviceCommissioning`, `ConnectedModules`) and fields (`ParameterValue`, `Denotation`).
+**CpjReader** parses CiA 306-3 nodelist projects by reading `[Topology]`, `[Topology2]`, ... sections and mapping node entries (`NodeXPresent`, `NodeXName`, `NodeXDCFName`, `NodeXRefd`) to `NetworkTopology`/`NetworkNode`.
 
-**CpjReader** holds an internal `IniParser` instance. It parses CiA 306-3 nodelist project files by iterating over all sections and identifying `[Topology]` sections (including numbered variants like `[Topology2]`). Each topology section is parsed into a `NetworkTopology` with its associated `NetworkNode` entries. Unknown sections are preserved in `AdditionalSections`.
+**XddReader** parses CiA 311 XML device descriptions into `ElectronicDataSheet`, including object dictionary, baud-rate capabilities, and optional `ApplicationProcessXml`.
+
+**XdcReader** parses CiA 311 XML device configurations into `DeviceConfigurationFile` and maps `actualValue`/`denotation` plus `deviceCommissioning`.
 
 ### 5.2.2 Writers
 
@@ -116,36 +121,33 @@ classDiagram
     class DcfWriter {
         +WriteFile(DeviceConfigurationFile dcf, string filePath) void
         +GenerateString(DeviceConfigurationFile dcf) string
-        -GenerateDcfContent(DeviceConfigurationFile dcf) string
-        -WriteFileInfo(StringBuilder sb, EdsFileInfo fileInfo) void
-        -WriteDeviceInfo(StringBuilder sb, DeviceInfo deviceInfo) void
-        -WriteDeviceCommissioning(StringBuilder sb, DeviceCommissioning dc) void
-        -WriteDummyUsage(StringBuilder sb, ObjectDictionary objDict) void
-        -WriteComments(StringBuilder sb, Comments comments) void
-        -WriteObjectLists(StringBuilder sb, ObjectDictionary objDict) void
-        -WriteObjects(StringBuilder sb, ObjectDictionary objDict) void
-        -WriteObject(StringBuilder sb, CanOpenObject obj) void
-        -WriteSubObject(StringBuilder sb, ushort index, CanOpenSubObject subObj) void
-        -WriteSupportedModules(StringBuilder sb, List~ModuleInfo~ modules) void
-        -WriteConnectedModules(StringBuilder sb, List~int~ modules) void
-        -WriteDynamicChannels(StringBuilder sb, DynamicChannels dc) void
-        -WriteTools(StringBuilder sb, List~ToolInfo~ tools) void
     }
-```
 
-**DcfWriter** is a stateless class that serializes a `DeviceConfigurationFile` model back into the INI-based DCF format. The `DeviceConfigurationFile` is passed as a parameter to each public method rather than stored in the writer. Output can be written either to a file (UTF-8 without BOM) or returned as a string.
-
-```mermaid
-classDiagram
     class CpjWriter {
         +WriteFile(NodelistProject cpj, string filePath) void
         +GenerateString(NodelistProject cpj) string
-        -GenerateCpjContent(NodelistProject cpj) string
-        -WriteTopology(StringBuilder sb, NetworkTopology topology, string sectionName) void$
     }
+
+    class XddWriter {
+        +WriteFile(ElectronicDataSheet eds, string filePath) void
+        +GenerateString(ElectronicDataSheet eds) string
+    }
+
+    class XdcWriter {
+        +WriteFile(DeviceConfigurationFile dcf, string filePath) void
+        +GenerateString(DeviceConfigurationFile dcf) string
+    }
+
+    XddWriter <|-- XdcWriter
 ```
 
-**CpjWriter** is a stateless class that serializes a `NodelistProject` model into the INI-based CPJ format. It writes topology sections with nodes ordered by node ID and the `Nodes` count formatted as hexadecimal. Multiple networks are written as `[Topology]`, `[Topology2]`, etc.
+**DcfWriter** serializes `DeviceConfigurationFile` to INI-based DCF and preserves unknown INI sections through `AdditionalSections` (except object-link sections for known objects, which are regenerated from typed model data).
+
+**CpjWriter** serializes `NodelistProject` to INI-based CPJ, writing topology sections in deterministic order and formatting node count as hexadecimal.
+
+**XddWriter** serializes `ElectronicDataSheet` into CiA 311 XML (`ISO15745ProfileContainer`) using UTF-8 without BOM.
+
+**XdcWriter** extends `XddWriter` for configuration data and emits `actualValue`, `denotation`, and `deviceCommissioning` (NodeID must be `1..127` when present).
 
 ### 5.2.3 Models
 
@@ -159,6 +161,7 @@ classDiagram
         +List~ModuleInfo~ SupportedModules
         +DynamicChannels? DynamicChannels
         +List~ToolInfo~ Tools
+        +string? ApplicationProcessXml
         +Dictionary~string, Dictionary~string, string~~ AdditionalSections
     }
 
@@ -172,144 +175,17 @@ classDiagram
         +List~ModuleInfo~ SupportedModules
         +DynamicChannels? DynamicChannels
         +List~ToolInfo~ Tools
+        +string? ApplicationProcessXml
         +Dictionary~string, Dictionary~string, string~~ AdditionalSections
-    }
-
-    class ObjectDictionary {
-        +List~ushort~ MandatoryObjects
-        +List~ushort~ OptionalObjects
-        +List~ushort~ ManufacturerObjects
-        +Dictionary~ushort, CanOpenObject~ Objects
-        +Dictionary~ushort, bool~ DummyUsage
-    }
-
-    class CanOpenObject {
-        +ushort Index
-        +string ParameterName
-        +byte ObjectType
-        +ushort? DataType
-        +AccessType AccessType
-        +string? DefaultValue
-        +string? ParameterValue
-        +string? Denotation
-        +string? LowLimit
-        +string? HighLimit
-        +bool PdoMapping
-        +bool SrdoMapping
-        +string? InvertedSrad
-        +uint ObjFlags
-        +byte? SubNumber
-        +byte? CompactSubObj
-        +Dictionary~byte, CanOpenSubObject~ SubObjects
-        +List~ushort~ ObjectLinks
-        +string? UploadFile
-        +string? DownloadFile
-        +string? ParamRefd
-    }
-
-    class CanOpenSubObject {
-        +byte SubIndex
-        +string ParameterName
-        +byte ObjectType
-        +ushort DataType
-        +AccessType AccessType
-        +string? DefaultValue
-        +string? ParameterValue
-        +string? Denotation
-        +string? LowLimit
-        +string? HighLimit
-        +bool PdoMapping
-        +bool SrdoMapping
-        +string? InvertedSrad
-        +string? ParamRefd
-    }
-
-    class DeviceInfo {
-        +string VendorName
-        +uint VendorNumber
-        +string ProductName
-        +uint ProductNumber
-        +uint RevisionNumber
-        +string OrderCode
-        +BaudRates SupportedBaudRates
-        +bool SimpleBootUpMaster
-        +bool SimpleBootUpSlave
-        +byte Granularity
-        +byte DynamicChannelsSupported
-        +bool GroupMessaging
-        +ushort NrOfRxPdo
-        +ushort NrOfTxPdo
-        +bool LssSupported
-        +byte CompactPdo
-        +bool CANopenSafetySupported
-    }
-
-    class DeviceCommissioning {
-        +byte NodeId
-        +string NodeName
-        +ushort Baudrate
-        +uint NetNumber
-        +string NetworkName
-        +bool CANopenManager
-        +uint? LssSerialNumber
-        +string? NodeRefd
-        +string? NetRefd
-    }
-
-    class EdsFileInfo {
-        +string FileName
-        +byte FileVersion
-        +byte FileRevision
-        +string EdsVersion
-        +string Description
-        +string CreationTime
-        +string CreationDate
-        +string CreatedBy
-        +string ModificationTime
-        +string ModificationDate
-        +string ModifiedBy
-        +string? LastEds
     }
 
     class NodelistProject {
         +List~NetworkTopology~ Networks
         +Dictionary~string, Dictionary~string, string~~ AdditionalSections
     }
-
-    class NetworkTopology {
-        +string? NetName
-        +string? NetRefd
-        +string? EdsBaseName
-        +Dictionary~byte, NetworkNode~ Nodes
-    }
-
-    class NetworkNode {
-        +byte NodeId
-        +bool Present
-        +string? Name
-        +string? Refd
-        +string? DcfFileName
-    }
-
-    ElectronicDataSheet *-- EdsFileInfo
-    ElectronicDataSheet *-- DeviceInfo
-    ElectronicDataSheet *-- ObjectDictionary
-    ElectronicDataSheet *-- Comments
-    ElectronicDataSheet *-- ModuleInfo
-    ElectronicDataSheet *-- DynamicChannels
-    ElectronicDataSheet *-- ToolInfo
-
-    DeviceConfigurationFile *-- EdsFileInfo
-    DeviceConfigurationFile *-- DeviceInfo
-    DeviceConfigurationFile *-- ObjectDictionary
-    DeviceConfigurationFile *-- DeviceCommissioning
-
-    NodelistProject *-- NetworkTopology
-    NetworkTopology *-- NetworkNode
-
-    ObjectDictionary *-- CanOpenObject
-    CanOpenObject *-- CanOpenSubObject
 ```
+
+Core models are shared across INI and XML formats, enabling cross-format conversion scenarios without duplicate object graphs.
 
 ### 5.2.4 Utilities
 
@@ -327,12 +203,7 @@ classDiagram
     }
 ```
 
-**ValueConverter** is a static utility class that encapsulates all type-specific conversions:
-
-- **Number formats**: Decimal (`123`), hexadecimal (`0x7B`), octal (`0173`)
-- **Boolean values**: `"1"`, `"true"`, `"yes"` are interpreted as `true`
-- **`$NODEID` formulas**: Expressions like `$NODEID+0x200` are evaluated at runtime
-- **AccessType mapping**: String-to-enum conversion (`"rw"` -> `ReadWrite`)
+`ValueConverter` encapsulates number parsing (decimal/hex/octal), `$NODEID` formula evaluation, and AccessType conversions.
 
 ### 5.2.5 Extensions
 
@@ -348,13 +219,6 @@ classDiagram
         +GetObjectsByType(ObjectCategory category) IEnumerable~CanOpenObject~$
         +GetPdoCommunicationParameters(bool transmit) IEnumerable~CanOpenObject~$
         +GetPdoMappingParameters(bool transmit) IEnumerable~CanOpenObject~$
-    }
-
-    class ObjectCategory {
-        <<enumeration>>
-        Mandatory
-        Optional
-        Manufacturer
     }
 ```
 
@@ -375,6 +239,5 @@ classDiagram
     }
 ```
 
-**EdsParseException** is thrown on parsing errors and optionally contains line number and section name for diagnostics.
-
-**DcfWriteException** is thrown on errors during DCF generation.
+`EdsParseException` is used for EDS/DCF/XDD/XDC parsing errors.  
+`DcfWriteException` is used for DCF write/generation failures.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -2,8 +2,6 @@
 
 ## 6.1 Reading an EDS File
 
-The following sequence diagram shows the flow when reading an EDS file:
-
 ```mermaid
 sequenceDiagram
     participant App as Application
@@ -15,20 +13,16 @@ sequenceDiagram
     App->>CF: ReadEds(filePath)
     CF->>ER: new EdsReader()
     CF->>ER: ReadFile(filePath)
-    ER->>IP: _iniParser.ParseFile(filePath)
+    ER->>IP: ParseFile(filePath)
     IP-->>ER: sections dictionary
     ER->>ER: ParseEds(sections)
-    ER->>ER: ParseFileInfo(sections)
-    Note over ER,IP: Uses static IniParser.GetValue(sections, ...)
-    ER->>ER: ParseDeviceInfo(sections)
+    ER->>ER: ParseDeviceInfo(), ParseObjectDictionary()
 
-    loop For each object in the ObjectDictionary
+    loop For each object/sub-object
         ER->>VC: ParseInteger(), ParseBoolean(), ParseAccessType()
         VC-->>ER: Typed values
-        ER->>ER: ParseObject() / ParseSubObject()
     end
 
-    ER->>ER: ParseComments(), ParseSupportedModules(), ...
     ER-->>CF: ElectronicDataSheet
     CF-->>App: ElectronicDataSheet
 ```
@@ -39,18 +33,14 @@ sequenceDiagram
 sequenceDiagram
     participant App as Application
     participant CF as CanOpenFile
-    participant ER as EdsReader
     participant Model as DeviceConfigurationFile
 
     App->>CF: EdsToDcf(eds, nodeId: 2, baudrate: 500)
-    CF->>CF: Transfer EDS data into new DCF model
-    CF->>Model: Copy FileInfo, DeviceInfo, ObjectDictionary
-    CF->>Model: Create DeviceCommissioning (NodeId=2, Baudrate=500)
-
-    loop For each object with DefaultValue
-        CF->>Model: Set ParameterValue = DefaultValue
-    end
-
+    CF->>CF: Validate nodeId (1..127)
+    CF->>CF: Deep-clone EDS model parts
+    CF->>Model: Build FileInfo/DeviceInfo/ObjectDictionary copies
+    CF->>Model: Create DeviceCommissioning
+    CF->>Model: Copy modules/comments/additional sections
     CF-->>App: DeviceConfigurationFile
 ```
 
@@ -68,119 +58,100 @@ sequenceDiagram
     CF->>DW: WriteFile(dcf, filePath)
     DW->>DW: GenerateDcfContent(dcf)
 
-    DW->>DW: WriteFileInfo()
-    DW->>DW: WriteDeviceInfo()
-    DW->>DW: WriteDeviceCommissioning()
-    DW->>DW: WriteDummyUsage()
-    DW->>DW: WriteComments()
-
-    loop For each object
-        DW->>VC: FormatInteger(), FormatBoolean()
-        VC-->>DW: Formatted string
-        DW->>DW: WriteObject() / WriteSubObject()
+    loop For each object/sub-object
+        DW->>VC: FormatInteger(), FormatBoolean(), AccessTypeToString()
+        VC-->>DW: formatted text
     end
 
-    DW->>DW: WriteSupportedModules()
-    DW->>DW: WriteAdditionalSections()
-    DW->>DW: File.WriteAllText(filePath, content, UTF-8 (no BOM))
-
+    DW->>DW: Write known sections + AdditionalSections
+    DW->>DW: File.WriteAllText(... UTF-8 without BOM)
     DW-->>CF: void
     CF-->>App: void
 ```
 
-## 6.4 DCF Round-Trip (Read and Write Back)
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant CF as CanOpenFile
-
-    App->>CF: ReadDcf("device.dcf")
-    CF-->>App: DeviceConfigurationFile
-
-    Note over App: Modify values, e.g.<br/>SetParameterValue(0x1017, "500")
-
-    App->>CF: WriteDcf(dcf, "device_modified.dcf")
-    CF-->>App: void
-
-    Note over App: Unknown sections are preserved<br/>(round-trip fidelity)
-```
-
-## 6.5 Reading a CPJ File
-
-The following sequence diagram shows the flow when reading a CiA 306-3 nodelist project file:
+## 6.4 Reading and Writing CPJ Files
 
 ```mermaid
 sequenceDiagram
     participant App as Application
     participant CF as CanOpenFile
     participant CR as CpjReader
+    participant CW as CpjWriter
     participant IP as IniParser
 
     App->>CF: ReadCpj(filePath)
     CF->>CR: new CpjReader()
-    CF->>CR: ReadFile(filePath)
-    CR->>IP: _iniParser.ParseFile(filePath)
+    CR->>IP: ParseFile(filePath)
     IP-->>CR: sections dictionary
-    CR->>CR: ParseCpj(sections)
-
-    loop For each Topology section
-        CR->>CR: ParseTopology(sections, sectionName)
-        Note over CR: Read NetName, NetRefd, EDSBaseName
-        loop For Node IDs 1-127
-            CR->>CR: Check NodeXPresent, parse NodeXName, NodeXDCFName, NodeXRefd
-        end
-    end
-
-    CR->>CR: Unknown sections → AdditionalSections
+    CR->>CR: Parse [Topology], [Topology2], ...
     CR-->>CF: NodelistProject
     CF-->>App: NodelistProject
-```
-
-## 6.6 Writing a CPJ File
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant CF as CanOpenFile
-    participant CW as CpjWriter
 
     App->>CF: WriteCpj(cpj, filePath)
     CF->>CW: new CpjWriter()
-    CF->>CW: WriteFile(cpj, filePath)
-    CW->>CW: GenerateCpjContent(cpj)
-
-    loop For each NetworkTopology
-        CW->>CW: WriteTopology(sb, topology, sectionName)
-        Note over CW: Write [Topology] / [Topology2] / ...
-        CW->>CW: Write NetName, NetRefd, Nodes (hex count)
-        loop For each node ordered by ID
-            CW->>CW: Write NodeXPresent, NodeXName, NodeXDCFName, NodeXRefd
-        end
-        CW->>CW: Write EDSBaseName
-    end
-
-    CW->>CW: Write AdditionalSections
-    CW->>CW: File.WriteAllText(filePath, content, UTF-8 (no BOM))
-
+    CW->>CW: GenerateCpjContent()
+    CW->>CW: Write topology sections ordered by node ID
+    CW->>CW: File.WriteAllText(... UTF-8 without BOM)
     CW-->>CF: void
     CF-->>App: void
 ```
 
-## 6.7 Error Handling During Parsing
+## 6.5 Reading an XDD File
 
 ```mermaid
 sequenceDiagram
     participant App as Application
     participant CF as CanOpenFile
-    participant ER as EdsReader
+    participant XR as XddReader
+    participant XML as XDocument
 
-    App->>CF: ReadEds("invalid.eds")
-    CF->>ER: ReadFile(filePath)
-    ER->>ER: Required section missing or invalid value
-
-    ER--xCF: EdsParseException (LineNumber, SectionName)
-    CF--xApp: EdsParseException
-
-    Note over App: Application can use LineNumber and<br/>SectionName for diagnostics
+    App->>CF: ReadXdd(filePath)
+    CF->>XR: new XddReader()
+    XR->>XML: XDocument.Parse(content)
+    XR->>XR: Locate ISO15745 profiles
+    XR->>XR: Parse Device + CommunicationNetwork profile bodies
+    XR->>XR: Map XML objects to ElectronicDataSheet
+    XR-->>CF: ElectronicDataSheet
+    CF-->>App: ElectronicDataSheet
 ```
+
+## 6.6 Reading and Writing XDC Files
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant CF as CanOpenFile
+    participant XR as XdcReader
+    participant XW as XdcWriter
+
+    App->>CF: ReadXdc(filePath)
+    CF->>XR: new XdcReader()
+    XR->>XR: Parse via XddReader(includeActualValues: true)
+    XR->>XR: Parse deviceCommissioning
+    XR-->>CF: DeviceConfigurationFile
+    CF-->>App: DeviceConfigurationFile
+
+    App->>CF: WriteXdc(dcf, filePath)
+    CF->>XW: new XdcWriter()
+    XW->>XW: GenerateString(dcf)
+    XW->>XW: Validate NodeId when commissioning is emitted (1..127)
+    XW->>XW: Write actualValue/denotation + commissioning
+    XW-->>CF: void
+    CF-->>App: void
+```
+
+## 6.7 Parse Error Handling
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant CF as CanOpenFile
+    participant Reader as EdsReader / DcfReader / CpjReader / XddReader / XdcReader
+
+    App->>CF: Read*(invalid input)
+    CF->>Reader: Parse content
+    Reader--xCF: EdsParseException
+    CF--xApp: EdsParseException
+```
+
+Errors include contextual metadata where available (e.g., section name, line number for INI parsing cases).

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -8,11 +8,12 @@ The library uses **exceptions** as its primary error mechanism:
 
 | Exception               | Use Case                                                    | Additional Information       |
 |-------------------------|-------------------------------------------------------------|------------------------------|
-| `EdsParseException`     | Errors during EDS/DCF parsing                               | `LineNumber`, `SectionName`  |
+| `EdsParseException`     | Errors during EDS/DCF/CPJ/XDD/XDC parsing                   | `LineNumber`, `SectionName`  |
 | `DcfWriteException`     | Errors during DCF writing                                   | `SectionName`                |
+| `InvalidOperationException` | Validation failures during XDC writing (e.g., invalid NodeId) | Standard .NET message |
 | `ArgumentException`     | Invalid input parameters where validation is performed by the API | Standard .NET          |
 
-> **Note:** `CanOpenFile.EdsToDcf` and DCF parsing enforce the CANopen Node-ID range (`1..127`) for provided `NodeID` values and reject out-of-range values with clear exceptions. If a DCF omits the entire `[DeviceCommissioning]` section (no `NodeID` provided), parsing succeeds and leaves `DeviceCommissioning.NodeId` at the default value (`0`) without throwing.
+> **Note:** `CanOpenFile.EdsToDcf`, DCF parsing, and XDC writing enforce CANopen Node-ID constraints for explicit commissioning data. `EdsToDcf` and DCF parsing require `1..127`; XDC writing emits commissioning only when a configured NodeId is present and valid.
 
 > **Compatibility note (AccessType):** Parsing of invalid or unknown `AccessType` values is intentionally tolerant and falls back to `ReadOnly` instead of failing. This is a deliberate trade-off to maximize interoperability with non-compliant manufacturer EDS/DCF files.
 
@@ -20,7 +21,7 @@ The library uses **exceptions** as its primary error mechanism:
 
 ```mermaid
 flowchart TD
-    A["Read EDS/DCF file"] --> B{Required section present?}
+    A["Read CANopen file (INI/XML)"] --> B{Required structure present?}
     B -->|No| C["EdsParseException"]
     B -->|Yes| D{Optional section present?}
     D -->|No| E["Use default value / null"]
@@ -32,11 +33,12 @@ flowchart TD
 
 - **Required fields**: Missing required sections result in an `EdsParseException`.
 - **Optional fields**: Missing optional values result in `null` or default values.
-- **Unknown sections**: Preserved in `AdditionalSections` (no warning, no error).
+- **Unknown INI sections**: Preserved in `AdditionalSections` (no warning, no error).
+- **CiA 311 XML**: Parsed against supported profile structures; unsupported XML nodes are not represented as generic passthrough data.
 
 ## 8.2 Culture Independence (InvariantCulture)
 
-EDS/DCF files are culture-independent INI files. Numeric values always use the period as a decimal separator, and there are no localized formats.
+CANopen INI/XML files are culture-independent. Numeric values use deterministic formats and must not depend on OS locale.
 
 ### Rule
 
@@ -91,11 +93,26 @@ flowchart LR
     style D fill:#F5A623,color:#fff
 ```
 
-Mechanisms:
+Mechanisms (INI formats):
 - **`AdditionalSections`**: All sections not mapped by the model are stored as raw key-value pairs and written back during output.
 - **`LastEds`**: DCF files store the filename of the source EDS.
 
-## 8.5 Modular Devices (CiA DS 306)
+For CiA 311 XML, round-trip behavior is guaranteed for the currently mapped schema subset used by `XddReader`/`XdcReader` and `XddWriter`/`XdcWriter`.
+
+## 8.5 CiA 311 XML Mapping
+
+CiA 311 support is implemented through explicit mapping of ISO 15745 profile elements to shared domain models:
+
+- `CANopenObject` / `CANopenSubObject` attributes map to Object Dictionary objects/sub-objects.
+- XDC `actualValue` and `denotation` map to `ParameterValue` and `Denotation`.
+- `deviceCommissioning` maps to `DeviceCommissioning`.
+
+XDC writer behavior:
+- NodeId `0` means "commissioning not configured" and omits the XML `deviceCommissioning` element.
+- NodeId `1..127` emits a valid `deviceCommissioning` element.
+- Out-of-range NodeId values cause an exception.
+
+## 8.6 Modular Devices (CiA DS 306)
 
 CANopen supports modular devices (e.g., bus couplers with pluggable I/O modules). EdsDcfNet fully represents this concept:
 
@@ -120,7 +137,7 @@ graph TD
     style DCF fill:#E74C3C,color:#fff
 ```
 
-## 8.6 CANopen Object Dictionary Structure
+## 8.7 CANopen Object Dictionary Structure
 
 The Object Dictionary is the heart of every CANopen device:
 

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -8,7 +8,8 @@ The library needs a clearly defined entry point for consumers.
 
 ### Decision
 
-`CanOpenFile` is a **static class** with static methods (`ReadEds`, `ReadDcf`, `WriteDcf`, `EdsToDcf`).
+`CanOpenFile` is a **static class** with static methods for all supported formats
+(`ReadEds`, `ReadDcf`, `ReadCpj`, `ReadXdd`, `ReadXdc`, write counterparts, and `EdsToDcf`).
 
 ### Rationale
 
@@ -20,7 +21,7 @@ The library needs a clearly defined entry point for consumers.
 
 - (+) Minimal API surface, easy to discover and use.
 - (+) No dependency injection setup needed for simple use cases.
-- (-) Harder to mock in consumer unit tests (workaround: use `ReadEdsFromString`/`WriteDcfToString`).
+- (-) Harder to mock in consumer unit tests (workaround: use `Read*FromString`/`Write*ToString` methods).
 
 ---
 
@@ -28,7 +29,7 @@ The library needs a clearly defined entry point for consumers.
 
 ### Context
 
-EDS/DCF files are based on the INI format. Numerous INI parser libraries exist for .NET.
+EDS/DCF/CPJ files are based on the INI format. Numerous INI parser libraries exist for .NET.
 
 ### Decision
 
@@ -37,14 +38,16 @@ A **custom, minimal INI parser** (`IniParser`) is implemented.
 ### Rationale
 
 - **Zero-dependency principle**: No external NuGet dependencies.
-- EDS/DCF uses only a subset of the INI format (sections, key-value pairs, comments with `;`).
+- EDS/DCF/CPJ use only a subset of the INI format (sections, key-value pairs, comments with `;`).
 - A tailored parser can natively support case-insensitive section names.
 
 ### Consequences
 
 - (+) No dependency conflicts, lean package.
-- (+) Full control over parsing behavior.
+- (+) Full control over INI parsing behavior.
 - (-) Maintenance overhead for the custom parser.
+
+For CiA 311 XML formats (XDD/XDC), the implementation uses built-in `.NET` XML APIs (`System.Xml.Linq`) rather than a third-party XML dependency.
 
 ---
 
@@ -100,7 +103,7 @@ The library should support as many .NET platforms as possible while benefiting f
 
 ### Context
 
-EDS/DCF files can contain vendor-specific or future sections not represented in the model.
+INI-based formats (EDS/DCF/CPJ) can contain vendor-specific or future sections not represented in the model.
 
 ### Decision
 
@@ -115,12 +118,12 @@ Unknown sections are stored in a `Dictionary<string, Dictionary<string, string>>
 ### Consequences
 
 - (+) No unintentional removal of information.
-- (+) Compatibility with extended EDS/DCF files.
+- (+) Compatibility with extended EDS/DCF/CPJ files.
 - (-) No typed validation for unknown sections.
 
 ---
 
-## ADR-6: UTF-8 (without BOM) for DCF/CPJ File Output
+## ADR-6: UTF-8 (without BOM) for INI/XML File Output
 
 ### Context
 
@@ -129,13 +132,13 @@ real-world files often contain extended characters from vendor/device names.
 
 ### Decision
 
-`DcfWriter` and `CpjWriter` use **UTF-8 without BOM** when writing files.
+All writers (`DcfWriter`, `CpjWriter`, `XddWriter`, `XdcWriter`) use **UTF-8 without BOM** when writing files.
 
 ### Rationale
 
 - UTF-8 is ASCII-compatible for the 7-bit subset required by classic tooling.
 - Non-ASCII characters are preserved instead of being replaced during write.
-- Reader and writer behavior stay symmetric (UTF-8-based text processing).
+- Reader and writer behavior stays symmetric across INI and XML formats (UTF-8-based text processing).
 
 ### Consequences
 

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -6,9 +6,10 @@
 mindmap
   root((Quality))
     Correctness
-      Specification compliance
+      Specification compliance (CiA DS 306 + CiA 311 subset)
       Number format processing
       Round-trip fidelity
+      INI/XML format interoperability
     Portability
       netstandard2.0
       net10.0
@@ -36,10 +37,10 @@ mindmap
 
 | Aspect           | Description                                                                |
 |------------------|----------------------------------------------------------------------------|
-| **Stimulus**     | An EDS file conforming to CiA DS 306 v1.4 is read.                        |
+| **Stimulus**     | A valid DS 306 (EDS/DCF/CPJ) or supported CiA 311 (XDD/XDC) file is read. |
 | **Environment**  | Regular library operation.                                                 |
-| **Response**     | All specified sections and fields are correctly interpreted.               |
-| **Metric**       | 100% of sections defined in the specification are supported.               |
+| **Response**     | Mapped sections and fields are correctly interpreted into typed models.    |
+| **Metric**       | All currently implemented sections/features pass automated parser/writer and integration tests. |
 
 ### Scenario 2: Platform Compatibility
 
@@ -54,7 +55,7 @@ mindmap
 
 | Aspect           | Description                                                                |
 |------------------|----------------------------------------------------------------------------|
-| **Stimulus**     | An EDS file with hexadecimal values is read on a system with German culture. |
+| **Stimulus**     | A CANopen INI/XML file with numeric values is read on a system with German culture. |
 | **Environment**  | Operating system with `de-DE` as default culture.                          |
 | **Response**     | Values are parsed correctly, no culture-related errors.                    |
 | **Metric**       | Identical results regardless of system culture.                            |
@@ -77,6 +78,15 @@ mindmap
 | **Response**     | `EdsParseException` is thrown with `SectionName = "1000"` and optionally `LineNumber`. |
 | **Metric**       | Errors can be localized within 30 seconds.                                 |
 
+### Scenario 6: XDC Commissioning Validation
+
+| Aspect           | Description                                                                |
+|------------------|----------------------------------------------------------------------------|
+| **Stimulus**     | An XDC is generated with an invalid commissioning NodeId (e.g., 128).     |
+| **Environment**  | Regular library operation.                                                 |
+| **Response**     | Writing fails fast with a clear exception before output is persisted.      |
+| **Metric**       | Invalid NodeId is rejected in all writer test cases.                       |
+
 ## 10.3 Test Coverage
 
 Quality is ensured through automated tests:
@@ -94,6 +104,11 @@ Quality is ensured through automated tests:
 | **Unit tests**           | `DcfWriteExceptionTests`         | Exception constructors and properties             |
 | **Unit tests**           | `CpjReaderTests`                 | CPJ topology parsing, multi-network, node IDs     |
 | **Unit tests**           | `CpjWriterTests`                 | CPJ output, round-trip fidelity                   |
+| **Unit tests**           | `XddReaderTests`                 | XDD XML profile parsing                            |
+| **Unit tests**           | `XdcReaderTests`                 | XDC XML parsing incl. commissioning/actual values |
+| **Unit tests**           | `XddWriterTests`                 | XDD XML generation                                 |
+| **Unit tests**           | `XdcWriterTests`                 | XDC XML generation and NodeId validation           |
 | **Integration tests**    | `CanOpenFileTests`               | End-to-end: read file, verify model               |
 | **Integration tests**    | `RoundTripDcfTests`              | Read -> write -> read again                       |
 | **Integration tests**    | `CpjIntegrationTests`            | CPJ end-to-end via CanOpenFile facade              |
+| **Integration tests**    | `XddXdcIntegrationTests`         | XDD/XDC round-trip and cross-format conversion     |

--- a/docs/architecture/11-risks-and-technical-debt.md
+++ b/docs/architecture/11-risks-and-technical-debt.md
@@ -2,14 +2,14 @@
 
 ## 11.1 Risks
 
-### R-1: Specification Changes (CiA DS 306)
+### R-1: Specification Changes (CiA DS 306 / CiA 311)
 
 | Aspect           | Description                                                                 |
 |------------------|-----------------------------------------------------------------------------|
-| **Risk**         | Future versions of the CiA DS 306 specification introduce new sections or fields. |
+| **Risk**         | Future versions of CiA DS 306 or CiA 311 introduce new sections/elements or attributes. |
 | **Likelihood**   | Medium (specification is periodically updated).                             |
 | **Impact**       | New fields could be ignored or misinterpreted.                              |
-| **Mitigation**   | `AdditionalSections` preserves unknown sections. New fields in known sections are treated as `null` (forward-compatible). |
+| **Mitigation**   | INI unknown sections are preserved in `AdditionalSections`; XML handling is kept strict to the supported mapped profile subset and extended incrementally with tests. |
 
 ### R-2: netstandard2.0 API Limitations
 
@@ -29,6 +29,15 @@
 | **Impact**       | `EdsParseException` on otherwise usable files.                              |
 | **Mitigation**   | Tolerant parsing for optional fields. Support for common deviations (e.g., misspelling `"DeviceComissioning"` instead of `"DeviceCommissioning"`). |
 
+### R-4: Non-Compliant or Tool-Specific XDD/XDC XML
+
+| Aspect           | Description                                                                 |
+|------------------|-----------------------------------------------------------------------------|
+| **Risk**         | Real-world XDD/XDC exports can vary between tooling vendors and may include unsupported XML constructs. |
+| **Likelihood**   | Medium.                                                                     |
+| **Impact**       | Parse failures or partial data mapping.                                     |
+| **Mitigation**   | Keep parser behavior explicit, add fixture-based compatibility tests for encountered variants, and extend mappings conservatively. |
+
 ## 11.2 Technical Debt
 
 ### TD-1: No Inheritance Hierarchy Between EDS and DCF
@@ -43,7 +52,7 @@
 
 | Aspect           | Description                                                                 |
 |------------------|-----------------------------------------------------------------------------|
-| **Description**  | Only a `DcfWriter` exists, no `EdsWriter`. EDS files can only be read.      |
+| **Description**  | There is no INI EDS writer (`.eds`). While XDD/XDC XML writing is supported, DS-306 EDS text generation is not implemented. |
 | **Impact**       | Users who want to programmatically create EDS files cannot do so.           |
 | **Priority**     | Medium (no demand expressed so far, as EDS is typically supplied by the manufacturer). |
 
@@ -51,6 +60,6 @@
 
 | Aspect           | Description                                                                 |
 |------------------|-----------------------------------------------------------------------------|
-| **Description**  | All file operations (`ReadEds`, `WriteDcf`) are synchronous.                |
+| **Description**  | All file operations (`ReadEds`, `ReadXdd`, `WriteDcf`, `WriteXdc`, etc.) are synchronous. |
 | **Impact**       | In async-based applications (e.g., ASP.NET), this may block the thread pool. |
 | **Priority**     | Low (EDS/DCF files are typically small, I/O is negligible).                 |

--- a/docs/architecture/12-glossary.md
+++ b/docs/architecture/12-glossary.md
@@ -6,8 +6,12 @@
 | **CAN (Controller Area Network)** | Serial bus system for networking control units, widely used in vehicles and industrial automation. |
 | **CiA**                       | CAN in Automation e.V. -- international manufacturer and user association that maintains the CANopen specifications. |
 | **CiA DS 306**                | Specification for Electronic Data Sheets (EDS) and Device Configuration Files (DCF) for CANopen devices. |
+| **CiA 311**                   | XML-based CANopen device description/configuration specification family (XDD/XDC, based on ISO 15745 profiles). |
 | **EDS (Electronic Data Sheet)** | Device description file in INI format that defines the communication capabilities and configurable parameters of a CANopen device. Serves as a template. |
 | **DCF (Device Configuration File)** | Configured instance of an EDS file for a specific network node. Contains concrete parameter values, node ID, and baud rate. |
+| **XDD (XML Device Description)** | XML representation of CANopen device description data (CiA 311). Roughly analogous to EDS content. |
+| **XDC (XML Device Configuration)** | XML representation of configured CANopen device data (CiA 311). Roughly analogous to DCF content. |
+| **ISO 15745 Profile**         | XML profile container concept used by CiA 311 to structure device and communication-network descriptions. |
 | **Object Dictionary (OD)**    | Central data object directory of a CANopen device. Each entry is addressable by a 16-bit index and optional 8-bit sub-index. |
 | **Node ID**                   | Unique identifier (1-127) of a CANopen device on the network.                                    |
 | **Baud rate**                 | Transmission speed on the CAN bus (typical values: 125, 250, 500, 1000 kbit/s).                  |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,7 +9,7 @@
 | **Repository**      | https://github.com/dborgards/eds-dcf-net                 |
 | **License**         | MIT                                                      |
 | **Platform**        | .NET Standard 2.0 / .NET 10.0                            |
-| **Specification**   | CiA DS 306 v1.4.0 (December 15, 2021) incl. CiA 306-3    |
+| **Specification**   | CiA DS 306 v1.4.0 (incl. CiA 306-3) and CiA 311 (XDD/XDC) |
 
 ---
 

--- a/docs/tech-stack-canvas.md
+++ b/docs/tech-stack-canvas.md
@@ -5,7 +5,7 @@
 | | Context | Layers | | Support |
 |---|---|---|---|---|
 | **Business Goals** | **Frontend Technologies** | **API & Integrations** | **Security & Compliance** | |
-| Provide a zero-dependency C# library for reading/writing CiA DS 306 EDS, DCF and CPJ files | _Not applicable_ (library, no UI) | CANopen Object Dictionary (0x1000–0x5FFF) | MIT License | |
+| Provide a zero-dependency C# library for reading/writing CiA DS 306 and CiA 311 CANopen files | _Not applicable_ (library, no UI) | CANopen Object Dictionary (0x1000–0x5FFF) | MIT License | |
 | Support broad .NET ecosystem (netstandard2.0 + net10.0) | | PDO / SRDO mapping | Nullable reference types enabled | |
 | Enable round-trip fidelity for industrial automation device configuration | | `$NODEID` formula evaluation | Deterministic builds | |
 | | | Modular device support (bus couplers + modules) | SourceLink for supply-chain transparency | |
@@ -17,7 +17,7 @@
 
 ### Business Goals
 
-- Provide a comprehensive, **zero-dependency** C# library for reading and writing CiA DS 306 EDS/DCF/CPJ files
+- Provide a comprehensive, **zero-dependency** C# library for reading and writing CiA DS 306 (EDS/DCF/CPJ) and CiA 311 (XDD/XDC) files
 - Support the broadest possible .NET ecosystem via **netstandard2.0** (.NET Framework 4.6.1+, .NET Core 2.0+, Unity, Xamarin) and **net10.0**
 - Enable **round-trip fidelity** — unknown/vendor-specific sections are preserved during read-modify-write cycles
 - Distribute as a NuGet package with automated semantic versioning and publishing
@@ -28,12 +28,12 @@
 - **External dependencies:** 0 (core library)
 - **Object Dictionary address space:** 0x1000–0x5FFF (CANopen standard)
 - **Current version:** Branch-specific; see `src/EdsDcfNet/EdsDcfNet.csproj` (managed by semantic-release)
-- **File formats:** 3 (EDS read, DCF read/write, CPJ read/write)
+- **File formats:** 5 (`.eds`, `.dcf`, `.cpj`, `.xdd`, `.xdc`)
 
 ### Major Quality Attributes
 
 - **Compatibility** — Must work on all .NET platforms via netstandard2.0; all string/number parsing uses `CultureInfo.InvariantCulture`
-- **Correctness** — Full compliance with CiA DS 306 v1.4.0 specification
+- **Correctness** — Correct parsing/writing of implemented CiA DS 306 and CiA 311 feature sets
 - **Round-trip fidelity** — Unknown sections preserved in `AdditionalSections` dictionary
 - **Simplicity** — Zero external dependencies, single static facade API (`CanOpenFile`)
 - **Maintainability** — Comprehensive test suite, architecture documentation (ARC42), XML doc comments on all public members
@@ -65,10 +65,10 @@ An **example console application** (`examples/EdsDcfNet.Examples/`) demonstrates
 
 | Category | Technology |
 |---|---|
-| **File formats** | EDS / DCF / CPJ (INI-style text files, CiA DS 306 v1.4.0) |
+| **File formats** | EDS / DCF / CPJ (INI-style) and XDD / XDC (XML, CiA 311) |
 | **File encoding (I/O)** | UTF-8 text processing; file writes use UTF-8 without BOM |
 | **In-memory model** | Strongly-typed C# objects (`ElectronicDataSheet`, `DeviceConfigurationFile`, `NodelistProject`, `ObjectDictionary`) |
-| **Persistence** | File-based — read from and write to `.eds` / `.dcf` / `.cpj` files |
+| **Persistence** | File-based — read from and write to `.eds` / `.dcf` / `.cpj` / `.xdd` / `.xdc` files |
 | **Unknown data** | Preserved in `Dictionary<string, Dictionary<string, string>> AdditionalSections` |
 
 ### API & Integrations
@@ -81,6 +81,10 @@ ReadDcf(filePath) / ReadDcfFromString(content) → DeviceConfigurationFile
 WriteDcf(dcf, filePath) / WriteDcfToString(dcf) → DCF output
 ReadCpj(filePath) / ReadCpjFromString(content) → NodelistProject
 WriteCpj(cpj, filePath) / WriteCpjToString(cpj) → CPJ output
+ReadXdd(filePath) / ReadXddFromString(content) → ElectronicDataSheet
+WriteXdd(xdd, filePath) / WriteXddToString(xdd) → XDD output
+ReadXdc(filePath) / ReadXdcFromString(content) → DeviceConfigurationFile
+WriteXdc(xdc, filePath) / WriteXdcToString(xdc) → XDC output
 EdsToDcf(eds, nodeId, baudrate, nodeName) → DeviceConfigurationFile
 ```
 
@@ -110,7 +114,7 @@ EdsToDcf(eds, nodeId, baudrate, nodeName) → DeviceConfigurationFile
 | **Coverage reporting** | Codecov |
 | **Naming convention** | `MethodName_Scenario_ExpectedBehavior` |
 | **Test pattern** | Arrange-Act-Assert (AAA) |
-| **Fixture data** | `tests/EdsDcfNet.Tests/Fixtures/` (sample EDS/DCF files) |
+| **Fixture data** | `tests/EdsDcfNet.Tests/Fixtures/` (sample EDS/DCF/XDD/XDC/CPJ files) |
 
 ### Infrastructure & Deployment
 
@@ -139,6 +143,6 @@ EdsToDcf(eds, nodeId, baudrate, nodeName) → DeviceConfigurationFile
 | **Commit convention** | Conventional Commits |
 | **Branching strategy** | `main` (stable) · `develop` (beta) · `alpha` (experimental) · feature branches |
 | **Release automation** | semantic-release with commit-analyzer, changelog, exec, git, github plugins |
-| **Documentation** | ARC42 architecture docs (12 chapters), CiA DS 306 specification PDF |
+| **Documentation** | ARC42 architecture docs (12 chapters), CiA DS 306 specification PDF, CiA format notes in README |
 | **IDE support** | Visual Studio 2017+ (.sln), VS Code |
 | **AI assistants** | CLAUDE.md, `.github/copilot-instructions.md` |

--- a/tests/EdsDcfNet.Tests/README.md
+++ b/tests/EdsDcfNet.Tests/README.md
@@ -56,6 +56,30 @@ Tests for the `DcfWriter` class:
 - Writing Comments section
 - Writing to files with error handling
 
+#### Parsers/CpjReaderTests.cs
+Tests for the `CpjReader` class:
+- Parsing topology sections (`[Topology]`, `[Topology2]`, ...)
+- Parsing node presence/name/DCF reference data
+- Preserving unknown sections as additional sections
+
+#### Writers/CpjWriterTests.cs
+Tests for the `CpjWriter` class:
+- Serializing network topologies and node entries
+- Deterministic node ordering
+- Round-trip behavior for CPJ data
+
+#### Parsers/XddReaderTests.cs and Parsers/XdcReaderTests.cs
+Tests for CiA 311 XML parsers:
+- Parsing `ISO15745ProfileContainer` content
+- Mapping object dictionary entries from XML
+- XDC-specific `actualValue`, `denotation`, and `deviceCommissioning`
+
+#### Writers/XddWriterTests.cs and Writers/XdcWriterTests.cs
+Tests for CiA 311 XML writers:
+- Generating valid XDD/XDC XML output
+- Emitting commissioning and actual-value attributes
+- Validating out-of-range NodeId behavior for XDC
+
 ### Integration Tests
 
 #### Integration/CanOpenFileTests.cs
@@ -66,6 +90,13 @@ Tests for the `CanOpenFile` API:
 - EdsToDcf conversion with commissioning parameters
 - Round-trip tests (EDS → DCF → String → DCF)
 - Data preservation through conversions
+
+#### Integration/XddXdcIntegrationTests.cs
+Integration tests for XML and cross-format flows:
+- XDD ↔ XDD round-trip
+- XDC ↔ XDC round-trip
+- EDS → XDD → model verification
+- XDD/XDC → DCF conversion paths
 
 ## Running Tests
 
@@ -102,15 +133,20 @@ The test suite provides comprehensive coverage of:
 - ✅ INI file parsing with various edge cases
 - ✅ EDS file reading and structure parsing
 - ✅ DCF file writing and formatting
+- ✅ CPJ parsing/writing and network topology handling
+- ✅ XDD/XDC XML parsing and writing (CiA 311)
 - ✅ Object dictionary manipulation
 - ✅ Main API entry points
-- ✅ Round-trip conversion scenarios
+- ✅ Round-trip and cross-format conversion scenarios
 - ✅ Error handling and validation
 
 ## Test Fixtures
 
 The `Fixtures/` directory contains:
-- `sample_device.eds` - Sample CANopen Electronic Data Sheet used for integration tests
+- `sample_device.eds` - Sample CANopen Electronic Data Sheet
+- `sample_device.xdd` - Sample CiA 311 XML device description
+- `minimal.dcf` / `minimal.xdc` - Minimal configuration files for INI/XML paths
+- `modular_device.dcf` / `full_features.dcf` - Extended DCF fixtures for feature coverage
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- update README to reflect current API and format support (EDS/DCF/CPJ/XDD/XDC)
- align ARC42 chapters with implemented INI and XML parsing/writing flows
- update tech stack and test documentation to include CiA 311 coverage

## Scope
- documentation only
- no production code changes