### PR TITLE
fix: restrict Polyfill IncludeAssets to compile/build/analyzers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,9 @@ EdsDcfNet is a C# library for reading and writing CiA DS 306 EDS (Electronic Dat
 
 ### .NET Standard 2.0 Compatibility
 
-This library must compile against netstandard2.0. The **Polyfill** package is included as a source generator: its polyfills are compiled directly into the library's own assembly (no separate Polyfill runtime DLL is shipped). `PrivateAssets="all"` ensures the package reference does not flow transitively to consumers of this library.
+This library must compile against netstandard2.0. The **Polyfill** package is included as a source generator with no runtime dependency for consumers:
+- `PrivateAssets="all"` — the package reference does not flow transitively to consumers.
+- `IncludeAssets="compile; build; analyzers; contentfiles"` — `native` and `buildtransitive` are excluded. `contentfiles` is required because Polyfill ships some polyfills (e.g. `System.Index`/`System.Range`) as source content files rather than purely through the Roslyn generator.
 
 Thanks to Polyfill, modern APIs can be used directly:
 

--- a/src/EdsDcfNet/EdsDcfNet.csproj
+++ b/src/EdsDcfNet/EdsDcfNet.csproj
@@ -35,7 +35,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.*" PrivateAssets="All" />
 		<PackageReference Include="Polyfill" Version="9.12.0" PrivateAssets="all">
-		  <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <IncludeAssets>compile; build; analyzers; contentfiles</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #84 (Copilot comment on `EdsDcfNet.csproj` and `copilot-instructions.md`).

- Add explicit `IncludeAssets` to the Polyfill package reference, consistent with the `NetAnalyzers` pattern. This makes the intent unambiguous: no runtime assets from Polyfill are included.
- Clarify `copilot-instructions.md`: Polyfill is a **source generator** — its polyfills are compiled directly into the library's own DLL (no separate runtime assembly is shipped). `PrivateAssets="all"` prevents the package reference from flowing to consumers.

## Test plan

- [x] `dotnet build` passes with 0 warnings and 0 errors for both `netstandard2.0` and `net10.0`
