### PR TITLE
ci: use release token for semantic-release push

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -89,9 +89,7 @@ jobs:
 
       - name: Semantic Release
         env:
-          # semantic-release checks GH_TOKEN before GIT_CREDENTIALS for git pushes,
-          # so use the bypass-capable release token for both git and GitHub API calls.
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GIT_CREDENTIALS: x-access-token:${{ secrets.RELEASE_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: ${{ vars.SEMANTIC_RELEASE_BOT_EMAIL }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -89,12 +89,9 @@ jobs:
 
       - name: Semantic Release
         env:
-          # Use the default workflow token for GitHub API operations performed
-          # by semantic-release/@semantic-release/github.
-          GH_TOKEN: ${{ github.token }}
-          # Keep the higher-privilege release token scoped to git operations:
-          # semantic-release tries GIT_CREDENTIALS when deriving its push URL.
-          GIT_CREDENTIALS: x-access-token:${{ secrets.RELEASE_TOKEN }}
+          # semantic-release checks GH_TOKEN before GIT_CREDENTIALS for git pushes,
+          # so use the bypass-capable release token for both git and GitHub API calls.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: ${{ vars.SEMANTIC_RELEASE_BOT_EMAIL }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -87,19 +87,14 @@ jobs:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: true
 
-      - name: Configure git auth for release push
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        shell: bash
-        run: |
-          # Keep the high-privilege token scoped to git push only.
-          # Prefer a fine-grained token with minimal repository permissions.
-          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
       - name: Semantic Release
         env:
-          # Use the default workflow token for GitHub API actions (least privilege).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the default workflow token for GitHub API operations performed
+          # by semantic-release/@semantic-release/github.
+          GH_TOKEN: ${{ github.token }}
+          # Keep the higher-privilege release token scoped to git operations:
+          # semantic-release tries GIT_CREDENTIALS when deriving its push URL.
+          GIT_CREDENTIALS: x-access-token:${{ secrets.RELEASE_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: ${{ vars.SEMANTIC_RELEASE_BOT_EMAIL }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Semantic Release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_CREDENTIALS: x-access-token:${{ secrets.RELEASE_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GIT_AUTHOR_NAME: semantic-release-bot


### PR DESCRIPTION
## Summary
- split semantic-release GitHub authentication between API and git operations
- use the default workflow token (`GH_TOKEN`) for `@semantic-release/github` API operations
- use `GIT_CREDENTIALS` with `RELEASE_TOKEN` only for semantic-release git/tag/release-commit pushes that need the repository-rule bypass
- remove the separate `git remote set-url` step because semantic-release derives its own authenticated push URL from token environment variables

## Why
The failed Semantic Release run on `develop` reached `@semantic-release/git`, generated the release commit, and then GitHub rejected `HEAD:develop` with GH013. After #230, semantic-release received only the default workflow token for both API and git auth. The earlier remote URL rewrite was not enough because semantic-release builds its push URL from its configured repository URL and token env vars.

This keeps the higher-privilege release token scoped to git operations while preserving the existing release workflow that commits generated changelog/version updates back to protected release branches.

## Test plan
- [x] `git diff --check`
- [ ] merge and re-run Semantic Release on `develop`