### PR TITLE
refactor: share ObjectLinks section detection across DcfReader and writers

### DIFF
--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -97,7 +97,9 @@ public class DcfReader : CanOpenReaderBase
         // Parse any additional unknown sections
         foreach (var sectionName in sections.Keys)
         {
-            if (!IsKnownSection(sectionName) && !IsToolSectionForParsedTools(sectionName, dcf.Tools.Count) && !IsObjectLinksSectionForExistingObject(sectionName, dcf.ObjectDictionary))
+            if (!IsKnownSection(sectionName) &&
+                !IsToolSectionForParsedTools(sectionName, dcf.Tools.Count) &&
+                !ObjectLinksSectionHelper.IsObjectLinksSectionForExistingObject(sectionName, dcf.ObjectDictionary))
             {
                 dcf.AdditionalSections[sectionName] = new Dictionary<string, string>(sections[sectionName]);
             }
@@ -275,29 +277,6 @@ public class DcfReader : CanOpenReaderBase
         }
 
         return modules;
-    }
-
-    private static bool IsObjectLinksSectionForExistingObject(string sectionName, ObjectDictionary objectDictionary)
-    {
-        const string suffix = "ObjectLinks";
-
-        if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var indexPart = sectionName.Substring(0, sectionName.Length - suffix.Length);
-        if (string.IsNullOrWhiteSpace(indexPart))
-        {
-            return false;
-        }
-
-        if (!ushort.TryParse(indexPart, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
-        {
-            return false;
-        }
-
-        return objectDictionary.Objects.ContainsKey(index);
     }
 
     #endregion

--- a/src/EdsDcfNet/Utilities/ObjectLinksSectionHelper.cs
+++ b/src/EdsDcfNet/Utilities/ObjectLinksSectionHelper.cs
@@ -1,0 +1,30 @@
+namespace EdsDcfNet.Utilities;
+
+using System.Globalization;
+using EdsDcfNet.Models;
+
+internal static class ObjectLinksSectionHelper
+{
+    public static bool IsObjectLinksSectionForExistingObject(string sectionName, ObjectDictionary objectDictionary)
+    {
+        if (!TryParseObjectLinksSectionIndex(sectionName, out var index))
+            return false;
+
+        return objectDictionary.Objects.ContainsKey(index);
+    }
+
+    private static bool TryParseObjectLinksSectionIndex(string sectionName, out ushort index)
+    {
+        const string suffix = "ObjectLinks";
+        index = 0;
+
+        if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var indexPart = sectionName[..^suffix.Length];
+        if (string.IsNullOrWhiteSpace(indexPart))
+            return false;
+
+        return ushort.TryParse(indexPart, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out index);
+    }
+}

--- a/src/EdsDcfNet/Writers/DcfWriter.cs
+++ b/src/EdsDcfNet/Writers/DcfWriter.cs
@@ -128,7 +128,7 @@ public class DcfWriter
         // Write additional sections
         foreach (var section in dcf.AdditionalSections)
         {
-            if (IsObjectLinksSectionForExistingObject(section.Key, dcf.ObjectDictionary))
+            if (ObjectLinksSectionHelper.IsObjectLinksSectionForExistingObject(section.Key, dcf.ObjectDictionary))
             {
                 continue;
             }
@@ -575,26 +575,4 @@ public class DcfWriter
         sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}={1}", key, value));
     }
 
-    private static bool IsObjectLinksSectionForExistingObject(string sectionName, ObjectDictionary objDict)
-    {
-        const string suffix = "ObjectLinks";
-
-        if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var indexPart = sectionName.Substring(0, sectionName.Length - suffix.Length);
-        if (string.IsNullOrWhiteSpace(indexPart))
-        {
-            return false;
-        }
-
-        if (!ushort.TryParse(indexPart, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
-        {
-            return false;
-        }
-
-        return objDict.Objects.ContainsKey(index);
-    }
 }

--- a/src/EdsDcfNet/Writers/EdsWriter.cs
+++ b/src/EdsDcfNet/Writers/EdsWriter.cs
@@ -127,7 +127,7 @@ public class EdsWriter
         // Write additional sections
         foreach (var section in eds.AdditionalSections)
         {
-            if (IsObjectLinksSectionForExistingObject(section.Key, eds.ObjectDictionary))
+            if (ObjectLinksSectionHelper.IsObjectLinksSectionForExistingObject(section.Key, eds.ObjectDictionary))
             {
                 continue;
             }
@@ -489,29 +489,6 @@ public class EdsWriter
     private static void WriteKeyValue(StringBuilder sb, string key, string? value)
     {
         sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}={1}", key, value));
-    }
-
-    private static bool IsObjectLinksSectionForExistingObject(string sectionName, ObjectDictionary objDict)
-    {
-        const string suffix = "ObjectLinks";
-
-        if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var indexPart = sectionName.Substring(0, sectionName.Length - suffix.Length);
-        if (string.IsNullOrWhiteSpace(indexPart))
-        {
-            return false;
-        }
-
-        if (!ushort.TryParse(indexPart, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
-        {
-            return false;
-        }
-
-        return objDict.Objects.ContainsKey(index);
     }
 
     private static void WriteSection(string sectionName, Action writeAction)


### PR DESCRIPTION
## Summary
- add one shared utility for ObjectLinks-section detection with existing-object validation
- switch DcfReader, DcfWriter, and EdsWriter to the shared implementation
- keep orphan/invalid ObjectLinks section behavior unchanged while removing duplication

## Verification
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --configuration Release --filter "FullyQualifiedName~DcfReaderTests|FullyQualifiedName~DcfWriterTests|FullyQualifiedName~EdsWriterTests"

Closes #107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c53f1f678e82132e4d1c99efe51848337d20d5e9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->