### PR TITLE
Writer code coverage

### DIFF
--- a/tests/EdsDcfNet.Tests/Writers/CpjWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/CpjWriterTests.cs
@@ -318,6 +318,26 @@ EDSBaseName=/eds/
     }
 
     [Fact]
+    public async Task WriteFileAsync_GenerationThrowsCpjWriteException_Rethrows()
+    {
+        var project = new NodelistProject();
+        project.Networks.Add(null!);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            var act = () => _writer.WriteFileAsync(project, tempFile);
+
+            var ex = (await act.Should().ThrowAsync<CpjWriteException>()).Which;
+            ex.SectionName.Should().Be("Topology");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void WriteFile_NonAsciiCharacters_PreservesCharacters()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -949,6 +949,27 @@ public class DcfWriterTests
     }
 
     [Fact]
+    public async Task WriteFileAsync_GenerationFailure_RethrowsDcfWriteException()
+    {
+        var dcf = CreateMinimalDcf();
+        dcf.DeviceInfo = null!;
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            var act = () => _writer.WriteFileAsync(dcf, tempFile);
+
+            var ex = (await act.Should().ThrowAsync<EdsDcfNet.Exceptions.DcfWriteException>()).Which;
+            ex.SectionName.Should().Be("DeviceInfo");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void GenerateString_InvalidDeviceInfo_ThrowsDcfWriteExceptionWithSectionName()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XdcWriterTests.cs
@@ -400,6 +400,27 @@ public class XdcWriterTests
     }
 
     [Fact]
+    public async Task WriteFileAsync_OutOfRangeNodeId_RethrowsXdcWriteException()
+    {
+        var dcf = CreateSampleDcf();
+        dcf.DeviceCommissioning!.NodeId = 128;
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xdc");
+
+        try
+        {
+            var act = () => _writer.WriteFileAsync(dcf, tempFile);
+
+            var ex = (await act.Should().ThrowAsync<XdcWriteException>()).Which;
+            ex.SectionName.Should().Be("deviceCommissioning");
+            ex.Message.Should().Contain("NodeId");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void GenerateString_NullDeviceInfo_WrapsXddWriteExceptionAsXdcWriteException()
     {
         var dcf = CreateSampleDcf();
@@ -410,6 +431,17 @@ public class XdcWriterTests
         var ex = act.Should().Throw<XdcWriteException>().Which;
         ex.InnerException.Should().NotBeNull();
         ex.SectionName.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void GenerateString_NullDcf_UsesDocumentFallbackSection()
+    {
+        var act = () => _writer.GenerateString(null!);
+
+        var ex = act.Should().Throw<XdcWriteException>().Which;
+        ex.SectionName.Should().Be("Document");
+        ex.Message.Should().Contain("Failed to write section [Document]");
+        ex.InnerException.Should().NotBeNull();
     }
 
     #endregion

--- a/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/XddWriterTests.cs
@@ -170,6 +170,18 @@ public class XddWriterTests
     }
 
     [Fact]
+    public void GenerateString_WhenSubclassThrowsXdcWriteException_PreservesXdcContext()
+    {
+        var writer = new ThrowingNetworkManagementWriter();
+
+        var act = () => writer.GenerateString(CreateSampleEds());
+
+        var ex = act.Should().Throw<XdcWriteException>().Which;
+        ex.SectionName.Should().Be("deviceCommissioning");
+        ex.Message.Should().Contain("forced");
+    }
+
+    [Fact]
     public void GenerateString_ContainsTwoProfiles()
     {
         // Act
@@ -790,6 +802,16 @@ public class XddWriterTests
         {
             WasCalled = true;
             return base.BuildDocument(eds, commissioning);
+        }
+    }
+
+    private sealed class ThrowingNetworkManagementWriter : XddWriter
+    {
+        protected override XElement BuildNetworkManagement(
+            ElectronicDataSheet eds,
+            DeviceCommissioning? commissioning)
+        {
+            throw new XdcWriteException("forced", "deviceCommissioning");
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add targeted unit tests to improve Codecov patch coverage for writer exception and rethrow branches.

---
<p><a href="https://cursor.com/agents/bc-3d1bb269-5d2c-4f1f-905b-575ec5db3ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d1bb269-5d2c-4f1f-905b-575ec5db3ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->