### PR TITLE
refactor: reduce numeric parsing duplication in ValueConverter

### DIFF
--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -169,8 +169,8 @@ public static class ValueConverter
     }
 
     /// <summary>
-    /// Evaluates a $NODEID formula with the given node ID.
-    /// Supports formulas like "$NODEID", "$NODEID+0x200", "$NODEID+512", etc.
+    /// Shared helper that detects the numeric base of <paramref name="value"/> and
+    /// delegates to the appropriate parser (decimal or non-decimal).
     /// </summary>
     private static T ParseUnsignedNumber<T>(
         string value,
@@ -195,6 +195,10 @@ public static class ValueConverter
         return (value, NumericBase.Decimal);
     }
 
+    /// <summary>
+    /// Evaluates a $NODEID formula with the given node ID.
+    /// Supports formulas like "$NODEID", "$NODEID+0x200", "$NODEID+512", etc.
+    /// </summary>
     private static uint EvaluateNodeIdFormula(string formula, byte nodeId)
     {
         formula = formula.Trim();


### PR DESCRIPTION
Implements #108.

Summary:
- Introduces shared internal numeric-format detection for decimal/octal/hex
- Reuses common parsing flow across ParseInteger, ParseByte and ParseUInt16
- Preserves existing public API and exception behavior

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~ValueConverterTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal refactor in a utility parser with no API surface changes; risk is limited to subtle behavioral regressions in numeric base detection/overflow handling.
> 
> **Overview**
> Refactors `ValueConverter` to remove duplicated decimal/octal/hex parsing logic in `ParseInteger`, `ParseByte`, and `ParseUInt16` by introducing a shared `ParseUnsignedNumber<T>` flow with centralized base detection (`GetNumericFormat`) and an internal `NumericBase` enum.
> 
> Behavior and exceptions are intended to remain the same, but the parsing path is now unified (including normalization of `0x`-prefixed values) which slightly changes the internal control flow for all unsigned numeric conversions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e378343e00014605f94166668a86d857d5885003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->