### PR TITLE
Fix SBOM generation script to handle missing files gracefully

### DIFF
--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -23,8 +23,8 @@ dotnet nuget push "./packages/*.nupkg" \
 # while || ensures a failed SBOM never aborts the release.
 # Clear any stale SBOM file first so a failed generation cannot upload a previous run's artifact.
 echo "Generating CycloneDX SBOM..."
-rm -f packages/bom.cdx.json packages/bom.json \
-  && dotnet tool restore \
+rm -f packages/bom.cdx.json packages/bom.json || true
+dotnet tool restore \
   && dotnet tool run dotnet-CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
   --output packages \
   --json \
@@ -37,7 +37,7 @@ rm -f packages/bom.cdx.json packages/bom.json \
 # handles both transport errors and API errors without aborting the release.
 echo "Generating SPDX SBOM..."
 if [[ -n "${GH_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
-  rm -f packages/sbom.spdx.json /tmp/sbom.spdx.json /tmp/spdx_raw.json
+  rm -f packages/sbom.spdx.json /tmp/sbom.spdx.json /tmp/spdx_raw.json || true
   curl -sLf \
     -H "Authorization: Bearer ${GH_TOKEN}" \
     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
Updated the semantic release publish script to prevent build failures when SBOM files don't exist during cleanup operations.

## Key Changes
- Added `|| true` to `rm -f` commands for SBOM file cleanup to ensure they succeed even when files are missing
  - CycloneDX SBOM cleanup (line 26)
  - SPDX SBOM cleanup (line 40)
- Separated the `rm -f` command from the subsequent `dotnet tool restore` command with proper command chaining

## Implementation Details
The `rm -f` command with `|| true` ensures that the script continues execution even if the files don't exist, preventing the entire release process from failing due to non-existent cleanup targets. This is particularly important in CI/CD environments where previous artifacts may not be present on every run.

https://claude.ai/code/session_017thABb7LmUyY9v1CX61TK1