### PR TITLE
fix: harden $NODEID formula suffix handling

### DIFF
--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -200,11 +200,11 @@ public static class ValueConverter
     {
         formula = formula.Trim();
 
-        if (formula.Equals("$NODEID", StringComparison.OrdinalIgnoreCase))
-            return nodeId;
-
         const string token = "$NODEID";
         var suffix = formula[token.Length..].Trim();
+
+        if (suffix.Length == 0)
+            return nodeId;
 
         if (suffix[0] == '+' || suffix[0] == '-')
         {

--- a/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
@@ -85,6 +85,7 @@ public class ValueConverterTests
 
     [Theory]
     [InlineData("$NODEID", 5, 5u)]
+    [InlineData("$NODEID   ", 7, 7u)] // Trailing whitespace should still behave like plain $NODEID
     [InlineData("$nodeid", 10, 10u)] // Case insensitive
     [InlineData("$NODEID+0x200", 5, 517u)] // 5 + 512
     [InlineData("$NODEID+0x180", 5, 389u)] // 5 + 384
@@ -117,15 +118,20 @@ public class ValueConverterTests
     [Theory]
     [InlineData("$NODEID*2")]
     [InlineData("$NODEID+0x200+1")]
+    [InlineData("$NODEID+")]
+    [InlineData("$NODEID+   ")]
     [InlineData("$NODEID-")]
+    [InlineData("$NODEID-   ")]
     public void ParseInteger_UnsupportedNodeIdFormula_ThrowsEdsParseException(string formula)
     {
+        var normalizedFormula = formula.Trim();
+
         // Act
         var act = () => ValueConverter.ParseInteger(formula, 5);
 
         // Assert
         act.Should().Throw<EdsParseException>()
-            .WithMessage($"*Unsupported $NODEID formula*'{formula}'*");
+            .WithMessage($"*Unsupported $NODEID formula*'{normalizedFormula}'*");
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- make NODEID suffix handling explicitly guard empty/whitespace suffixes before operator indexing
- keep malformed suffix forms mapped to EdsParseException instead of index errors
- extend ValueConverter tests for whitespace and malformed suffix inputs

## Verification
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --configuration Release --filter "FullyQualifiedName~ValueConverterTests"

Closes #137