### PR TITLE
refactor: use UTC default timestamp in EdsToDcf

### DIFF
--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -976,6 +976,10 @@ public static class CanOpenFile
     /// <param name="nodeId">Node ID for the device</param>
     /// <param name="baudrate">Baudrate in kbit/s (default: 250)</param>
     /// <param name="nodeName">Optional node name</param>
+    /// <remarks>
+    /// Uses <see cref="DateTime.UtcNow"/> for generated FileInfo date/time fields.
+    /// Use the overload with explicit timestamp for fully deterministic output.
+    /// </remarks>
     /// <returns>A new DeviceConfigurationFile</returns>
     /// <example>
     /// <code>
@@ -990,7 +994,7 @@ public static class CanOpenFile
         ushort baudrate = 250,
         string? nodeName = null)
     {
-        return EdsToDcf(eds, nodeId, DateTime.Now, baudrate, nodeName);
+        return EdsToDcf(eds, nodeId, DateTime.UtcNow, baudrate, nodeName);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- switch default `CanOpenFile.EdsToDcf(...)` overload from `DateTime.Now` to `DateTime.UtcNow`
- document UTC default behavior and recommend explicit timestamp overload for fully deterministic output

## Linked issue
- closes #228

## Test plan
- [ ] run `CanOpenFileTests`
- [ ] verify existing timestamp format assertions still pass
- [ ] verify no behavior change when explicit timestamp overload is used