### PR TITLE
ci: add continue-on-error to claude-review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Problem

The OIDC app-token exchange in `claude-code-review.yml` always fails on PRs where the workflow file does not yet exist on `main` (Anthropic's backend requires the file to be present and identical on the default branch). This causes a permanent red check on the bootstrap release PR.

## Fix

Add `continue-on-error: true` to the `claude-review` job so that this expected failure never blocks a PR. The review itself still runs and posts its comment when successful — the job simply won't mark the PR as failed when the OIDC exchange cannot complete.

## Note

This should be merged into `develop` before merging the develop→main release PR (#72) so that `main` gets the correct workflow from the start.
