### PR TITLE
chore: extra hardening for semantic-release checkout credentials

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: true
-          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- harden the checkout step in `semantic-release.yml` by setting `persist-credentials: false`
- remove explicit use of `RELEASE_TOKEN` during checkout so repository write credentials are not persisted before dependency installation
- keep `RELEASE_TOKEN` usage scoped to the semantic-release step (`GITHUB_TOKEN` env) only

## Scope
This is an **extra workflow hardening** change and intentionally separate from SBP-001..SBP-003 parser-related fixes.
