### PR TITLE
fix(ci): harden CycloneDX SBOM generation in publish script

### DIFF
--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -21,9 +21,11 @@ dotnet nuget push "./packages/*.nupkg" \
 # --- SBOM: CycloneDX ---
 # Use && chain so each step's failure is properly detected under set -euo pipefail,
 # while || ensures a failed SBOM never aborts the release.
+# Clear any stale SBOM file first so a failed generation cannot upload a previous run's artifact.
 echo "Generating CycloneDX SBOM..."
+rm -f packages/bom.cdx.json packages/bom.json
 dotnet tool restore \
-  && dotnet CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
+  && dotnet tool run dotnet-CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
   --output packages \
   --json \
   && mv packages/bom.json packages/bom.cdx.json \

--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -23,8 +23,8 @@ dotnet nuget push "./packages/*.nupkg" \
 # while || ensures a failed SBOM never aborts the release.
 # Clear any stale SBOM file first so a failed generation cannot upload a previous run's artifact.
 echo "Generating CycloneDX SBOM..."
-rm -f packages/bom.cdx.json packages/bom.json \
-  && dotnet tool restore \
+rm -f packages/bom.cdx.json packages/bom.json || true
+dotnet tool restore \
   && dotnet tool run dotnet-CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
   --output packages \
   --json \
@@ -37,7 +37,7 @@ rm -f packages/bom.cdx.json packages/bom.json \
 # handles both transport errors and API errors without aborting the release.
 echo "Generating SPDX SBOM..."
 if [[ -n "${GH_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
-  rm -f packages/sbom.spdx.json /tmp/sbom.spdx.json /tmp/spdx_raw.json
+  rm -f packages/sbom.spdx.json /tmp/sbom.spdx.json /tmp/spdx_raw.json || true
   curl -sLf \
     -H "Authorization: Bearer ${GH_TOKEN}" \
     -H "Accept: application/vnd.github+json" \

--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -23,8 +23,8 @@ dotnet nuget push "./packages/*.nupkg" \
 # while || ensures a failed SBOM never aborts the release.
 # Clear any stale SBOM file first so a failed generation cannot upload a previous run's artifact.
 echo "Generating CycloneDX SBOM..."
-rm -f packages/bom.cdx.json packages/bom.json
-dotnet tool restore \
+rm -f packages/bom.cdx.json packages/bom.json \
+  && dotnet tool restore \
   && dotnet tool run dotnet-CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
   --output packages \
   --json \


### PR DESCRIPTION
## Summary

Follow-up to post-merge review comments on #239 (SBOM generation).

- Invoke CycloneDX as a manifest-installed local tool via `dotnet tool run dotnet-CycloneDX` instead of `dotnet CycloneDX`. The explicit form does not depend on a globally discoverable `dotnet-CycloneDX` shim on `PATH` and is more reliable on clean GitHub runners (addresses the **P1** finding from `chatgpt-codex-connector`).
- Remove any stale `packages/bom.cdx.json` / `packages/bom.json` before running CycloneDX, mirroring what the SPDX step already does. Without this, a failed CycloneDX run could leave a previous run's SBOM in place and have it uploaded as a release asset (addresses both Copilot review comments).

## Why `.releaserc.json` is unchanged

`@semantic-release/github` only warns on missing assets, it does not fail the release. Once stale files can no longer linger, missing assets are simply skipped — no need to make the asset list conditional.

## Test plan

- [ ] Next release cuts a tag and uploads `bom.cdx.json` + `sbom.spdx.json` as assets.
- [ ] If CycloneDX generation fails (simulated), no stale `bom.cdx.json` is uploaded.

Refs: #239

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnZTPJNR4YnsPJaQXAfv4Z)_