### PR TITLE
test: use structural XML assertions in writer tests

### DIFF
--- a/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
@@ -94,7 +94,7 @@ public class XdcWriterTests
         var result = _writer.GenerateString(CreateSampleDcf());
         var document = XDocument.Parse(result);
         var canOpenObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
+            .Single(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
 
         // Assert
         GetAttributeValue(canOpenObject, "actualValue").Should().Be("0x00000191");
@@ -107,7 +107,7 @@ public class XdcWriterTests
         var result = _writer.GenerateString(CreateSampleDcf());
         var document = XDocument.Parse(result);
         var canOpenObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
+            .Single(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
 
         // Assert
         GetAttributeValue(canOpenObject, "denotation").Should().Be("MyDeviceType");
@@ -238,7 +238,7 @@ public class XdcWriterTests
         var result = _writer.GenerateString(dcf);
         var document = XDocument.Parse(result);
         var subObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
+            .Single(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
 
         // Assert
         GetAttributeValue(subObject, "actualValue").Should().Be("4");
@@ -272,7 +272,7 @@ public class XdcWriterTests
         var result = _writer.GenerateString(dcf);
         var document = XDocument.Parse(result);
         var subObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "01");
+            .Single(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "01");
 
         // Assert
         GetAttributeValue(subObject, "denotation").Should().Be("VendorIdentifier");

--- a/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
@@ -142,7 +142,7 @@ public class XddWriterTests
         var result = _writer.GenerateString(CreateSampleEds());
         var document = XDocument.Parse(result);
         var canOpenObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
+            .Single(e => e.Name.LocalName == "CANopenObject" && GetAttributeValue(e, "index") == "1000");
 
         // Assert
         GetAttributeValue(canOpenObject, "name").Should().Be("Device Type");
@@ -182,7 +182,7 @@ public class XddWriterTests
         var result = _writer.GenerateString(eds);
         var document = XDocument.Parse(result);
         var subObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
+            .Single(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
 
         // Assert
         GetAttributeValue(subObject, "name").Should().Be("Number of Entries");
@@ -217,7 +217,7 @@ public class XddWriterTests
         var result = _writer.GenerateString(eds);
         var document = XDocument.Parse(result);
         var subObject = document.Descendants()
-            .First(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
+            .Single(e => e.Name.LocalName == "CANopenSubObject" && GetAttributeValue(e, "subIndex") == "00");
 
         // Assert
         GetAttributeValue(subObject, "PDOmapping").Should().Be("optional");


### PR DESCRIPTION
Implements #145.

Summary:
- Replaces brittle XML string-fragment checks in core XDD/XDC writer tests with structure-aware XDocument assertions
- Validates required elements/attributes semantically (object lists, object/subobject attributes, commissioning fields)
- Keeps targeted literal checks only where structure-only access is not practical

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter "FullyQualifiedName~XddWriterTests|FullyQualifiedName~XdcWriterTests"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that primarily improve assertion robustness; low risk beyond potential for overly strict XML expectations causing failing tests.
> 
> **Overview**
> Reworks the `XdcWriterTests` and `XddWriterTests` assertions to parse writer output with `XDocument` and validate specific elements/attributes (e.g., commissioning fields, object/subobject `actualValue`/`denotation`, object list counts, supported baud rates) rather than relying on brittle string `Contain` checks.
> 
> Adds small XML test helpers (`GetSingleElement`, `GetAttributeValue`) to centralize element/attribute lookup, keeping only a few literal string assertions where convenient.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a6c7ca5f055d8a95fc5b8c94017855a156a8f78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->