### PR TITLE
refactor: deduplicate object list parsing in CanOpenReaderBase

### DIFF
--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -134,47 +134,9 @@ public abstract class CanOpenReaderBase
     {
         var objDict = new ObjectDictionary();
 
-        // Parse mandatory objects
-        if (IniParser.HasSection(sections, "MandatoryObjects"))
-        {
-            var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, "MandatoryObjects", "SupportedObjects", "0"));
-            for (int i = 1; i <= count; i++)
-            {
-                var indexStr = IniParser.GetValue(sections, "MandatoryObjects", i.ToString(CultureInfo.InvariantCulture));
-                if (!string.IsNullOrEmpty(indexStr))
-                {
-                    objDict.MandatoryObjects.Add(ValueConverter.ParseUInt16(indexStr));
-                }
-            }
-        }
-
-        // Parse optional objects
-        if (IniParser.HasSection(sections, "OptionalObjects"))
-        {
-            var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, "OptionalObjects", "SupportedObjects", "0"));
-            for (int i = 1; i <= count; i++)
-            {
-                var indexStr = IniParser.GetValue(sections, "OptionalObjects", i.ToString(CultureInfo.InvariantCulture));
-                if (!string.IsNullOrEmpty(indexStr))
-                {
-                    objDict.OptionalObjects.Add(ValueConverter.ParseUInt16(indexStr));
-                }
-            }
-        }
-
-        // Parse manufacturer objects
-        if (IniParser.HasSection(sections, "ManufacturerObjects"))
-        {
-            var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, "ManufacturerObjects", "SupportedObjects", "0"));
-            for (int i = 1; i <= count; i++)
-            {
-                var indexStr = IniParser.GetValue(sections, "ManufacturerObjects", i.ToString(CultureInfo.InvariantCulture));
-                if (!string.IsNullOrEmpty(indexStr))
-                {
-                    objDict.ManufacturerObjects.Add(ValueConverter.ParseUInt16(indexStr));
-                }
-            }
-        }
+        ParseObjectListSection(sections, "MandatoryObjects", objDict.MandatoryObjects);
+        ParseObjectListSection(sections, "OptionalObjects", objDict.OptionalObjects);
+        ParseObjectListSection(sections, "ManufacturerObjects", objDict.ManufacturerObjects);
 
         // Parse all object definitions
         var allObjects = objDict.MandatoryObjects
@@ -209,6 +171,25 @@ public abstract class CanOpenReaderBase
         }
 
         return objDict;
+    }
+
+    private static void ParseObjectListSection(
+        Dictionary<string, Dictionary<string, string>> sections,
+        string sectionName,
+        List<ushort> targetList)
+    {
+        if (!IniParser.HasSection(sections, sectionName))
+            return;
+
+        var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, sectionName, "SupportedObjects", "0"));
+        for (int i = 1; i <= count; i++)
+        {
+            var indexStr = IniParser.GetValue(sections, sectionName, i.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrEmpty(indexStr))
+            {
+                targetList.Add(ValueConverter.ParseUInt16(indexStr));
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- extract one shared helper in CanOpenReaderBase for SupportedObjects section parsing
- route MandatoryObjects, OptionalObjects, and ManufacturerObjects through the shared helper
- keep parsing behavior unchanged while reducing duplication risk

## Verification
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --configuration Release --filter "FullyQualifiedName~EdsReaderTests|FullyQualifiedName~DcfReaderTests"

Closes #109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal refactor confined to object-list parsing; behavior should be unchanged aside from potential edge-case regressions in section handling.
> 
> **Overview**
> Refactors `CanOpenReaderBase.ParseObjectDictionary` to **deduplicate parsing of `SupportedObjects` lists** by routing `MandatoryObjects`, `OptionalObjects`, and `ManufacturerObjects` through a new shared helper `ParseObjectListSection`.
> 
> Intended parsing behavior remains the same, but the repeated section-walking logic is centralized to reduce drift and maintenance risk.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c46f08af9ff8e1951aba927ad2f1c5098c624d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->