### PR TITLE
build: pin .NET SDK selection with global.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: |
-          8.0.x
-          10.0.x
+        global-json-file: global.json
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -35,9 +35,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          global-json-file: global.json
 
       - name: Install dependencies
         run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,13 @@ Repository-wide formatting and baseline analyzer severities are defined in
 [`.editorconfig`](.editorconfig). Please keep local IDE formatting aligned with
 that file.
 
+## .NET SDK policy
+
+- SDK resolution is pinned in [`global.json`](global.json).
+- CI resolves the .NET SDK from that file in both workflows.
+- To update the SDK baseline, submit one PR that updates `global.json` and
+  briefly notes the change in the PR description.
+
 ## Commit convention
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/).

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary
- add a repository-level global.json to pin SDK resolution
- configure both GitHub workflows to resolve .NET via global.json
- document the SDK baseline/update policy in CONTRIBUTING.md

Closes #125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/build configuration and documentation changes only; main risk is workflow failures if the pinned SDK version is unavailable or incompatible with the codebase.
> 
> **Overview**
> Pins repository .NET SDK resolution by adding `global.json` (set to `10.0.100` with patch roll-forward).
> 
> Updates both GitHub Actions workflows (`build.yml`, `semantic-release.yml`) to use `actions/setup-dotnet`’s `global-json-file` instead of specifying multiple `dotnet-version` values, and documents the SDK baseline/update policy in `CONTRIBUTING.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7f0f2379560ca53f939038e04a941b3d6057238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->