### PR TITLE
ci: reduce semantic-release token privileges

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  packages: write
 
 jobs:
   release:
@@ -93,11 +92,14 @@ jobs:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash
         run: |
+          # Keep the high-privilege token scoped to git push only.
+          # Prefer a fine-grained token with minimal repository permissions.
           git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # Use the default workflow token for GitHub API actions (least privilege).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: ${{ vars.SEMANTIC_RELEASE_BOT_EMAIL }}


### PR DESCRIPTION
## Summary
- use the default `GITHUB_TOKEN` for semantic-release GitHub API actions
- keep `RELEASE_TOKEN` scoped to git push auth only
- drop unused `packages: write` workflow permission

## Linked issue
- closes #226

## Test plan
- [ ] run semantic-release workflow on develop in dry-run/normal path
- [ ] confirm release notes + tagging still work
- [ ] verify release push still succeeds with configured token