### PR TITLE
test: expand DcfWriter coverage for less-tested sections

### DIFF
--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -520,85 +520,6 @@ public class DcfWriterTests
     }
 
     [Fact]
-    public void GenerateString_DynamicChannels_WritesSectionAndSegments()
-    {
-        // Arrange
-        var dcf = CreateMinimalDcf();
-        dcf.DynamicChannels = new DynamicChannels();
-        dcf.DynamicChannels.Segments.Add(new DynamicChannelSegment
-        {
-            Type = 0x0007,
-            Dir = AccessType.ReadOnly,
-            Range = "0xA080-0xA0BF",
-            PPOffset = 0
-        });
-        dcf.DynamicChannels.Segments.Add(new DynamicChannelSegment
-        {
-            Type = 0x0005,
-            Dir = AccessType.ReadWriteOutput,
-            Range = "0xA0C0-0xA0FF",
-            PPOffset = 64
-        });
-
-        // Act
-        var result = _writer.GenerateString(dcf);
-
-        // Assert
-        result.Should().Contain("[DynamicChannels]");
-        result.Should().Contain("NrOfSeg=2");
-        result.Should().Contain("Type1=0x7");
-        result.Should().Contain("Dir1=ro");
-        result.Should().Contain("Range1=0xA080-0xA0BF");
-        result.Should().Contain("PPOffset1=0");
-        result.Should().Contain("Type2=0x5");
-        result.Should().Contain("Dir2=rww");
-        result.Should().Contain("Range2=0xA0C0-0xA0FF");
-        result.Should().Contain("PPOffset2=64");
-    }
-
-    [Fact]
-    public void GenerateString_Tools_WritesSectionAndToolEntries()
-    {
-        // Arrange
-        var dcf = CreateMinimalDcf();
-        dcf.Tools.Add(new ToolInfo { Name = "EDS Checker", Command = "checker.exe $EDS" });
-        dcf.Tools.Add(new ToolInfo { Name = "Configurator", Command = "config.exe $DCF $NODEID" });
-
-        // Act
-        var result = _writer.GenerateString(dcf);
-
-        // Assert
-        result.Should().Contain("[Tools]");
-        result.Should().Contain("Items=2");
-        result.Should().Contain("[Tool1]");
-        result.Should().Contain("Name=EDS Checker");
-        result.Should().Contain("Command=checker.exe $EDS");
-        result.Should().Contain("[Tool2]");
-        result.Should().Contain("Name=Configurator");
-        result.Should().Contain("Command=config.exe $DCF $NODEID");
-    }
-
-    [Fact]
-    public void GenerateString_AdditionalSections_WritesRepresentativeContent()
-    {
-        // Arrange
-        var dcf = CreateMinimalDcf();
-        dcf.AdditionalSections["VendorSpecific"] = new Dictionary<string, string>
-        {
-            { "Key1", "Value1" },
-            { "Key2", "Value2" }
-        };
-
-        // Act
-        var result = _writer.GenerateString(dcf);
-
-        // Assert
-        result.Should().Contain("[VendorSpecific]");
-        result.Should().Contain("Key1=Value1");
-        result.Should().Contain("Key2=Value2");
-    }
-
-    [Fact]
     public void GenerateString_CANopenSafetySupported_WrittenWhenTrue()
     {
         // Arrange
@@ -874,7 +795,8 @@ public class DcfWriterTests
         var dcf = CreateMinimalDcf();
         dcf.AdditionalSections["VendorSpecific"] = new Dictionary<string, string>
         {
-            { "Key", "Value" }
+            { "Key1", "Value1" },
+            { "Key2", "Value2" }
         };
 
         // Act
@@ -882,7 +804,8 @@ public class DcfWriterTests
 
         // Assert
         result.Should().Contain("[VendorSpecific]");
-        result.Should().Contain("Key=Value");
+        result.Should().Contain("Key1=Value1");
+        result.Should().Contain("Key2=Value2");
     }
 
     [Fact]


### PR DESCRIPTION
Implements #121.

Summary:
- Adds focused DcfWriter tests for ConnectedModules, DynamicChannels, Tools, ObjectLinks and AdditionalSections
- Extends representative serialization assertions for these sections
- Keeps existing behavior unchanged while reducing regression risk

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~DcfWriterTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that broaden assertions for writer output; no production logic is modified.
> 
> **Overview**
> Adds new `DcfWriterTests` validating `GenerateString` output for per-object `ObjectLinks` sections and the top-level `[ConnectedModules]` section (including entry counts and ordering).
> 
> Updates the `AdditionalSections` coverage to assert multiple key/value pairs are written for non-`ObjectLinks` sections, improving regression protection around section filtering/duplication behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9868d5baf2cacc693ceec894d3b81f5d23c2bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->