### PR TITLE
fix(deps): pin patched undici versions via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -648,6 +648,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -6094,16 +6104,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,20 @@
   "engines": {
     "node": "^22.14.0 || >=24.10.0"
   },
+  "overrides": {
+    "@actions/http-client": {
+      "undici": "6.27.0"
+    },
+    "@semantic-release/github": {
+      "undici": "7.28.0"
+    },
+    "node-gyp": {
+      "undici": "6.27.0"
+    },
+    "npm": {
+      "undici": "6.27.0"
+    }
+  },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",


### PR DESCRIPTION
## Summary
- Add npm `overrides` to pin `undici@6.27.0` (via `@actions/http-client`, `node-gyp`, and `npm`) and `undici@7.28.0` (via `@semantic-release/github`).
- Resolves six of nine open Dependabot alerts for transitive `undici` versions in semantic-release dev tooling.
- The remaining three 6.x alerts may persist until the bundled `undici@6.26.0` inside `npm` is updated upstream (overrides cannot replace bundled dependencies).

## Test plan
- [x] `npm install` succeeds with overrides applied
- [x] `npm ls undici` shows `6.27.0` under `@actions/http-client` and `7.28.0` under `@semantic-release/github`
- [ ] Dependabot re-scan closes the seven 7.x and `@actions/http-client` 6.x alerts after merge


Made with [Cursor](https://cursor.com)