### PR TITLE
ci: switch Claude Code workflows to ANTHROPIC_API_KEY auth

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Problem

Both `claude.yml` and `claude-code-review.yml` used `claude_code_oauth_token`, which requires a Claude.ai Pro/Teams OAuth token. Without the `CLAUDE_CODE_OAUTH_TOKEN` secret set, Claude Code exits immediately with code 1 (exit code visible in CI as `total_cost_usd: 0`, `duration_ms: ~200`).

## Fix

Switch both workflows to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`.

## Required action after merge

Add your Anthropic API key as a repository secret:
1. Go to **Settings → Secrets and variables → Actions**
2. Add a new secret named **`ANTHROPIC_API_KEY`**
3. Paste your API key from [console.anthropic.com](https://console.anthropic.com)
