### PR TITLE
fix(ci): enhance cyclonedx sbom

### DIFF
--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -28,7 +28,8 @@ dotnet tool restore \
   && dotnet CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
     --output packages \
     --json \
-    --set-version "${next_version}" \   # ← das hinzufügen
+    --set-version "${next_version}" \
+    --set-type Library \
   && mv packages/bom.json packages/bom.cdx.json \
   && echo "CycloneDX SBOM written to packages/bom.cdx.json with version ${next_version}" \
   || echo "Warning: CycloneDX SBOM generation failed; skipping."

--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -25,11 +25,12 @@ dotnet nuget push "./packages/*.nupkg" \
 echo "Generating CycloneDX SBOM..."
 rm -f packages/bom.cdx.json packages/bom.json || true
 dotnet tool restore \
-  && dotnet tool run dotnet-CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
-  --output packages \
-  --json \
+  && dotnet CycloneDX src/EdsDcfNet/EdsDcfNet.csproj \
+    --output packages \
+    --json \
+    --set-version "${next_version}" \   # ← das hinzufügen
   && mv packages/bom.json packages/bom.cdx.json \
-  && echo "CycloneDX SBOM written to packages/bom.cdx.json" \
+  && echo "CycloneDX SBOM written to packages/bom.cdx.json with version ${next_version}" \
   || echo "Warning: CycloneDX SBOM generation failed; skipping."
 
 # --- SBOM: SPDX via GitHub Dependency Graph API ---


### PR DESCRIPTION
This PR updates the release publish script to ensure the generated CycloneDX SBOM includes the upcoming release version.

Changes:

Switch CycloneDX invocation in the publish script to dotnet CycloneDX.
Add --set-version "${next_version}" so the SBOM reflects the release version.
Add --set-type Library to reflect the correct type in SBOM.
Update the success message to include the written version.