### PR TITLE
docs: use DateTime.UtcNow in examples for library consistency

### DIFF
--- a/examples/EdsDcfNet.Examples/Program.cs
+++ b/examples/EdsDcfNet.Examples/Program.cs
@@ -40,8 +40,8 @@ class Program
                 FileRevision = 0,
                 EdsVersion = "4.0",
                 Description = "Example CANopen Device",
-                CreationDate = DateTime.Now.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture),
-                CreationTime = DateTime.Now.ToString("hh:mmtt", CultureInfo.InvariantCulture),
+                CreationDate = DateTime.UtcNow.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture),
+                CreationTime = DateTime.UtcNow.ToString("hh:mmtt", CultureInfo.InvariantCulture),
                 CreatedBy = "EdsDcfNet Example"
             },
             DeviceInfo = new DeviceInfo


### PR DESCRIPTION
## Summary
- Replace `DateTime.Now` with `DateTime.UtcNow` in `examples/EdsDcfNet.Examples/Program.cs`
- Aligns example-generated `CreationDate`/`CreationTime` with the library default used by `EdsToDcf` since #228

## Test plan
- [x] `dotnet build examples/EdsDcfNet.Examples/EdsDcfNet.Examples.csproj --configuration Release`

Closes #289

Made with [Cursor](https://cursor.com)