### PR TITLE
refactor: replace netstandard2.0 workarounds with Polyfill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,13 +8,19 @@ EdsDcfNet is a C# library for reading and writing CiA DS 306 EDS (Electronic Dat
 
 ### .NET Standard 2.0 Compatibility
 
-This library must compile against netstandard2.0. The following APIs are **not available** and must be avoided:
+This library must compile against netstandard2.0. The **Polyfill** package (build-time only, `PrivateAssets="all"`) is included to bridge the API gap — it does not create a runtime dependency for consumers.
 
-- `string.Replace(string, string, StringComparison)` — use `IndexOf` + `Substring` for case-insensitive replacement
-- `string.Contains(string, StringComparison)` — use `IndexOf(string, StringComparison) >= 0`
-- `string.Contains(char)` — use `IndexOf(char) >= 0`
-- `string.StartsWith(char)` / `string.EndsWith(char)` — use the `string` overload instead
-- `[NotNullWhen]`, `[MemberNotNull]` attributes — not available without polyfill
+Thanks to Polyfill, modern APIs can be used directly:
+
+- `string.Contains(char)` ✓
+- `string.Contains(string, StringComparison)` ✓
+- `string.StartsWith(char)` / `string.EndsWith(char)` ✓
+- Range indexers (`[n..]`, `[..n]`, `[^n]`) ✓
+- `[NotNullWhen]`, `[MemberNotNull]` attributes ✓
+
+The following API is still **not available** and must be avoided:
+
+- `string.Replace(string, string, StringComparison)` — use `IndexOf` + range indexer for case-insensitive replacement
 
 ### Invariant Culture
 

--- a/src/EdsDcfNet/EdsDcfNet.csproj
+++ b/src/EdsDcfNet/EdsDcfNet.csproj
@@ -34,6 +34,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.*" PrivateAssets="All" />
+		<PackageReference Include="Polyfill" Version="9.12.0" PrivateAssets="all" />
 	</ItemGroup>
 
 </Project>

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -7,8 +7,6 @@ using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Utilities;
 
-#pragma warning disable CA1845, CA1846 // span-based overloads not available in netstandard2.0
-
 /// <summary>
 /// Abstract base class for EDS and DCF readers.
 /// Contains all shared CANopen INI parsing logic; format-specific behaviour
@@ -191,7 +189,7 @@ public abstract class CanOpenReaderBase
             {
                 if (key.StartsWith("Dummy", StringComparison.OrdinalIgnoreCase) && key.Length > 5)
                 {
-                    var indexStr = key.Substring(5);
+                    var indexStr = key[5..];
                     if (ushort.TryParse(indexStr, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
                     {
                         objDict.DummyUsage[index] = ValueConverter.ParseBoolean(
@@ -509,7 +507,7 @@ public abstract class CanOpenReaderBase
         if (!sectionName.StartsWith("Tool", StringComparison.OrdinalIgnoreCase) || sectionName.Length <= 4)
             return false;
 
-        if (!int.TryParse(sectionName.Substring(4), NumberStyles.Integer, CultureInfo.InvariantCulture, out var toolNumber))
+        if (!int.TryParse(sectionName[4..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var toolNumber))
             return false;
 
         return toolNumber >= 1 && toolNumber <= parsedToolCount;
@@ -524,7 +522,7 @@ public abstract class CanOpenReaderBase
         if (subPos < 1)
             return false;
 
-        var prefix = sectionName.Substring(0, subPos);
+        var prefix = sectionName[..subPos];
         return ushort.TryParse(prefix, NumberStyles.HexNumber,
             CultureInfo.InvariantCulture, out _);
     }
@@ -537,7 +535,7 @@ public abstract class CanOpenReaderBase
         if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var prefix = sectionName.Substring(0, sectionName.Length - suffix.Length);
+        var prefix = sectionName[..^suffix.Length];
         return prefix.Length > 0 && ushort.TryParse(prefix,
             NumberStyles.HexNumber,
             CultureInfo.InvariantCulture, out _);
@@ -561,7 +559,7 @@ public abstract class CanOpenReaderBase
             return false;
 
         // The suffix after "M{digits}" must be a known module suffix
-        var suffix = sectionName.Substring(i);
+        var suffix = sectionName[i..];
         return suffix.Equals("ModuleInfo", StringComparison.OrdinalIgnoreCase) ||
                suffix.Equals("FixedObjects", StringComparison.OrdinalIgnoreCase) ||
                suffix.StartsWith("SubExtend", StringComparison.OrdinalIgnoreCase) ||
@@ -569,5 +567,3 @@ public abstract class CanOpenReaderBase
                suffix.Equals("Comments", StringComparison.OrdinalIgnoreCase);
     }
 }
-
-#pragma warning restore CA1845, CA1846 // span-based overloads not available in netstandard2.0

--- a/src/EdsDcfNet/Parsers/IniParser.cs
+++ b/src/EdsDcfNet/Parsers/IniParser.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using EdsDcfNet.Exceptions;
 
-#pragma warning disable CA1865, CA1866 // char overloads not available in netstandard2.0
-
 /// <summary>
 /// Low-level INI file parser for EDS/DCF files.
 /// Parses INI-style files with sections and key-value pairs.
@@ -138,13 +136,13 @@ public static class IniParser
             var line = rawLine.Trim();
 
             // Skip empty lines and comments
-            if (string.IsNullOrWhiteSpace(line) || line.StartsWith(";", StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith(';'))
                 continue;
 
             // Check for section header
-            if (line.StartsWith("[", StringComparison.Ordinal) && line.EndsWith("]", StringComparison.Ordinal))
+            if (line.StartsWith('[') && line.EndsWith(']'))
             {
-                currentSection = line.Substring(1, line.Length - 2).Trim();
+                currentSection = line[1..^1].Trim();
 
                 if (!sections.ContainsKey(currentSection))
                 {
@@ -163,9 +161,9 @@ public static class IniParser
                     throw new EdsParseException($"Key-value pair found outside of any section at line {lineNumber}", lineNumber);
                 }
 
-                var key = line.Substring(0, equalIndex).Trim();
+                var key = line[..equalIndex].Trim();
                 var value = equalIndex < line.Length - 1
-                    ? line.Substring(equalIndex + 1).Trim()
+                    ? line[(equalIndex + 1)..].Trim()
                     : string.Empty;
 
                 sections[currentSection][key] = value;
@@ -175,5 +173,3 @@ public static class IniParser
         return sections;
     }
 }
-
-#pragma warning restore CA1865, CA1866 // char overloads not available in netstandard2.0

--- a/src/EdsDcfNet/Parsers/XdcReader.cs
+++ b/src/EdsDcfNet/Parsers/XdcReader.cs
@@ -93,7 +93,7 @@ public class XdcReader
 
             // Only look in the CommunicationNetwork profile body
             var xsiType = XddReader.GetXsiType(profileBody);
-            if (xsiType.IndexOf("ProfileBody_CommunicationNetwork_CANopen", StringComparison.OrdinalIgnoreCase) < 0)
+            if (!xsiType.Contains("ProfileBody_CommunicationNetwork_CANopen", StringComparison.OrdinalIgnoreCase))
                 continue;
 
             var networkMgmt = profileBody.Elements()

--- a/src/EdsDcfNet/Parsers/XddReader.cs
+++ b/src/EdsDcfNet/Parsers/XddReader.cs
@@ -8,10 +8,6 @@ using System.Xml.Linq;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 
-#pragma warning disable CA1845, CA1865, CA1866 // span-based and char overloads not available in netstandard2.0
-#pragma warning disable CA2249 // string.Contains(string, StringComparison) not available in netstandard2.0; IndexOf is the correct alternative
-#pragma warning disable CA1846 // AsSpan not available in netstandard2.0
-
 /// <summary>
 /// Reader for CiA 311 XDD (XML Device Description) files.
 /// </summary>
@@ -96,9 +92,9 @@ public class XddReader
                 continue;
 
             var xsiType = GetXsiType(profileBody);
-            if (xsiType.IndexOf("ProfileBody_Device_CANopen", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (xsiType.Contains("ProfileBody_Device_CANopen", StringComparison.OrdinalIgnoreCase))
                 deviceProfileBody = profileBody;
-            else if (xsiType.IndexOf("ProfileBody_CommunicationNetwork_CANopen", StringComparison.OrdinalIgnoreCase) >= 0)
+            else if (xsiType.Contains("ProfileBody_CommunicationNetwork_CANopen", StringComparison.OrdinalIgnoreCase))
                 commNetProfileBody = profileBody;
         }
 
@@ -138,7 +134,7 @@ public class XddReader
         {
             // If it looks like "1.0", take the part before the dot
             var dotIdx = fileVersionStr.IndexOf('.');
-            var majorPart = dotIdx >= 0 ? fileVersionStr.Substring(0, dotIdx) : fileVersionStr;
+            var majorPart = dotIdx >= 0 ? fileVersionStr[..dotIdx] : fileVersionStr;
             if (byte.TryParse(majorPart, NumberStyles.None, CultureInfo.InvariantCulture, out var ver))
                 fileInfo.FileVersion = ver;
         }
@@ -1090,14 +1086,14 @@ public class XddReader
             if (eqIdx < 0)
                 continue;
 
-            var keyPart = entry.Substring(0, eqIdx).Trim();
-            var valPart = entry.Substring(eqIdx + 1).Trim();
+            var keyPart = entry[..eqIdx].Trim();
+            var valPart = entry[(eqIdx + 1)..].Trim();
 
             // keyPart must start with "Dummy" followed by 4 hex digits
             if (!keyPart.StartsWith("Dummy", StringComparison.OrdinalIgnoreCase) || keyPart.Length < 9)
                 continue;
 
-            var hexPart = keyPart.Substring(5);
+            var hexPart = keyPart[5..];
             if (!ushort.TryParse(hexPart, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var dummyIndex))
                 continue;
 
@@ -1216,7 +1212,7 @@ public class XddReader
             byte nodeIdValue;
             bool parsed;
             if (nodeIdStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-                parsed = byte.TryParse(nodeIdStr.Substring(2), NumberStyles.HexNumber,
+                parsed = byte.TryParse(nodeIdStr[2..], NumberStyles.HexNumber,
                     CultureInfo.InvariantCulture, out nodeIdValue);
             else
                 parsed = byte.TryParse(nodeIdStr, NumberStyles.None,
@@ -1290,7 +1286,7 @@ public class XddReader
     {
         var trimmed = value.Trim();
         var hex = trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
-            ? trimmed.Substring(2) : trimmed;
+            ? trimmed[2..] : trimmed;
 
         if (ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             return result;
@@ -1305,7 +1301,7 @@ public class XddReader
     {
         var trimmed = value.Trim();
         var hex = trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
-            ? trimmed.Substring(2) : trimmed;
+            ? trimmed[2..] : trimmed;
 
         if (byte.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             return result;
@@ -1321,7 +1317,7 @@ public class XddReader
         value = value.Trim();
 
         if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-            value = value.Substring(2);
+            value = value[2..];
 
         if (ushort.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             return result;
@@ -1334,7 +1330,7 @@ public class XddReader
         value = value.Trim();
 
         if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-            value = value.Substring(2);
+            value = value[2..];
 
         if (uint.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             return result;
@@ -1402,16 +1398,12 @@ public class XddReader
         if (xsdDate.Length >= 10 &&
             xsdDate[4] == '-' && xsdDate[7] == '-')
         {
-            var year = xsdDate.Substring(0, 4);
-            var month = xsdDate.Substring(5, 2);
-            var day = xsdDate.Substring(8, 2);
+            var year = xsdDate[..4];
+            var month = xsdDate[5..7];
+            var day = xsdDate[8..10];
             return string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}", month, day, year);
         }
 
         return xsdDate;
     }
 }
-
-#pragma warning restore CA1845, CA1865, CA1866
-#pragma warning restore CA2249
-#pragma warning restore CA1846

--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 
-#pragma warning disable CA1845, CA1865, CA1866 // span-based and char overloads not available in netstandard2.0
-#pragma warning disable CA2249 // string.Contains(char) not available in netstandard2.0; IndexOf(char) >= 0 is the correct alternative
-
 /// <summary>
 /// Utility class for converting string values from EDS/DCF files to typed values.
 /// </summary>
@@ -44,7 +41,7 @@ public static class ValueConverter
             if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
                 value.StartsWith("0X", StringComparison.OrdinalIgnoreCase))
             {
-                return Convert.ToUInt32(value.Substring(2), 16);
+                return Convert.ToUInt32(value[2..], 16);
             }
 
             // Octal (leading 0, but not 0x)
@@ -92,7 +89,7 @@ public static class ValueConverter
             // Hexadecimal
             if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
             {
-                return Convert.ToByte(value.Substring(2), 16);
+                return Convert.ToByte(value[2..], 16);
             }
 
             // Octal
@@ -125,7 +122,7 @@ public static class ValueConverter
             // Hexadecimal
             if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
             {
-                return Convert.ToUInt16(value.Substring(2), 16);
+                return Convert.ToUInt16(value[2..], 16);
             }
 
             // Octal
@@ -207,12 +204,12 @@ public static class ValueConverter
             return nodeId;
 
         const string token = "$NODEID";
-        var suffix = formula.Substring(token.Length).Trim();
+        var suffix = formula[token.Length..].Trim();
 
         if (suffix[0] == '+' || suffix[0] == '-')
         {
-            var rightSide = suffix.Substring(1).Trim();
-            if (string.IsNullOrEmpty(rightSide) || rightSide.IndexOf('+') >= 0 || rightSide.IndexOf('-') >= 0)
+            var rightSide = suffix[1..].Trim();
+            if (string.IsNullOrEmpty(rightSide) || rightSide.Contains('+') || rightSide.Contains('-'))
             {
                 throw new EdsParseException(
                     $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
@@ -246,5 +243,3 @@ public static class ValueConverter
             $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
     }
 }
-
-#pragma warning restore CA1845, CA1865, CA1866, CA2249 // span-based and char overloads not available in netstandard2.0


### PR DESCRIPTION
## Summary

- Add **Polyfill** v9.12.0 as a build-time-only dependency (`PrivateAssets="all"`) — no runtime dependency for consumers of the library
- Remove all `#pragma warning disable/restore` blocks for CA1845, CA1846, CA1865, CA1866, CA2249 from `ValueConverter`, `IniParser`, `CanOpenReaderBase`, `XdcReader`, and `XddReader`
- Replace netstandard2.0 workarounds with idiomatic modern APIs:
  - `IndexOf(char) >= 0` → `Contains(char)`
  - `IndexOf(str, StringComparison) >= 0/< 0` → `Contains(str, SC)` / `!Contains(...)`
  - `StartsWith`/`EndsWith` single-char string overloads → char overloads
  - `Substring(n)` / `Substring(0, n)` → range indexers `[n..]` / `[..n]`
- Update `copilot-instructions.md` to document the newly available APIs

## Test plan

- [x] `dotnet build` succeeds with 0 warnings and 0 errors for both `netstandard2.0` and `net10.0`
- [x] All 744 tests pass
