### PR TITLE
test: add XDD/XDC read-write-read integration round-trips

### DIFF
--- a/tests/EdsDcfNet.Tests/Integration/XddXdcIntegrationTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/XddXdcIntegrationTests.cs
@@ -30,7 +30,7 @@ public class XddXdcIntegrationTests
         roundTripped.DeviceInfo.ProductName.Should().Be(original.DeviceInfo.ProductName);
         roundTripped.DeviceInfo.VendorNumber.Should().Be(original.DeviceInfo.VendorNumber);
         roundTripped.DeviceInfo.ProductNumber.Should().Be(original.DeviceInfo.ProductNumber);
-        AssertObjectDictionaryKeysAndNamesEqual(original.ObjectDictionary, roundTripped.ObjectDictionary);
+        AssertObjectDictionaryKeysNamesAndTypesEqual(original.ObjectDictionary, roundTripped.ObjectDictionary);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class XddXdcIntegrationTests
         roundTripped.DeviceInfo.ProductName.Should().Be(original.DeviceInfo.ProductName);
         roundTripped.DeviceInfo.VendorNumber.Should().Be(original.DeviceInfo.VendorNumber);
         roundTripped.DeviceInfo.ProductNumber.Should().Be(original.DeviceInfo.ProductNumber);
-        roundTripped.ObjectDictionary.Objects.Keys.Should().BeEquivalentTo(original.ObjectDictionary.Objects.Keys);
+        AssertObjectDictionaryKeysNamesAndTypesEqual(original.ObjectDictionary, roundTripped.ObjectDictionary);
 
         foreach (var index in original.ObjectDictionary.Objects.Keys)
         {
@@ -77,7 +77,7 @@ public class XddXdcIntegrationTests
         roundTripped.DeviceCommissioning.NodeId.Should().Be(original.DeviceCommissioning.NodeId);
         roundTripped.DeviceCommissioning.Baudrate.Should().Be(original.DeviceCommissioning.Baudrate);
         roundTripped.DeviceCommissioning.NodeName.Should().Be(original.DeviceCommissioning.NodeName);
-        AssertObjectDictionaryKeysAndNamesEqual(original.ObjectDictionary, roundTripped.ObjectDictionary);
+        AssertObjectDictionaryKeysNamesAndTypesEqual(original.ObjectDictionary, roundTripped.ObjectDictionary);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class XddXdcIntegrationTests
         fromDcf.DeviceCommissioning.Baudrate.Should().Be(xdc.DeviceCommissioning.Baudrate);
     }
 
-    private static void AssertObjectDictionaryKeysAndNamesEqual(ObjectDictionary expected, ObjectDictionary actual)
+    private static void AssertObjectDictionaryKeysNamesAndTypesEqual(ObjectDictionary expected, ObjectDictionary actual)
     {
         actual.Objects.Count.Should().Be(expected.Objects.Count);
 


### PR DESCRIPTION
Implements #142.

Summary:
- Adds explicit XDD and XDC read-write-read integration tests via public CanOpenFile APIs
- Uses semantic assertions on model fields and object dictionaries (no fragile string-fragment checks)
- Complements existing direct reader/writer integration coverage

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~XddXdcIntegrationTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand assertions around existing serialization APIs; no production logic is modified.
> 
> **Overview**
> Strengthens integration coverage by adding **semantic round-trip tests** for XDD and XDC: read fixture -> write to string -> read back, asserting key model fields and `ObjectDictionary` entries survive serialization.
> 
> Adds parallel tests that exercise the same round-trip behavior through the public `CanOpenFile` APIs, and refactors repeated object-dictionary assertions into a shared helper for consistency across XDD/XDC and cross-format conversion tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 953cc187f91d7fd3262553edc362c8e2b13e3fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->