### PR TITLE
test: raise parser and writer coverage for edge branches

### DIFF
--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1248,6 +1248,26 @@ NrOfEntries=3
     }
 
     [Fact]
+    public void ReadString_ConnectedModules_InvalidEntries_AreSkipped()
+    {
+        // Arrange
+        var content = BuildMinimalDcf(extraSections: @"
+[ConnectedModules]
+NrOfEntries=4
+1=1
+2=abc
+3=
+4=2
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.ConnectedModules.Should().ContainInOrder(1, 2);
+    }
+
+    [Fact]
     public void ReadString_NoConnectedModules_EmptyList()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
@@ -240,6 +240,19 @@ public class XdcReaderTests
     }
 
     [Fact]
+    public void ParseDeviceCommissioning_DocumentWithoutRoot_ReturnsNull()
+    {
+        var method = typeof(XdcReader).GetMethod(
+            "ParseDeviceCommissioning",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        method.Should().NotBeNull();
+
+        var result = method!.Invoke(null, new object[] { new System.Xml.Linq.XDocument() });
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void ParseDeviceCommissioning_NoNetworkManagementElement_ReturnsDefault()
     {
         // XDC without a deviceCommissioning element → ParseDeviceCommissioning returns null → default

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -750,6 +750,91 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void ReadString_XddActualValueAndDenotation_AreIgnored()
+    {
+        // XDD reader parses with includeActualValues=false, so actualValue/denotation must not be mapped.
+        var xdd = MinimalXdd.Replace(
+            @"<CANopenObjectList mandatoryObjects=""1"" optionalObjects=""0"" manufacturerObjects=""0"">
+          <CANopenObject index=""1000"" name=""Device Type"" objectType=""7"" dataType=""0007""
+                         accessType=""ro"" defaultValue=""0x00000000"" PDOmapping=""no""/>",
+            @"<CANopenObjectList mandatoryObjects=""0"" optionalObjects=""1"" manufacturerObjects=""0"">
+          <CANopenObject index=""1018"" name=""Identity"" objectType=""9"" subNumber=""1""
+                         actualValue=""ignored"" denotation=""ignored-too"">
+            <CANopenSubObject subIndex=""00"" name=""Count"" objectType=""7"" dataType=""0005""
+                              accessType=""ro"" defaultValue=""1"" PDOmapping=""no""
+                              actualValue=""7"" denotation=""SubText""/>
+          </CANopenObject>");
+
+        var result = _reader.ReadString(xdd);
+
+        var obj = result.ObjectDictionary.Objects[0x1018];
+        obj.ParameterValue.Should().BeNull();
+        obj.Denotation.Should().BeNull();
+        obj.SubObjects[0].ParameterValue.Should().BeNull();
+        obj.SubObjects[0].Denotation.Should().BeNull();
+    }
+
+    [Fact]
+    public void FileInfo_FileVersionWithMinorPart_UsesMajorAndParsesModificationMetadata()
+    {
+        var xdd = MinimalXdd.Replace(
+            @"fileCreationDate=""2025-01-15"" fileVersion=""1""",
+            @"fileCreationDate=""2025-01-15"" fileVersion=""7.3"" fileModifiedBy=""Editor"" fileModificationDate=""2025-02-20"" fileModificationTime=""16:45""");
+
+        var result = _reader.ReadString(xdd);
+
+        result.FileInfo.FileVersion.Should().Be(7);
+        result.FileInfo.ModifiedBy.Should().Be("Editor");
+        result.FileInfo.ModificationDate.Should().Be("02-20-2025");
+        result.FileInfo.ModificationTime.Should().Be("16:45");
+    }
+
+    [Fact]
+    public void ParseNetworkManagement_InvalidNumericValues_AreIgnored_BooleanOnesAreAccepted()
+    {
+        var xdd = MinimalXdd
+            .Replace(@"granularity=""8""", @"granularity=""invalid""")
+            .Replace(@"nrOfRxPDO=""2""", @"nrOfRxPDO=""oops""")
+            .Replace(@"nrOfTxPDO=""2""", @"nrOfTxPDO=""nope""")
+            .Replace(@"dynamicChannels=""0""", @"dynamicChannels=""bad""")
+            .Replace(@"bootUpSlave=""true""", @"bootUpSlave=""1""")
+            .Replace(@"layerSettingServiceSlave=""false""", @"layerSettingServiceSlave=""1""")
+            .Replace(@"groupMessaging=""false""", @"groupMessaging=""1""")
+            .Replace(@"bootUpMaster=""false""", @"bootUpMaster=""1""");
+
+        var result = _reader.ReadString(xdd);
+
+        result.DeviceInfo.Granularity.Should().Be(8);
+        result.DeviceInfo.NrOfRxPdo.Should().Be(0);
+        result.DeviceInfo.NrOfTxPdo.Should().Be(0);
+        result.DeviceInfo.DynamicChannelsSupported.Should().Be(0);
+        result.DeviceInfo.SimpleBootUpSlave.Should().BeTrue();
+        result.DeviceInfo.LssSupported.Should().BeTrue();
+        result.DeviceInfo.GroupMessaging.Should().BeTrue();
+        result.DeviceInfo.SimpleBootUpMaster.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseDynamicChannels_EndIndexWithoutStartIndex_DoesNotBuildRangeAndInvalidOffsetIgnored()
+    {
+        var xdd = MinimalXdd.Replace(
+            "</ApplicationLayers>",
+            @"  <dynamicChannels>
+            <dynamicChannel dataType=""0007"" accessType=""ro"" endIndex=""17FF"" pDOmappingIndex=""not-a-number""/>
+          </dynamicChannels>
+        </ApplicationLayers>");
+
+        var result = _reader.ReadString(xdd);
+
+        result.DynamicChannels.Should().NotBeNull();
+        result.DynamicChannels!.Segments.Should().HaveCount(1);
+        result.DynamicChannels.Segments[0].Type.Should().Be(0x0007);
+        result.DynamicChannels.Segments[0].Dir.Should().Be(AccessType.ReadOnly);
+        result.DynamicChannels.Segments[0].Range.Should().BeEmpty();
+        result.DynamicChannels.Segments[0].PPOffset.Should().Be(0);
+    }
+
+    [Fact]
     public void ParseXddAccessType_Unknown_DefaultsToReadOnly()
     {
         // An unrecognized accessType should fall through to the default (ReadOnly)

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -553,6 +553,41 @@ public class DcfWriterTests
     }
 
     [Fact]
+    public void GenerateString_SubObjectLowAndHighLimit_WrittenWhenSet()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.OptionalObjects.Add(0x1018);
+        dcf.ObjectDictionary.Objects[0x1018] = new CanOpenObject
+        {
+            Index = 0x1018,
+            ParameterName = "Identity Object",
+            ObjectType = 0x9,
+            SubNumber = 1
+        };
+        dcf.ObjectDictionary.Objects[0x1018].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "Number of Entries",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "1",
+            LowLimit = "0",
+            HighLimit = "0xFF",
+            PdoMapping = false
+        };
+
+        // Act
+        var result = _writer.GenerateString(dcf);
+
+        // Assert
+        result.Should().Contain("[1018sub0]");
+        result.Should().Contain("LowLimit=0");
+        result.Should().Contain("HighLimit=0xFF");
+    }
+
+    [Fact]
     public void GenerateString_SrdoMapping_WrittenOnObjectAndSubObject()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
@@ -123,6 +123,32 @@ public class XdcWriterTests
     }
 
     [Fact]
+    public void GenerateString_DeviceCommissioning_OptionalFieldsOmitted_AndManagerTrue()
+    {
+        // Arrange
+        var dcf = CreateSampleDcf();
+        dcf.DeviceCommissioning = new DeviceCommissioning
+        {
+            NodeId = 5,
+            Baudrate = 0,
+            NetNumber = 7,
+            CANopenManager = true
+        };
+
+        // Act
+        var result = _writer.GenerateString(dcf);
+
+        // Assert
+        result.Should().Contain("deviceCommissioning");
+        result.Should().Contain("nodeID=\"5\"");
+        result.Should().Contain("networkNumber=\"7\"");
+        result.Should().Contain("CANopenManager=\"true\"");
+        result.Should().NotContain("nodeName=");
+        result.Should().NotContain("actualBaudRate=");
+        result.Should().NotContain("networkName=");
+    }
+
+    [Fact]
     public void GenerateString_DeviceCommissioning_Null_ElementOmitted()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
@@ -211,6 +211,36 @@ public class XddWriterTests
     }
 
     [Fact]
+    public void GenerateString_GeneralFeatures_GroupMessagingAndLssSupported_WrittenAsTrue()
+    {
+        // Arrange
+        var eds = CreateSampleEds();
+        eds.DeviceInfo.GroupMessaging = true;
+        eds.DeviceInfo.LssSupported = true;
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("groupMessaging=\"true\"");
+        result.Should().Contain("layerSettingServiceSlave=\"true\"");
+    }
+
+    [Fact]
+    public void GenerateString_MasterFeatures_BootUpMaster_WrittenAsTrue()
+    {
+        // Arrange
+        var eds = CreateSampleEds();
+        eds.DeviceInfo.SimpleBootUpMaster = true;
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("bootUpMaster=\"true\"");
+    }
+
+    [Fact]
     public void GenerateString_ApplicationProcessXml_PreservedRoundTrip()
     {
         // Arrange


### PR DESCRIPTION
Summary

- add targeted DCF writer coverage for sub-object LowLimit/HighLimit output
- add XDD/XDC parser tests for edge branches (ignored actualValue in XDD mode, fileVersion major.minor handling, invalid numeric parsing, dynamic-channel edge handling, root-less XDC commissioning parse)
- add writer tests for optional commissioning attributes and master/general feature boolean flags
- add connected-modules parser test that verifies invalid entries are skipped\n\nValidation
- dotnet test EdsDcfNet.sln
- dotnet test EdsDcfNet.sln --collect:XPlat\ Code\ Coverage --results-directory TestResultsLatestAfter

- Coverage impact
- overall line rate: 99.70% -> 99.96%
- overall branch rate: 94.00% -> 95.21%
- remaining uncovered source line: Parsers/XdcReader.cs:72