### PR TITLE
fix(deps): sync package-lock.json with undici v7 overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -650,16 +650,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@semantic-release/npm": {
       "version": "13.1.4",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.4.tgz",
@@ -6104,6 +6094,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,16 +54,6 @@
         "undici": "^6.23.0"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` after PR #283 updated npm `overrides` to `undici@7.28.0`
- Fixes the Semantic Release workflow failure on `develop` where `npm ci` reported `Missing: undici@7.28.0 from lock file`

## Test plan
- [x] `npm ci` succeeds locally
- [ ] Semantic Release workflow passes on merge


Made with [Cursor](https://cursor.com)