### PR TITLE
refactor: deduplicate object list writing across DcfWriter and EdsWriter

### DIFF
--- a/src/EdsDcfNet/Utilities/ObjectListSectionWriter.cs
+++ b/src/EdsDcfNet/Utilities/ObjectListSectionWriter.cs
@@ -1,0 +1,41 @@
+namespace EdsDcfNet.Utilities;
+
+using System.Globalization;
+using System.Text;
+using EdsDcfNet.Models;
+
+internal static class ObjectListSectionWriter
+{
+    public static void WriteObjectLists(
+        StringBuilder sb,
+        ObjectDictionary objDict,
+        Action<StringBuilder, string, string?> writeKeyValue)
+    {
+        WriteObjectListSection(sb, "MandatoryObjects", objDict.MandatoryObjects, writeKeyValue);
+        WriteObjectListSection(sb, "OptionalObjects", objDict.OptionalObjects, writeKeyValue);
+        WriteObjectListSection(sb, "ManufacturerObjects", objDict.ManufacturerObjects, writeKeyValue);
+    }
+
+    private static void WriteObjectListSection(
+        StringBuilder sb,
+        string sectionName,
+        List<ushort> objectIndexes,
+        Action<StringBuilder, string, string?> writeKeyValue)
+    {
+        if (objectIndexes.Count == 0)
+            return;
+
+        sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0}]", sectionName));
+        writeKeyValue(sb, "SupportedObjects", objectIndexes.Count.ToString(CultureInfo.InvariantCulture));
+
+        for (int i = 0; i < objectIndexes.Count; i++)
+        {
+            writeKeyValue(
+                sb,
+                (i + 1).ToString(CultureInfo.InvariantCulture),
+                ValueConverter.FormatInteger(objectIndexes[i]));
+        }
+
+        sb.AppendLine();
+    }
+}

--- a/src/EdsDcfNet/Writers/DcfWriter.cs
+++ b/src/EdsDcfNet/Writers/DcfWriter.cs
@@ -247,47 +247,7 @@ public class DcfWriter
 
     private static void WriteObjectLists(StringBuilder sb, ObjectDictionary objDict)
     {
-        // Write MandatoryObjects
-        if (objDict.MandatoryObjects.Count > 0)
-        {
-            sb.AppendLine("[MandatoryObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.MandatoryObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.MandatoryObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.MandatoryObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
-
-        // Write OptionalObjects
-        if (objDict.OptionalObjects.Count > 0)
-        {
-            sb.AppendLine("[OptionalObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.OptionalObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.OptionalObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.OptionalObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
-
-        // Write ManufacturerObjects
-        if (objDict.ManufacturerObjects.Count > 0)
-        {
-            sb.AppendLine("[ManufacturerObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.ManufacturerObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.ManufacturerObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.ManufacturerObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
+        ObjectListSectionWriter.WriteObjectLists(sb, objDict, WriteKeyValue);
     }
 
     private static void WriteObjects(StringBuilder sb, ObjectDictionary objDict)

--- a/src/EdsDcfNet/Writers/EdsWriter.cs
+++ b/src/EdsDcfNet/Writers/EdsWriter.cs
@@ -211,47 +211,7 @@ public class EdsWriter
 
     private static void WriteObjectLists(StringBuilder sb, ObjectDictionary objDict)
     {
-        // Write MandatoryObjects
-        if (objDict.MandatoryObjects.Count > 0)
-        {
-            sb.AppendLine("[MandatoryObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.MandatoryObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.MandatoryObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.MandatoryObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
-
-        // Write OptionalObjects
-        if (objDict.OptionalObjects.Count > 0)
-        {
-            sb.AppendLine("[OptionalObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.OptionalObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.OptionalObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.OptionalObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
-
-        // Write ManufacturerObjects
-        if (objDict.ManufacturerObjects.Count > 0)
-        {
-            sb.AppendLine("[ManufacturerObjects]");
-            WriteKeyValue(sb, "SupportedObjects", objDict.ManufacturerObjects.Count.ToString(CultureInfo.InvariantCulture));
-
-            for (int i = 0; i < objDict.ManufacturerObjects.Count; i++)
-            {
-                WriteKeyValue(sb, (i + 1).ToString(CultureInfo.InvariantCulture), ValueConverter.FormatInteger(objDict.ManufacturerObjects[i]));
-            }
-
-            sb.AppendLine();
-        }
+        ObjectListSectionWriter.WriteObjectLists(sb, objDict, WriteKeyValue);
     }
 
     private static void WriteObjects(StringBuilder sb, ObjectDictionary objDict)


### PR DESCRIPTION
## Summary
- add one shared writer helper for MandatoryObjects/OptionalObjects/ManufacturerObjects section emission
- switch DcfWriter and EdsWriter to the shared helper
- keep serialized output behavior equivalent while removing duplicated blocks

## Verification
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --configuration Release --filter "FullyQualifiedName~DcfWriterTests|FullyQualifiedName~EdsWriterTests"

Closes #110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b15c46f0b438454cc3e03e1f6ddb58c18fd36bbc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->