### PR TITLE
fix(ci): prune orphan components and assert CycloneDX completeness

### DIFF
--- a/sbom/README.md
+++ b/sbom/README.md
@@ -36,6 +36,12 @@ The `dotnet CycloneDX` CLI reads only the *version* from the project file; it do
 
 Keep the template in sync with `src/EdsDcfNet/EdsDcfNet.csproj` (authors, license expression, description) when those values change.
 
+### Dependency-graph pruning and completeness
+
+`dotnet CycloneDX --exclude-dev` removes packages flagged as development dependencies (analyzers, SourceLink, Polyfill) but leaves their transitive dependencies behind as orphan components no longer reachable from the root. Because the published package declares zero runtime dependencies, those orphans would misrepresent the supply chain.
+
+After generation the BOM is post-processed with [`prune-cyclonedx.jq`](prune-cyclonedx.jq), which keeps only components reachable from the root component, drops dangling dependency entries, and adds a `compositions` block asserting the dependency inventory is `complete`. The filter uses no hardcoded package names, so genuine runtime dependencies added later are retained automatically.
+
 ## Triage release-tooling advisories
 
 Dependency alerts can target runtime packages, test packages, GitHub Actions, or the Node-based release tooling used by `semantic-release`. Triage the alert before changing package versions:

--- a/sbom/prune-cyclonedx.jq
+++ b/sbom/prune-cyclonedx.jq
@@ -1,0 +1,30 @@
+# Prunes the CycloneDX BOM produced by dotnet-CycloneDX so it accurately
+# reflects the published package's runtime dependency footprint.
+#
+# Rationale: with --exclude-dev the tool drops packages flagged as
+# DevelopmentDependency (analyzers, SourceLink, Polyfill) but leaves their
+# transitive dependencies behind as orphan components that are no longer
+# reachable from the root component. For EdsDcfNet the published NuGet package
+# declares zero runtime dependencies, so these orphans (System.*, SourceLink
+# internals, …) misrepresent the supply chain for SCA tooling.
+#
+# This filter keeps only components reachable from the root component via the
+# dependency graph, prunes dangling dependency entries, and adds a truthful
+# `compositions` block asserting the dependency inventory is complete. It uses
+# no hardcoded package names, so genuine runtime dependencies added later are
+# retained automatically.
+
+def closure($adj):
+  def step(s): (s + ([ s[] | ($adj[.] // []) ] | add // [])) | unique;
+  until(step(.) == .; step(.));
+
+. as $bom
+| ($bom.metadata.component["bom-ref"]) as $root
+| (reduce ($bom.dependencies // [])[] as $d ({}; .[$d.ref] = ($d.dependsOn // []))) as $adj
+| ([$root] | closure($adj)) as $reach
+| $bom
+| .components = [ (.components // [])[] | select( ((.["bom-ref"]) // .purl) as $r | $reach | index($r)) ]
+| .dependencies = [ (.dependencies // [])[]
+                    | select(.ref as $r | $reach | index($r))
+                    | .dependsOn = [ (.dependsOn // [])[] | select(. as $r | $reach | index($r)) ] ]
+| .compositions = [ { "aggregate": "complete", "assemblies": [$root], "dependencies": $reach } ]

--- a/sbom/prune-cyclonedx.jq
+++ b/sbom/prune-cyclonedx.jq
@@ -27,4 +27,4 @@ def closure($adj):
 | .dependencies = [ (.dependencies // [])[]
                     | select(.ref as $r | $reach | index($r))
                     | .dependsOn = [ (.dependsOn // [])[] | select(. as $r | $reach | index($r)) ] ]
-| .compositions = [ { "aggregate": "complete", "assemblies": [$root], "dependencies": $reach } ]
+| .compositions = [ { "aggregate": "complete", "assemblies": [$root], "dependencies": [$root] } ]

--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -27,6 +27,9 @@ best_effort() {
 }
 
 generate_cyclonedx_sbom() {
+  local cdx_json
+  local exit_code
+
   echo "Generating CycloneDX SBOM..."
 
   rm -f packages/bom.cdx.json packages/bom.json || return
@@ -42,8 +45,18 @@ generate_cyclonedx_sbom() {
     --exclude-dev \
     --exclude-test-projects \
     --enable-github-licenses || return
-  jq -f sbom/prune-cyclonedx.jq packages/bom.json > packages/bom.cdx.json || return
-  rm -f packages/bom.json
+  cdx_json="$(mktemp packages/bom.cdx.XXXXXX)" || return
+  jq -f sbom/prune-cyclonedx.jq packages/bom.json > "$cdx_json" || {
+    exit_code=$?
+    rm -f "$cdx_json"
+    return "$exit_code"
+  }
+  mv "$cdx_json" packages/bom.cdx.json || {
+    exit_code=$?
+    rm -f "$cdx_json"
+    return "$exit_code"
+  }
+  rm -f packages/bom.json "$cdx_json"
 
   echo "CycloneDX SBOM written to packages/bom.cdx.json with version ${next_version}"
 }

--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -42,7 +42,8 @@ generate_cyclonedx_sbom() {
     --exclude-dev \
     --exclude-test-projects \
     --enable-github-licenses || return
-  mv packages/bom.json packages/bom.cdx.json || return
+  jq -f sbom/prune-cyclonedx.jq packages/bom.json > packages/bom.cdx.json || return
+  rm -f packages/bom.json
 
   echo "CycloneDX SBOM written to packages/bom.cdx.json with version ${next_version}"
 }


### PR DESCRIPTION
## Summary

Addresses the remaining CycloneDX follow-ups from #274 (dependency-graph orphans, a transitive component with an unresolved license, and the missing `compositions` block). These turned out to be one coupled concern. Builds on #275 (already merged).

### Problem

`dotnet CycloneDX --exclude-dev` drops packages flagged as development dependencies (analyzers, SourceLink, Polyfill) but leaves their **transitive** dependencies behind as orphan components no longer reachable from the root (`dependsOn: []`). The published `EdsDcfNet` package declares **zero runtime dependencies** (verified via nuget.org for both target frameworks), so these 8 orphans (`System.*`, SourceLink internals, `Microsoft.NETCore.Platforms`) misrepresent the supply chain for SCA tooling. One of them (`Microsoft.NETCore.Platforms@1.1.0`) also had no resolvable license.

### Fix

Add `sbom/prune-cyclonedx.jq`, applied after generation, which:

- keeps only components reachable from the root component via the dependency graph,
- drops dangling dependency entries, and
- adds a truthful `compositions` block (`aggregate: "complete"`).

The filter uses **no hardcoded package names** — genuine runtime dependencies added later remain reachable from the root and are retained automatically. This also resolves the missing-license point (the unlicensed orphan is removed) and enables an honest completeness assertion.

### Result (locally verified, end-to-end with the script's flags)

- `components`: `[]` (matches the package's zero declared dependencies)
- `dependencies`: root only, `dependsOn: []`
- `compositions`: `aggregate: "complete"`
- root metadata from #275 (supplier, MIT license, purl, externalReferences) preserved

## Test plan

- [x] End-to-end generation with the exact publish-script flags + prune; `components` empty, graph consistent, `compositions` present.
- [x] Root-component metadata from #275 intact; output is valid CycloneDX 1.7 JSON.
- [ ] Confirm the next release's `bom.cdx.json` asset reflects the pruned graph.

## Related

- Follows #275, refs #274.
- SPDX BOM quality tracked separately in #276.

Made with [Cursor](https://cursor.com)