### PR TITLE
fix: address copilot findings from release PR #95

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -90,6 +90,13 @@ jobs:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
 
+      - name: Configure git auth for release push
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        shell: bash
+        run: |
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/src/EdsDcfNet/Parsers/XdcReader.cs
+++ b/src/EdsDcfNet/Parsers/XdcReader.cs
@@ -26,7 +26,7 @@ public class XdcReader
             throw new FileNotFoundException($"XDC file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDC");
-        var content = File.ReadAllText(filePath, Encoding.UTF8);
+        var content = File.ReadAllText(filePath);
         return ReadString(content);
     }
 

--- a/src/EdsDcfNet/Parsers/XddReader.cs
+++ b/src/EdsDcfNet/Parsers/XddReader.cs
@@ -39,7 +39,7 @@ public class XddReader
             throw new FileNotFoundException($"XDD file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDD");
-        var content = File.ReadAllText(filePath, Encoding.UTF8);
+        var content = File.ReadAllText(filePath);
         return ReadString(content);
     }
 


### PR DESCRIPTION
## Summary
- make release push auth explicit while keeping checkout credentials disabled
- align sync XDD/XDC file reads with BOM-detecting behavior using File.ReadAllText(path)

## Why
- addresses Copilot review findings on PR #95
- keeps sync/async XML read behavior aligned for BOM-marked inputs

## Validation
- dotnet test (774 passed)