### PR TITLE
Refactor numeric parsing to eliminate code duplication

### DIFF
--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -169,8 +169,8 @@ public static class ValueConverter
     }
 
     /// <summary>
-    /// Evaluates a $NODEID formula with the given node ID.
-    /// Supports formulas like "$NODEID", "$NODEID+0x200", "$NODEID+512", etc.
+    /// Shared helper that detects the numeric base of <paramref name="value"/> and
+    /// delegates to the appropriate parser (decimal or non-decimal).
     /// </summary>
     private static T ParseUnsignedNumber<T>(
         string value,
@@ -195,6 +195,10 @@ public static class ValueConverter
         return (value, NumericBase.Decimal);
     }
 
+    /// <summary>
+    /// Evaluates a $NODEID formula with the given node ID.
+    /// Supports formulas like "$NODEID", "$NODEID+0x200", "$NODEID+512", etc.
+    /// </summary>
     private static uint EvaluateNodeIdFormula(string formula, byte nodeId)
     {
         formula = formula.Trim();


### PR DESCRIPTION
## Summary
Refactored the numeric parsing logic in `ValueConverter` to eliminate code duplication across `ParseInteger`, `ParseByte`, and `ParseUInt16` methods. The parsing logic for detecting numeric bases (decimal, hexadecimal, octal) is now centralized in reusable helper methods.

## Key Changes
- Added `NumericBase` private enum to represent the three supported numeric bases (Decimal=10, Octal=8, Hexadecimal=16)
- Extracted numeric format detection logic into `GetNumericFormat()` helper method that identifies the base and returns the normalized value
- Created `ParseUnsignedNumber<T>()` generic helper method that handles the common parsing pattern across all unsigned integer types
- Refactored `ParseInteger()`, `ParseByte()`, and `ParseUInt16()` to use the new helper methods, reducing each from ~15 lines to 3 lines of parsing logic
- Maintained identical parsing behavior and error handling across all methods

## Implementation Details
- The `GetNumericFormat()` method detects hexadecimal (0x prefix), octal (leading 0 followed by digit), and decimal formats
- The generic `ParseUnsignedNumber<T>()` method accepts type-specific parsers as delegates, allowing reuse across different numeric types
- All three parsing methods now follow the same pattern: detect format, then delegate to appropriate parser
- No changes to public API or parsing behavior

https://claude.ai/code/session_01VN6t1Td59LRCSVEpwA9HK5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of numeric parsing with centralized base-detection; risk is limited to potential subtle behavior drift in hex/octal/decimal detection used across EDS/DCF parsing.
> 
> **Overview**
> Refactors `ValueConverter`’s unsigned numeric parsing (`ParseInteger`, `ParseByte`, `ParseUInt16`) to remove duplicated hex/octal/decimal detection logic.
> 
> Introduces a private `NumericBase` enum plus shared helpers `GetNumericFormat()` and generic `ParseUnsignedNumber<T>()`, with existing methods now delegating to these helpers while keeping the same exception wrapping (`EdsParseException`) semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beeb7010a2bceab7934325de12781353c9051ce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->