### PR TITLE
test: make EdsWriter invalid-path test platform-independent

### DIFF
--- a/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
@@ -399,7 +399,7 @@ public class EdsWriterTests
     {
         // Arrange
         var eds = CreateMinimalEds();
-        var invalidPath = "/invalid/path/that/does/not/exist/test.eds";
+        var invalidPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "test.eds");
 
         // Act
         var act = () => _writer.WriteFile(eds, invalidPath);


### PR DESCRIPTION
## Summary
- replace hard-coded invalid path test value with a deterministic non-existent temp path
- use Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "test.eds") for platform independence

## Why
- addresses Copilot review feedback about environment-dependent path assumptions

## Testing
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter "FullyQualifiedName~EdsWriterTests"