### PR TITLE
ci: fail workflows when Codecov upload fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
         override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
     - name: Post codecov/patch status
       if: always()

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/coverage.cobertura.xml'
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
       - name: Configure git auth for release push
         env:


### PR DESCRIPTION
## Summary
- set Codecov action fail_ci_if_error to true in build workflow
- set Codecov action fail_ci_if_error to true in semantic-release workflow

Closes #128