### PR TITLE
test: add focused TextFileIo behavior tests

### DIFF
--- a/tests/EdsDcfNet.Tests/Utilities/TextFileIoTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/TextFileIoTests.cs
@@ -1,0 +1,196 @@
+namespace EdsDcfNet.Tests.Utilities;
+
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using EdsDcfNet;
+
+public class TextFileIoTests
+{
+    [Fact]
+    public async Task ReadAllTextAsync_WithUtf8BomAndDetectionEnabled_ReturnsContentWithoutBomCharacter()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        const string expected = "ÄÖÜ utf8 content";
+        await File.WriteAllTextAsync(tempFile, expected, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        try
+        {
+            // Act
+            var actual = await InvokeReadAllTextAsync(
+                tempFile,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                detectEncodingFromByteOrderMarks: true,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            actual.Should().Be(expected);
+            actual.Should().NotStartWith("\uFEFF");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadAllTextAsync_WithUtf8BomAndDetectionDisabled_PreservesLeadingBomCharacter()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        const string content = "BOM-sensitive text";
+        await File.WriteAllTextAsync(tempFile, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        try
+        {
+            // Act
+            var actual = await InvokeReadAllTextAsync(
+                tempFile,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                detectEncodingFromByteOrderMarks: false,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            actual.Should().StartWith("\uFEFF");
+            actual[1..].Should().Be(content);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAllTextAsync_AndReadAllTextAsync_RoundTripsLargeUtf8Content()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        var largeContent = string.Concat(Enumerable.Repeat("Zeile mit Umlaut äöü 12345\n", 600));
+        var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        try
+        {
+            // Act
+            await InvokeWriteAllTextAsync(tempFile, largeContent, utf8NoBom, CancellationToken.None);
+            var actual = await InvokeReadAllTextAsync(tempFile, utf8NoBom, detectEncodingFromByteOrderMarks: true, CancellationToken.None);
+
+            // Assert
+            actual.Should().Be(largeContent);
+            var bytes = await File.ReadAllBytesAsync(tempFile);
+            var utf8Bom = new byte[] { 0xEF, 0xBB, 0xBF };
+            bytes.Take(3).Should().NotEqual(utf8Bom);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadAllTextAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, "content", Encoding.UTF8);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            // Act
+            var act = () => InvokeReadAllTextAsync(
+                tempFile,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                detectEncodingFromByteOrderMarks: true,
+                cancellationToken: cts.Token);
+
+            // Assert
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAllTextAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            // Act
+            var act = () => InvokeWriteAllTextAsync(
+                tempFile,
+                "content",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                cts.Token);
+
+            // Assert
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static Task<string> InvokeReadAllTextAsync(
+        string filePath,
+        Encoding encoding,
+        bool detectEncodingFromByteOrderMarks,
+        CancellationToken cancellationToken)
+    {
+        var method = GetTextFileIoMethod("ReadAllTextAsync");
+
+        try
+        {
+            return (Task<string>)method.Invoke(null, [filePath, encoding, detectEncodingFromByteOrderMarks, cancellationToken])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static Task InvokeWriteAllTextAsync(
+        string filePath,
+        string content,
+        Encoding encoding,
+        CancellationToken cancellationToken)
+    {
+        var method = GetTextFileIoMethod("WriteAllTextAsync");
+
+        try
+        {
+            return (Task)method.Invoke(null, [filePath, content, encoding, cancellationToken])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static MethodInfo GetTextFileIoMethod(string name)
+    {
+        var textFileIoType = typeof(CanOpenFile).Assembly.GetType("EdsDcfNet.Utilities.TextFileIo");
+        textFileIoType.Should().NotBeNull("TextFileIo must exist in the main assembly.");
+
+        var method = textFileIoType!.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull($"TextFileIo.{name} should be available for reflection-based utility tests.");
+
+        return method!;
+    }
+}


### PR DESCRIPTION
Implements #143.

Summary:
- Adds reflection-based tests for internal TextFileIo utility behavior
- Covers UTF-8 BOM detection behavior (enabled/disabled)
- Covers async write/read round-trip with large UTF-8 content and cancellation behavior

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~TextFileIoTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t alter production code paths; main risk is potential flakiness due to temp-file I/O and reflection-based access to internals.
> 
> **Overview**
> Adds a new `TextFileIoTests` suite that reflectively invokes internal `TextFileIo.ReadAllTextAsync`/`WriteAllTextAsync` to lock down file I/O behavior.
> 
> The tests cover **UTF-8 BOM detection on/off** (stripping vs preserving the leading `\uFEFF`), **large UTF-8 round-trip writes without emitting a BOM**, and **proper `OperationCanceledException` behavior** when cancellation tokens are pre-canceled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f502045b750dbded6166a90ee78bbb4813f407. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->