### PR TITLE
test: expand ApplicationProcess parser/model coverage

### DIFF
--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -608,7 +608,7 @@ public class XddReaderTests
           <connection source=""top1.Out"" destination=""top1.In"" description=""loop""/>
         </functionInstanceList>
         <templateList>
-          <parameterTemplate uniqueID=""uid_tpl1"" access=""readWrite"" templateIDRef=""uid_tplbase"">
+          <parameterTemplate uniqueID=""uid_tpl1"" access=""readWrite"">
             <UINT/>
             <defaultValue value=""7""/>
           </parameterTemplate>
@@ -618,7 +618,7 @@ public class XddReaderTests
           </allowedValuesTemplate>
         </templateList>
         <parameterList>
-          <parameter uniqueID=""uid_p1"" access=""read""><UINT/></parameter>
+          <parameter uniqueID=""uid_p1"" access=""read"" templateIDRef=""uid_tpl1""><UINT/></parameter>
         </parameterList>
       </ApplicationProcess>
     </ProfileBody>
@@ -662,6 +662,7 @@ public class XddReaderTests
         ap.TemplateList.Should().NotBeNull();
         ap.TemplateList!.ParameterTemplates.Should().ContainSingle(t => t.UniqueId == "uid_tpl1");
         ap.TemplateList.AllowedValuesTemplates.Should().ContainSingle(t => t.UniqueId == "uid_avt1");
+        ap.ParameterList.Should().ContainSingle(p => p.UniqueId == "uid_p1" && p.TemplateIdRef == "uid_tpl1");
     }
 
     #endregion


### PR DESCRIPTION
Implements #144.

Summary:
- Adds focused XddReader ApplicationProcess test coverage for under-covered model areas
- Validates parsing of functionTypeList, nested and top-level functionInstanceList, and templateList constructs
- Extends semantic assertions for typed ApplicationProcess model content

Validation:
- dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --filter FullyQualifiedName~XddReaderTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage without modifying runtime parsing logic.
> 
> **Overview**
> Expands `XddReaderTests` with a new focused `ApplicationProcess_FunctionTypeTemplateAndInstanceLists_AreParsed` test that validates parsing of `functionTypeList` (including nested `functionInstanceList`), top-level `functionInstanceList` connections, and `templateList` (`parameterTemplate`/`allowedValuesTemplate`) plus `parameter` `templateIDRef` wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 696297dd89eee573443a586498eff4fc5ac739e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->