### PR TITLE
test: add parser/writer edge-case coverage

### DIFF
--- a/tests/EdsDcfNet.Tests/Integration/ParserWriterEdgeCaseTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/ParserWriterEdgeCaseTests.cs
@@ -6,6 +6,14 @@ using EdsDcfNet;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 
+/// <summary>
+/// Edge-case matrix for issue #122:
+/// - malformed numeric literals -> ReadDcfFromString_MalformedHexLiteral_ThrowsActionableParseException
+/// - UTF-8 BOM and mixed line endings -> ReadDcf_FileWithUtf8Bom_ParsesSuccessfully, ReadDcfFromString_MixedLineEndings_ParsesSuccessfully
+/// - large object dictionary round-trip -> RoundTrip_LargeObjectDictionary_PreservesObjectAndListCounts
+/// - Unicode/non-ASCII round-trip -> RoundTrip_UnicodeAndNonAsciiValues_PreservesContent
+/// - unsigned boundary handling -> ReadDcfFromString_UnsignedBoundaries_ParsesCorrectly, ReadDcfFromString_NegativeUnsignedValue_ThrowsParseException
+/// </summary>
 public class ParserWriterEdgeCaseTests
 {
     [Fact]
@@ -101,7 +109,7 @@ public class ParserWriterEdgeCaseTests
         for (ushort i = 0; i < 500; i++)
         {
             var index = (ushort)(0x2000 + i);
-            original.ObjectDictionary.OptionalObjects.Add(index);
+            original.ObjectDictionary.ManufacturerObjects.Add(index);
             original.ObjectDictionary.Objects[index] = new CanOpenObject
             {
                 Index = index,
@@ -120,7 +128,7 @@ public class ParserWriterEdgeCaseTests
 
         // Assert
         roundTripped.ObjectDictionary.Objects.Count.Should().Be(original.ObjectDictionary.Objects.Count);
-        roundTripped.ObjectDictionary.OptionalObjects.Count.Should().Be(original.ObjectDictionary.OptionalObjects.Count);
+        roundTripped.ObjectDictionary.ManufacturerObjects.Count.Should().Be(original.ObjectDictionary.ManufacturerObjects.Count);
     }
 
     [Fact]
@@ -145,7 +153,7 @@ public class ParserWriterEdgeCaseTests
     }
 
     [Fact]
-    public void ReadDcfFromString_UnsignedBoundaries_ParseCorrectly()
+    public void ReadDcfFromString_UnsignedBoundaries_ParsesCorrectly()
     {
         // Arrange
         var content = BuildMinimalDcf(


### PR DESCRIPTION
Implements #122.

Summary:
- Adds edge-case tests for malformed hex literals, UTF-8 BOM, mixed line endings, large object dictionaries, Unicode values, and unsigned-boundary parsing
- Verifies representative parser and writer behavior for malformed and extreme inputs
- Adds clear regression coverage for robustness hotspots

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~ParserWriterEdgeCaseTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t alter production code paths; risk is limited to potential CI/test runtime impact from the large round-trip case.
> 
> **Overview**
> Adds a new integration test suite `ParserWriterEdgeCaseTests` to lock in expected DCF parsing/writing behavior for common robustness edge cases.
> 
> The tests cover actionable failures for malformed hex literals and negative values for unsigned fields, successful parsing with UTF-8 BOM and mixed line endings, and round-trip preservation for large object dictionaries and Unicode/non-ASCII text fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a273447fcca7525febc2fa441ce66033943f09f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->