### PR TITLE
feat: extend model validation and add optional write guard

### DIFF
--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -277,7 +277,26 @@ public static class CanOpenFile
         ElectronicDataSheet eds,
         string filePath,
         CancellationToken cancellationToken = default)
+        => WriteEdsAsync(eds, filePath, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes an Electronic Data Sheet (EDS) to disk asynchronously.
+    /// </summary>
+    /// <param name="eds">The ElectronicDataSheet to write</param>
+    /// <param name="filePath">Path where the EDS file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting file I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteEdsAsync(
+        ElectronicDataSheet eds,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.WriteFileAsync(eds, filePath, cancellationToken);
     }
@@ -293,7 +312,27 @@ public static class CanOpenFile
         ElectronicDataSheet eds,
         Stream stream,
         CancellationToken cancellationToken = default)
+        => WriteEdsAsync(eds, stream, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes an Electronic Data Sheet (EDS) to a stream asynchronously.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="eds">The ElectronicDataSheet to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting stream I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteEdsAsync(
+        ElectronicDataSheet eds,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.WriteStreamAsync(eds, stream, cancellationToken);
     }
@@ -513,7 +552,26 @@ public static class CanOpenFile
         DeviceConfigurationFile dcf,
         string filePath,
         CancellationToken cancellationToken = default)
+        => WriteDcfAsync(dcf, filePath, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a Device Configuration File (DCF) to disk asynchronously.
+    /// </summary>
+    /// <param name="dcf">The DeviceConfigurationFile to write</param>
+    /// <param name="filePath">Path where the DCF file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting file I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteDcfAsync(
+        DeviceConfigurationFile dcf,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.WriteFileAsync(dcf, filePath, cancellationToken);
     }
@@ -529,7 +587,27 @@ public static class CanOpenFile
         DeviceConfigurationFile dcf,
         Stream stream,
         CancellationToken cancellationToken = default)
+        => WriteDcfAsync(dcf, stream, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a Device Configuration File (DCF) to a stream asynchronously.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="dcf">The DeviceConfigurationFile to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting stream I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteDcfAsync(
+        DeviceConfigurationFile dcf,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.WriteStreamAsync(dcf, stream, cancellationToken);
     }
@@ -734,7 +812,26 @@ public static class CanOpenFile
         NodelistProject cpj,
         string filePath,
         CancellationToken cancellationToken = default)
+        => WriteCpjAsync(cpj, filePath, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a CiA 306-3 nodelist project (.cpj) to disk asynchronously.
+    /// </summary>
+    /// <param name="cpj">The NodelistProject to write</param>
+    /// <param name="filePath">Path where the CPJ file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting file I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteCpjAsync(
+        NodelistProject cpj,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.WriteFileAsync(cpj, filePath, cancellationToken);
     }
@@ -750,7 +847,27 @@ public static class CanOpenFile
         NodelistProject cpj,
         Stream stream,
         CancellationToken cancellationToken = default)
+        => WriteCpjAsync(cpj, stream, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a CiA 306-3 nodelist project (.cpj) to a stream asynchronously.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="cpj">The NodelistProject to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting stream I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteCpjAsync(
+        NodelistProject cpj,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.WriteStreamAsync(cpj, stream, cancellationToken);
     }
@@ -955,7 +1072,26 @@ public static class CanOpenFile
         ElectronicDataSheet xdd,
         string filePath,
         CancellationToken cancellationToken = default)
+        => WriteXddAsync(xdd, filePath, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes an ElectronicDataSheet as a CiA 311 XDD file asynchronously.
+    /// </summary>
+    /// <param name="xdd">The ElectronicDataSheet to write</param>
+    /// <param name="filePath">Path where the XDD file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting file I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteXddAsync(
+        ElectronicDataSheet xdd,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.WriteFileAsync(xdd, filePath, cancellationToken);
     }
@@ -971,7 +1107,27 @@ public static class CanOpenFile
         ElectronicDataSheet xdd,
         Stream stream,
         CancellationToken cancellationToken = default)
+        => WriteXddAsync(xdd, stream, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes an ElectronicDataSheet as a CiA 311 XDD stream asynchronously.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="xdd">The ElectronicDataSheet to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting stream I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteXddAsync(
+        ElectronicDataSheet xdd,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.WriteStreamAsync(xdd, stream, cancellationToken);
     }
@@ -1176,7 +1332,26 @@ public static class CanOpenFile
         DeviceConfigurationFile xdc,
         string filePath,
         CancellationToken cancellationToken = default)
+        => WriteXdcAsync(xdc, filePath, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a DeviceConfigurationFile as a CiA 311 XDC file asynchronously.
+    /// </summary>
+    /// <param name="xdc">The DeviceConfigurationFile to write</param>
+    /// <param name="filePath">Path where the XDC file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting file I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteXdcAsync(
+        DeviceConfigurationFile xdc,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.WriteFileAsync(xdc, filePath, cancellationToken);
     }
@@ -1192,7 +1367,27 @@ public static class CanOpenFile
         DeviceConfigurationFile xdc,
         Stream stream,
         CancellationToken cancellationToken = default)
+        => WriteXdcAsync(xdc, stream, options: null, cancellationToken);
+
+    /// <summary>
+    /// Writes a DeviceConfigurationFile as a CiA 311 XDC stream asynchronously.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="xdc">The DeviceConfigurationFile to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <param name="cancellationToken">Cancellation token for aborting stream I/O</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static Task WriteXdcAsync(
+        DeviceConfigurationFile xdc,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
     {
+        EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.WriteStreamAsync(xdc, stream, cancellationToken);
     }

--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Utilities;
@@ -47,6 +48,47 @@ public static class CanOpenFile
     public static IReadOnlyList<ValidationIssue> Validate(DeviceConfigurationFile dcf)
     {
         return CanOpenModelValidator.Validate(dcf);
+    }
+
+    /// <summary>
+    /// Validates a nodelist project (CPJ) model using the full
+    /// <see cref="CanOpenModelValidator"/> rule set.
+    /// </summary>
+    /// <param name="cpj">Model instance to validate</param>
+    /// <returns>List of validation issues. Empty when model is valid.</returns>
+    public static IReadOnlyList<ValidationIssue> Validate(NodelistProject cpj)
+    {
+        return CanOpenModelValidator.Validate(cpj);
+    }
+
+    /// <summary>
+    /// Validates an EDS model and throws <see cref="ModelValidationException"/> when issues are found.
+    /// </summary>
+    /// <param name="eds">Model instance to validate</param>
+    /// <exception cref="ModelValidationException">Thrown when validation issues are found.</exception>
+    public static void EnsureValid(ElectronicDataSheet eds)
+    {
+        ThrowIfInvalid(Validate(eds));
+    }
+
+    /// <summary>
+    /// Validates a DCF model and throws <see cref="ModelValidationException"/> when issues are found.
+    /// </summary>
+    /// <param name="dcf">Model instance to validate</param>
+    /// <exception cref="ModelValidationException">Thrown when validation issues are found.</exception>
+    public static void EnsureValid(DeviceConfigurationFile dcf)
+    {
+        ThrowIfInvalid(Validate(dcf));
+    }
+
+    /// <summary>
+    /// Validates a CPJ model and throws <see cref="ModelValidationException"/> when issues are found.
+    /// </summary>
+    /// <param name="cpj">Model instance to validate</param>
+    /// <exception cref="ModelValidationException">Thrown when validation issues are found.</exception>
+    public static void EnsureValid(NodelistProject cpj)
+    {
+        ThrowIfInvalid(Validate(cpj));
     }
 
     #region EDS Read
@@ -179,7 +221,21 @@ public static class CanOpenFile
     /// </code>
     /// </example>
     public static void WriteEds(ElectronicDataSheet eds, string filePath)
+        => WriteEds(eds, filePath, options: null);
+
+    /// <summary>
+    /// Writes an Electronic Data Sheet (EDS) to disk.
+    /// </summary>
+    /// <param name="eds">The ElectronicDataSheet to write</param>
+    /// <param name="filePath">Path where the EDS file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteEds(ElectronicDataSheet eds, string filePath, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         writer.WriteFile(eds, filePath);
     }
@@ -191,7 +247,22 @@ public static class CanOpenFile
     /// <param name="eds">The ElectronicDataSheet to write</param>
     /// <param name="stream">Writable destination stream</param>
     public static void WriteEds(ElectronicDataSheet eds, Stream stream)
+        => WriteEds(eds, stream, options: null);
+
+    /// <summary>
+    /// Writes an Electronic Data Sheet (EDS) to a stream.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="eds">The ElectronicDataSheet to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteEds(ElectronicDataSheet eds, Stream stream, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         writer.WriteStream(eds, stream);
     }
@@ -233,7 +304,21 @@ public static class CanOpenFile
     /// <param name="eds">The ElectronicDataSheet to convert</param>
     /// <returns>EDS content as string</returns>
     public static string WriteEdsToString(ElectronicDataSheet eds)
+        => WriteEdsToString(eds, options: null);
+
+    /// <summary>
+    /// Generates an EDS file content as string.
+    /// </summary>
+    /// <param name="eds">The ElectronicDataSheet to convert</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <returns>EDS content as string</returns>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static string WriteEdsToString(ElectronicDataSheet eds, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.GenerateString(eds);
     }
@@ -372,7 +457,21 @@ public static class CanOpenFile
     /// </code>
     /// </example>
     public static void WriteDcf(DeviceConfigurationFile dcf, string filePath)
+        => WriteDcf(dcf, filePath, options: null);
+
+    /// <summary>
+    /// Writes a Device Configuration File (DCF) to disk.
+    /// </summary>
+    /// <param name="dcf">The DeviceConfigurationFile to write</param>
+    /// <param name="filePath">Path where the DCF file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteDcf(DeviceConfigurationFile dcf, string filePath, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         writer.WriteFile(dcf, filePath);
     }
@@ -384,7 +483,22 @@ public static class CanOpenFile
     /// <param name="dcf">The DeviceConfigurationFile to write</param>
     /// <param name="stream">Writable destination stream</param>
     public static void WriteDcf(DeviceConfigurationFile dcf, Stream stream)
+        => WriteDcf(dcf, stream, options: null);
+
+    /// <summary>
+    /// Writes a Device Configuration File (DCF) to a stream.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="dcf">The DeviceConfigurationFile to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteDcf(DeviceConfigurationFile dcf, Stream stream, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         writer.WriteStream(dcf, stream);
     }
@@ -426,7 +540,21 @@ public static class CanOpenFile
     /// <param name="dcf">The DeviceConfigurationFile to convert</param>
     /// <returns>DCF content as string</returns>
     public static string WriteDcfToString(DeviceConfigurationFile dcf)
+        => WriteDcfToString(dcf, options: null);
+
+    /// <summary>
+    /// Generates a DCF file content as string.
+    /// </summary>
+    /// <param name="dcf">The DeviceConfigurationFile to convert</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <returns>DCF content as string</returns>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static string WriteDcfToString(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.GenerateString(dcf);
     }
@@ -550,7 +678,21 @@ public static class CanOpenFile
     /// <param name="cpj">The NodelistProject to write</param>
     /// <param name="filePath">Path where the CPJ file should be written</param>
     public static void WriteCpj(NodelistProject cpj, string filePath)
+        => WriteCpj(cpj, filePath, options: null);
+
+    /// <summary>
+    /// Writes a CiA 306-3 nodelist project (.cpj) to disk.
+    /// </summary>
+    /// <param name="cpj">The NodelistProject to write</param>
+    /// <param name="filePath">Path where the CPJ file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteCpj(NodelistProject cpj, string filePath, CanOpenWriteOptions? options)
     {
+        EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         writer.WriteFile(cpj, filePath);
     }
@@ -562,7 +704,22 @@ public static class CanOpenFile
     /// <param name="cpj">The NodelistProject to write</param>
     /// <param name="stream">Writable destination stream</param>
     public static void WriteCpj(NodelistProject cpj, Stream stream)
+        => WriteCpj(cpj, stream, options: null);
+
+    /// <summary>
+    /// Writes a CiA 306-3 nodelist project (.cpj) to a stream.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="cpj">The NodelistProject to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteCpj(NodelistProject cpj, Stream stream, CanOpenWriteOptions? options)
     {
+        EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         writer.WriteStream(cpj, stream);
     }
@@ -604,7 +761,21 @@ public static class CanOpenFile
     /// <param name="cpj">The NodelistProject to convert</param>
     /// <returns>CPJ content as string</returns>
     public static string WriteCpjToString(NodelistProject cpj)
+        => WriteCpjToString(cpj, options: null);
+
+    /// <summary>
+    /// Generates a CPJ file content as string.
+    /// </summary>
+    /// <param name="cpj">The NodelistProject to convert</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <returns>CPJ content as string</returns>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static string WriteCpjToString(NodelistProject cpj, CanOpenWriteOptions? options)
     {
+        EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.GenerateString(cpj);
     }
@@ -728,7 +899,21 @@ public static class CanOpenFile
     /// <param name="xdd">The ElectronicDataSheet to write</param>
     /// <param name="filePath">Path where the XDD file should be written</param>
     public static void WriteXdd(ElectronicDataSheet xdd, string filePath)
+        => WriteXdd(xdd, filePath, options: null);
+
+    /// <summary>
+    /// Writes an ElectronicDataSheet as a CiA 311 XDD file.
+    /// </summary>
+    /// <param name="xdd">The ElectronicDataSheet to write</param>
+    /// <param name="filePath">Path where the XDD file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteXdd(ElectronicDataSheet xdd, string filePath, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         writer.WriteFile(xdd, filePath);
     }
@@ -740,7 +925,22 @@ public static class CanOpenFile
     /// <param name="xdd">The ElectronicDataSheet to write</param>
     /// <param name="stream">Writable destination stream</param>
     public static void WriteXdd(ElectronicDataSheet xdd, Stream stream)
+        => WriteXdd(xdd, stream, options: null);
+
+    /// <summary>
+    /// Writes an ElectronicDataSheet as a CiA 311 XDD stream.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="xdd">The ElectronicDataSheet to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteXdd(ElectronicDataSheet xdd, Stream stream, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         writer.WriteStream(xdd, stream);
     }
@@ -782,7 +982,21 @@ public static class CanOpenFile
     /// <param name="xdd">The ElectronicDataSheet to convert</param>
     /// <returns>XDD content as string</returns>
     public static string WriteXddToString(ElectronicDataSheet xdd)
+        => WriteXddToString(xdd, options: null);
+
+    /// <summary>
+    /// Generates a CiA 311 XDD file content as string.
+    /// </summary>
+    /// <param name="xdd">The ElectronicDataSheet to convert</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <returns>XDD content as string</returns>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static string WriteXddToString(ElectronicDataSheet xdd, CanOpenWriteOptions? options)
     {
+        EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.GenerateString(xdd);
     }
@@ -906,7 +1120,21 @@ public static class CanOpenFile
     /// <param name="xdc">The DeviceConfigurationFile to write</param>
     /// <param name="filePath">Path where the XDC file should be written</param>
     public static void WriteXdc(DeviceConfigurationFile xdc, string filePath)
+        => WriteXdc(xdc, filePath, options: null);
+
+    /// <summary>
+    /// Writes a DeviceConfigurationFile as a CiA 311 XDC file.
+    /// </summary>
+    /// <param name="xdc">The DeviceConfigurationFile to write</param>
+    /// <param name="filePath">Path where the XDC file should be written</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteXdc(DeviceConfigurationFile xdc, string filePath, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         writer.WriteFile(xdc, filePath);
     }
@@ -918,7 +1146,22 @@ public static class CanOpenFile
     /// <param name="xdc">The DeviceConfigurationFile to write</param>
     /// <param name="stream">Writable destination stream</param>
     public static void WriteXdc(DeviceConfigurationFile xdc, Stream stream)
+        => WriteXdc(xdc, stream, options: null);
+
+    /// <summary>
+    /// Writes a DeviceConfigurationFile as a CiA 311 XDC stream.
+    /// The stream is not disposed by this method.
+    /// </summary>
+    /// <param name="xdc">The DeviceConfigurationFile to write</param>
+    /// <param name="stream">Writable destination stream</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static void WriteXdc(DeviceConfigurationFile xdc, Stream stream, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         writer.WriteStream(xdc, stream);
     }
@@ -960,7 +1203,21 @@ public static class CanOpenFile
     /// <param name="xdc">The DeviceConfigurationFile to convert</param>
     /// <returns>XDC content as string</returns>
     public static string WriteXdcToString(DeviceConfigurationFile xdc)
+        => WriteXdcToString(xdc, options: null);
+
+    /// <summary>
+    /// Generates a CiA 311 XDC file content as string.
+    /// </summary>
+    /// <param name="xdc">The DeviceConfigurationFile to convert</param>
+    /// <param name="options">Optional write behavior such as pre-write validation.</param>
+    /// <returns>XDC content as string</returns>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <paramref name="options"/>.<see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is
+    /// <see langword="true"/> and the model has validation issues.
+    /// </exception>
+    public static string WriteXdcToString(DeviceConfigurationFile xdc, CanOpenWriteOptions? options)
     {
+        EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.GenerateString(xdc);
     }
@@ -1057,6 +1314,34 @@ public static class CanOpenFile
             dcf.AdditionalSections[kvp.Key] = kvp.Value;
 
         return dcf;
+    }
+
+    #endregion
+
+    #region Write validation helpers
+
+    private static void EnsureValidEdsForWrite(ElectronicDataSheet eds, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            EnsureValid(eds);
+    }
+
+    private static void EnsureValidDcfForWrite(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            EnsureValid(dcf);
+    }
+
+    private static void EnsureValidCpjForWrite(NodelistProject cpj, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            EnsureValid(cpj);
+    }
+
+    private static void ThrowIfInvalid(IReadOnlyList<ValidationIssue> issues)
+    {
+        if (issues.Count > 0)
+            throw new ModelValidationException(issues);
     }
 
     #endregion

--- a/src/EdsDcfNet/CanOpenWriteOptions.cs
+++ b/src/EdsDcfNet/CanOpenWriteOptions.cs
@@ -1,0 +1,24 @@
+namespace EdsDcfNet;
+
+/// <summary>
+/// Optional behavior for <see cref="CanOpenFile"/> write operations.
+/// </summary>
+public sealed class CanOpenWriteOptions
+{
+    /// <summary>
+    /// Gets a default options instance with validation disabled.
+    /// </summary>
+    public static CanOpenWriteOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets an options instance that validates the model before writing.
+    /// </summary>
+    public static CanOpenWriteOptions Validated { get; } = new() { ValidateBeforeWrite = true };
+
+    /// <summary>
+    /// When <see langword="true"/>, write methods validate the model and throw
+    /// <see cref="Exceptions.ModelValidationException"/> when validation issues are found.
+    /// Default is <see langword="false"/> for backward compatibility.
+    /// </summary>
+    public bool ValidateBeforeWrite { get; init; }
+}

--- a/src/EdsDcfNet/Exceptions/ModelValidationException.cs
+++ b/src/EdsDcfNet/Exceptions/ModelValidationException.cs
@@ -30,7 +30,12 @@ public sealed class ModelValidationException : Exception
             return "Model validation failed.";
 
         if (issues.Count == 1)
-            return "Model validation failed: " + issues[0];
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Model validation failed: {0}",
+                issues[0]);
+        }
 
         return string.Format(
             CultureInfo.InvariantCulture,

--- a/src/EdsDcfNet/Exceptions/ModelValidationException.cs
+++ b/src/EdsDcfNet/Exceptions/ModelValidationException.cs
@@ -1,0 +1,41 @@
+namespace EdsDcfNet.Exceptions;
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using EdsDcfNet.Validation;
+
+/// <summary>
+/// Exception thrown when a model fails validation before a write operation.
+/// </summary>
+public sealed class ModelValidationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModelValidationException"/> class.
+    /// </summary>
+    /// <param name="issues">Validation issues that blocked the write operation.</param>
+    public ModelValidationException(IReadOnlyList<ValidationIssue> issues)
+        : base(BuildMessage(issues))
+    {
+        Issues = new ReadOnlyCollection<ValidationIssue>(issues.ToList());
+    }
+
+    /// <summary>
+    /// Gets the validation issues that blocked the write operation.
+    /// </summary>
+    public IReadOnlyList<ValidationIssue> Issues { get; }
+
+    private static string BuildMessage(IReadOnlyList<ValidationIssue> issues)
+    {
+        if (issues.Count == 0)
+            return "Model validation failed.";
+
+        if (issues.Count == 1)
+            return "Model validation failed: " + issues[0];
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed with {0} issue(s). First issue: {1}",
+            issues.Count,
+            issues[0]);
+    }
+}

--- a/src/EdsDcfNet/Models/NodelistProject.cs
+++ b/src/EdsDcfNet/Models/NodelistProject.cs
@@ -1,5 +1,7 @@
 namespace EdsDcfNet.Models;
 
+using EdsDcfNet.Validation;
+
 /// <summary>
 /// Represents a CiA 306-3 nodelist project (.cpj) file containing one or more network topologies.
 /// </summary>
@@ -18,4 +20,13 @@ public class NodelistProject
     /// </summary>
     public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; } =
         new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Validates this model instance against common CANopen constraints.
+    /// </summary>
+    /// <returns>List of validation issues. Empty when model is valid.</returns>
+    public IReadOnlyList<ValidationIssue> Validate()
+    {
+        return CanOpenModelValidator.Validate(this);
+    }
 }

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -661,12 +661,8 @@ public static class CanOpenModelValidator
 
     private static void ThrowIfNull(object? value, string paramName)
     {
-#if NET10_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value, paramName);
-#else
-        if (value == null)
+        if (value is null)
             throw new ArgumentNullException(paramName);
-#endif
     }
 
     private static void ValidateMaxLength(

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -344,13 +344,20 @@ public static class CanOpenModelValidator
                     functionTypePath + ".VersionInfos",
                     "At least one versionInfo entry is required."));
             }
+        }
 
+        var instanceIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
+        {
+            var functionType = applicationProcess.FunctionTypeList[index];
             if (functionType.FunctionInstanceList != null)
             {
+                var functionTypePath = path + ".FunctionTypeList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
                 ValidateFunctionInstanceList(
                     functionType.FunctionInstanceList,
                     functionTypePath + ".FunctionInstanceList",
                     functionTypeIds,
+                    instanceIds,
                     issues);
             }
         }
@@ -383,6 +390,7 @@ public static class CanOpenModelValidator
                 applicationProcess.FunctionInstanceList,
                 path + ".FunctionInstanceList",
                 functionTypeIds,
+                instanceIds,
                 issues);
         }
     }
@@ -427,9 +435,9 @@ public static class CanOpenModelValidator
         ApFunctionInstanceList instanceList,
         string path,
         HashSet<string> functionTypeIds,
+        HashSet<string> instanceIds,
         List<ValidationIssue> issues)
     {
-        var instanceIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < instanceList.FunctionInstances.Count; index++)
         {
             var instance = instanceList.FunctionInstances[index];

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -333,6 +333,8 @@ public static class CanOpenModelValidator
     {
         var allUniqueIds = new HashSet<string>(StringComparer.Ordinal);
         var dataTypeIds = new HashSet<string>(StringComparer.Ordinal);
+        var parameterTemplateIds = new HashSet<string>(StringComparer.Ordinal);
+        var allowedValuesTemplateIds = new HashSet<string>(StringComparer.Ordinal);
 
         if (applicationProcess.DataTypeList != null)
         {
@@ -352,13 +354,25 @@ public static class CanOpenModelValidator
                 allUniqueIds,
                 dataTypeIds,
                 issues);
+
+            foreach (var template in applicationProcess.TemplateList.ParameterTemplates)
+            {
+                if (!string.IsNullOrEmpty(template.UniqueId))
+                    parameterTemplateIds.Add(template.UniqueId);
+            }
+
+            foreach (var template in applicationProcess.TemplateList.AllowedValuesTemplates)
+            {
+                if (!string.IsNullOrEmpty(template.UniqueId))
+                    allowedValuesTemplateIds.Add(template.UniqueId);
+            }
         }
 
         var functionTypeIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
         {
             var functionType = applicationProcess.FunctionTypeList[index];
-            var functionTypePath = path + ".FunctionTypeList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var functionTypePath = IndexedPath(path + ".FunctionTypeList", index);
             RegisterUniqueId(functionType.UniqueId, functionTypePath + ".UniqueId", allUniqueIds, issues);
             if (!string.IsNullOrEmpty(functionType.UniqueId))
                 functionTypeIds.Add(functionType.UniqueId);
@@ -386,7 +400,7 @@ public static class CanOpenModelValidator
             var functionType = applicationProcess.FunctionTypeList[index];
             if (functionType.FunctionInstanceList != null)
             {
-                var functionTypePath = path + ".FunctionTypeList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+                var functionTypePath = IndexedPath(path + ".FunctionTypeList", index);
                 ValidateFunctionInstanceList(
                     functionType.FunctionInstanceList,
                     functionTypePath + ".FunctionInstanceList",
@@ -400,7 +414,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < applicationProcess.ParameterList.Count; index++)
         {
             var parameter = applicationProcess.ParameterList[index];
-            var parameterPath = path + ".ParameterList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var parameterPath = IndexedPath(path + ".ParameterList", index);
             RegisterUniqueId(
                 parameter.UniqueId,
                 parameterPath + ".UniqueId",
@@ -410,13 +424,26 @@ public static class CanOpenModelValidator
                 parameterIds.Add(parameter.UniqueId);
 
             ValidateDataTypeRef(parameter.TypeRef, parameterPath + ".TypeRef", dataTypeIds, issues);
+            ValidateParameterTemplateIdRef(
+                parameter.TemplateIdRef,
+                parameterPath + ".TemplateIdRef",
+                parameterTemplateIds,
+                issues);
+            if (parameter.AllowedValues != null)
+            {
+                ValidateAllowedValuesTemplateIdRef(
+                    parameter.AllowedValues.TemplateIdRef,
+                    parameterPath + ".AllowedValues.TemplateIdRef",
+                    allowedValuesTemplateIds,
+                    issues);
+            }
         }
 
         for (var index = 0; index < applicationProcess.ParameterGroupList.Count; index++)
         {
             ValidateParameterGroup(
                 applicationProcess.ParameterGroupList[index],
-                path + ".ParameterGroupList[" + index.ToString(CultureInfo.InvariantCulture) + "]",
+                IndexedPath(path + ".ParameterGroupList", index),
                 allUniqueIds,
                 parameterIds,
                 issues);
@@ -443,7 +470,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < dataTypeList.Arrays.Count; index++)
         {
             var arrayType = dataTypeList.Arrays[index];
-            var arrayPath = path + ".Arrays[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var arrayPath = IndexedPath(path + ".Arrays", index);
             RegisterUniqueId(arrayType.UniqueId, arrayPath + ".UniqueId", allUniqueIds, issues);
             if (!string.IsNullOrEmpty(arrayType.UniqueId))
                 dataTypeIds.Add(arrayType.UniqueId);
@@ -452,7 +479,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < dataTypeList.Structs.Count; index++)
         {
             var structType = dataTypeList.Structs[index];
-            var structPath = path + ".Structs[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var structPath = IndexedPath(path + ".Structs", index);
             RegisterUniqueId(structType.UniqueId, structPath + ".UniqueId", allUniqueIds, issues);
             if (!string.IsNullOrEmpty(structType.UniqueId))
                 dataTypeIds.Add(structType.UniqueId);
@@ -461,7 +488,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < dataTypeList.Enums.Count; index++)
         {
             var enumType = dataTypeList.Enums[index];
-            var enumPath = path + ".Enums[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var enumPath = IndexedPath(path + ".Enums", index);
             RegisterUniqueId(enumType.UniqueId, enumPath + ".UniqueId", allUniqueIds, issues);
             if (!string.IsNullOrEmpty(enumType.UniqueId))
                 dataTypeIds.Add(enumType.UniqueId);
@@ -470,7 +497,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < dataTypeList.Derived.Count; index++)
         {
             var derivedType = dataTypeList.Derived[index];
-            var derivedPath = path + ".Derived[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var derivedPath = IndexedPath(path + ".Derived", index);
             RegisterUniqueId(derivedType.UniqueId, derivedPath + ".UniqueId", allUniqueIds, issues);
             if (!string.IsNullOrEmpty(derivedType.UniqueId))
                 dataTypeIds.Add(derivedType.UniqueId);
@@ -488,7 +515,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < dataTypeList.Arrays.Count; index++)
         {
             var arrayType = dataTypeList.Arrays[index];
-            var arrayPath = path + ".Arrays[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var arrayPath = IndexedPath(path + ".Arrays", index);
             ValidateDataTypeRef(arrayType.ElementType, arrayPath + ".ElementType", dataTypeIds, issues);
         }
 
@@ -496,7 +523,7 @@ public static class CanOpenModelValidator
         {
             ValidateVarDeclarations(
                 dataTypeList.Structs[index].VarDeclarations,
-                path + ".Structs[" + index.ToString(CultureInfo.InvariantCulture) + "].VarDeclarations",
+                IndexedPath(path + ".Structs", index) + ".VarDeclarations",
                 allUniqueIds,
                 dataTypeIds,
                 issues);
@@ -504,7 +531,7 @@ public static class CanOpenModelValidator
 
         for (var index = 0; index < dataTypeList.Derived.Count; index++)
         {
-            var derivedPath = path + ".Derived[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var derivedPath = IndexedPath(path + ".Derived", index);
             ValidateDataTypeRef(
                 dataTypeList.Derived[index].BaseType,
                 derivedPath + ".BaseType",
@@ -523,7 +550,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < templateList.ParameterTemplates.Count; index++)
         {
             var template = templateList.ParameterTemplates[index];
-            var templatePath = path + ".ParameterTemplates[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var templatePath = IndexedPath(path + ".ParameterTemplates", index);
             RegisterUniqueId(template.UniqueId, templatePath + ".UniqueId", allUniqueIds, issues);
             ValidateDataTypeRef(template.TypeRef, templatePath + ".TypeRef", dataTypeIds, issues);
         }
@@ -531,7 +558,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < templateList.AllowedValuesTemplates.Count; index++)
         {
             var template = templateList.AllowedValuesTemplates[index];
-            var templatePath = path + ".AllowedValuesTemplates[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var templatePath = IndexedPath(path + ".AllowedValuesTemplates", index);
             RegisterUniqueId(template.UniqueId, templatePath + ".UniqueId", allUniqueIds, issues);
         }
     }
@@ -558,7 +585,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < varDeclarations.Count; index++)
         {
             var varDeclaration = varDeclarations[index];
-            var varPath = path + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var varPath = IndexedPath(path, index);
             RegisterUniqueId(varDeclaration.UniqueId, varPath + ".UniqueId", allUniqueIds, issues);
             ValidateDataTypeRef(varDeclaration.Type, varPath + ".Type", dataTypeIds, issues);
         }
@@ -580,6 +607,43 @@ public static class CanOpenModelValidator
                 "Data type reference '" + dataTypeIdRef + "' does not match any dataTypeList uniqueID."));
         }
     }
+
+    private static void ValidateParameterTemplateIdRef(
+        string? templateIdRef,
+        string path,
+        HashSet<string> parameterTemplateIds,
+        List<ValidationIssue> issues)
+    {
+        if (templateIdRef is not { Length: > 0 })
+            return;
+
+        if (!parameterTemplateIds.Contains(templateIdRef))
+        {
+            issues.Add(new ValidationIssue(
+                path,
+                "Parameter template reference '" + templateIdRef + "' does not match any parameterTemplate uniqueID."));
+        }
+    }
+
+    private static void ValidateAllowedValuesTemplateIdRef(
+        string? templateIdRef,
+        string path,
+        HashSet<string> allowedValuesTemplateIds,
+        List<ValidationIssue> issues)
+    {
+        if (templateIdRef is not { Length: > 0 })
+            return;
+
+        if (!allowedValuesTemplateIds.Contains(templateIdRef))
+        {
+            issues.Add(new ValidationIssue(
+                path,
+                "Allowed values template reference '" + templateIdRef + "' does not match any allowedValuesTemplate uniqueID."));
+        }
+    }
+
+    private static string IndexedPath(string path, int index)
+        => path + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
 
     private static void ValidateParameterGroup(
         ApParameterGroup group,
@@ -610,7 +674,7 @@ public static class CanOpenModelValidator
         {
             ValidateParameterGroup(
                 group.SubGroups[index],
-                path + ".SubGroups[" + index.ToString(CultureInfo.InvariantCulture) + "]",
+                IndexedPath(path + ".SubGroups", index),
                 allUniqueIds,
                 parameterIds,
                 issues);
@@ -627,7 +691,7 @@ public static class CanOpenModelValidator
         for (var index = 0; index < instanceList.FunctionInstances.Count; index++)
         {
             var instance = instanceList.FunctionInstances[index];
-            var instancePath = path + ".FunctionInstances[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            var instancePath = IndexedPath(path + ".FunctionInstances", index);
             RegisterUniqueId(instance.UniqueId, instancePath + ".UniqueId", allUniqueIds, issues);
 
             if (string.IsNullOrEmpty(instance.TypeIdRef))

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -331,12 +331,15 @@ public static class CanOpenModelValidator
         string path,
         List<ValidationIssue> issues)
     {
+        var allUniqueIds = new HashSet<string>(StringComparer.Ordinal);
         var functionTypeIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
         {
             var functionType = applicationProcess.FunctionTypeList[index];
             var functionTypePath = path + ".FunctionTypeList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
-            RegisterUniqueId(functionType.UniqueId, functionTypePath + ".UniqueId", functionTypeIds, issues);
+            RegisterUniqueId(functionType.UniqueId, functionTypePath + ".UniqueId", allUniqueIds, issues);
+            if (!string.IsNullOrEmpty(functionType.UniqueId))
+                functionTypeIds.Add(functionType.UniqueId);
 
             if (functionType.VersionInfos.Count == 0)
             {
@@ -346,7 +349,6 @@ public static class CanOpenModelValidator
             }
         }
 
-        var instanceIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
         {
             var functionType = applicationProcess.FunctionTypeList[index];
@@ -357,7 +359,7 @@ public static class CanOpenModelValidator
                     functionType.FunctionInstanceList,
                     functionTypePath + ".FunctionInstanceList",
                     functionTypeIds,
-                    instanceIds,
+                    allUniqueIds,
                     issues);
             }
         }
@@ -369,17 +371,18 @@ public static class CanOpenModelValidator
             RegisterUniqueId(
                 parameter.UniqueId,
                 path + ".ParameterList[" + index.ToString(CultureInfo.InvariantCulture) + "].UniqueId",
-                parameterIds,
+                allUniqueIds,
                 issues);
+            if (!string.IsNullOrEmpty(parameter.UniqueId))
+                parameterIds.Add(parameter.UniqueId);
         }
 
-        var parameterGroupIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < applicationProcess.ParameterGroupList.Count; index++)
         {
             ValidateParameterGroup(
                 applicationProcess.ParameterGroupList[index],
                 path + ".ParameterGroupList[" + index.ToString(CultureInfo.InvariantCulture) + "]",
-                parameterGroupIds,
+                allUniqueIds,
                 parameterIds,
                 issues);
         }
@@ -390,7 +393,7 @@ public static class CanOpenModelValidator
                 applicationProcess.FunctionInstanceList,
                 path + ".FunctionInstanceList",
                 functionTypeIds,
-                instanceIds,
+                allUniqueIds,
                 issues);
         }
     }
@@ -398,11 +401,11 @@ public static class CanOpenModelValidator
     private static void ValidateParameterGroup(
         ApParameterGroup group,
         string path,
-        HashSet<string> seenGroupIds,
+        HashSet<string> allUniqueIds,
         HashSet<string> parameterIds,
         List<ValidationIssue> issues)
     {
-        RegisterUniqueId(group.UniqueId, path + ".UniqueId", seenGroupIds, issues);
+        RegisterUniqueId(group.UniqueId, path + ".UniqueId", allUniqueIds, issues);
 
         foreach (var parameterRef in group.ParameterRefs)
         {
@@ -425,7 +428,7 @@ public static class CanOpenModelValidator
             ValidateParameterGroup(
                 group.SubGroups[index],
                 path + ".SubGroups[" + index.ToString(CultureInfo.InvariantCulture) + "]",
-                seenGroupIds,
+                allUniqueIds,
                 parameterIds,
                 issues);
         }
@@ -435,14 +438,14 @@ public static class CanOpenModelValidator
         ApFunctionInstanceList instanceList,
         string path,
         HashSet<string> functionTypeIds,
-        HashSet<string> instanceIds,
+        HashSet<string> allUniqueIds,
         List<ValidationIssue> issues)
     {
         for (var index = 0; index < instanceList.FunctionInstances.Count; index++)
         {
             var instance = instanceList.FunctionInstances[index];
             var instancePath = path + ".FunctionInstances[" + index.ToString(CultureInfo.InvariantCulture) + "]";
-            RegisterUniqueId(instance.UniqueId, instancePath + ".UniqueId", instanceIds, issues);
+            RegisterUniqueId(instance.UniqueId, instancePath + ".UniqueId", allUniqueIds, issues);
 
             if (string.IsNullOrEmpty(instance.TypeIdRef))
             {

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using EdsDcfNet.Models;
 
 /// <summary>
-/// Validates CANopen models against common CiA 306 constraints.
+/// Validates CANopen models against common CiA 306 and CiA 311 constraints.
 /// </summary>
 public static class CanOpenModelValidator
 {
@@ -35,6 +35,8 @@ public static class CanOpenModelValidator
         var issues = new List<ValidationIssue>();
         ValidateDeviceInfo(eds.DeviceInfo, issues);
         ValidateObjectDictionary(eds.ObjectDictionary, issues);
+        if (eds.ApplicationProcess != null)
+            ValidateApplicationProcess(eds.ApplicationProcess, "ApplicationProcess", issues);
 
         return new ReadOnlyCollection<ValidationIssue>(issues);
     }
@@ -52,6 +54,24 @@ public static class CanOpenModelValidator
         ValidateDeviceInfo(dcf.DeviceInfo, issues);
         ValidateObjectDictionary(dcf.ObjectDictionary, issues);
         ValidateDeviceCommissioning(dcf.DeviceCommissioning, issues);
+        if (dcf.ApplicationProcess != null)
+            ValidateApplicationProcess(dcf.ApplicationProcess, "ApplicationProcess", issues);
+
+        return new ReadOnlyCollection<ValidationIssue>(issues);
+    }
+
+    /// <summary>
+    /// Validates a <see cref="NodelistProject"/> instance.
+    /// </summary>
+    /// <param name="cpj">Model instance to validate.</param>
+    /// <returns>List of validation issues. Empty when model is valid.</returns>
+    public static IReadOnlyList<ValidationIssue> Validate(NodelistProject cpj)
+    {
+        ThrowIfNull(cpj, nameof(cpj));
+
+        var issues = new List<ValidationIssue>();
+        for (var networkIndex = 0; networkIndex < cpj.Networks.Count; networkIndex++)
+            ValidateNetworkTopology(cpj.Networks[networkIndex], "Networks[" + networkIndex.ToString(CultureInfo.InvariantCulture) + "]", issues);
 
         return new ReadOnlyCollection<ValidationIssue>(issues);
     }
@@ -252,6 +272,197 @@ public static class CanOpenModelValidator
                objectType == 0x7 ||
                objectType == 0x8 ||
                objectType == 0x9;
+    }
+
+    private static void ValidateNetworkTopology(
+        NetworkTopology network,
+        string path,
+        List<ValidationIssue> issues)
+    {
+        ValidateMaxLength(network.NetName, MaxNetworkNameLength, path + ".NetName", issues);
+        ValidateMaxLength(network.NetRefd, MaxReferenceNameLength, path + ".NetRefd", issues);
+
+        foreach (var kvp in network.Nodes.OrderBy(n => n.Key))
+        {
+            var nodePath = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}.Nodes[{1}]",
+                path,
+                kvp.Key);
+
+            if (kvp.Key < 1 || kvp.Key > 127)
+            {
+                issues.Add(new ValidationIssue(
+                    nodePath,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Node dictionary key {0} is outside the CANopen range 1..127.",
+                        kvp.Key)));
+            }
+
+            if (kvp.Key != kvp.Value.NodeId)
+            {
+                issues.Add(new ValidationIssue(
+                    nodePath + ".NodeId",
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "NodeId {0} does not match the dictionary key {1}.",
+                        kvp.Value.NodeId,
+                        kvp.Key)));
+            }
+
+            if (kvp.Value.NodeId < 1 || kvp.Value.NodeId > 127)
+            {
+                issues.Add(new ValidationIssue(
+                    nodePath + ".NodeId",
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Node-ID {0} is outside the CANopen range 1..127.",
+                        kvp.Value.NodeId)));
+            }
+
+            ValidateMaxLength(kvp.Value.Name, MaxNodeNameLength, nodePath + ".Name", issues);
+            ValidateMaxLength(kvp.Value.Refd, MaxReferenceNameLength, nodePath + ".Refd", issues);
+        }
+    }
+
+    private static void ValidateApplicationProcess(
+        ApplicationProcess applicationProcess,
+        string path,
+        List<ValidationIssue> issues)
+    {
+        var functionTypeIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
+        {
+            var functionType = applicationProcess.FunctionTypeList[index];
+            var functionTypePath = path + ".FunctionTypeList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(functionType.UniqueId, functionTypePath + ".UniqueId", functionTypeIds, issues);
+
+            if (functionType.VersionInfos.Count == 0)
+            {
+                issues.Add(new ValidationIssue(
+                    functionTypePath + ".VersionInfos",
+                    "At least one versionInfo entry is required."));
+            }
+
+            if (functionType.FunctionInstanceList != null)
+            {
+                ValidateFunctionInstanceList(
+                    functionType.FunctionInstanceList,
+                    functionTypePath + ".FunctionInstanceList",
+                    functionTypeIds,
+                    issues);
+            }
+        }
+
+        var parameterIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < applicationProcess.ParameterList.Count; index++)
+        {
+            var parameter = applicationProcess.ParameterList[index];
+            RegisterUniqueId(
+                parameter.UniqueId,
+                path + ".ParameterList[" + index.ToString(CultureInfo.InvariantCulture) + "].UniqueId",
+                parameterIds,
+                issues);
+        }
+
+        var parameterGroupIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < applicationProcess.ParameterGroupList.Count; index++)
+        {
+            ValidateParameterGroup(
+                applicationProcess.ParameterGroupList[index],
+                path + ".ParameterGroupList[" + index.ToString(CultureInfo.InvariantCulture) + "]",
+                parameterGroupIds,
+                parameterIds,
+                issues);
+        }
+
+        if (applicationProcess.FunctionInstanceList != null)
+        {
+            ValidateFunctionInstanceList(
+                applicationProcess.FunctionInstanceList,
+                path + ".FunctionInstanceList",
+                functionTypeIds,
+                issues);
+        }
+    }
+
+    private static void ValidateParameterGroup(
+        ApParameterGroup group,
+        string path,
+        HashSet<string> seenGroupIds,
+        HashSet<string> parameterIds,
+        List<ValidationIssue> issues)
+    {
+        RegisterUniqueId(group.UniqueId, path + ".UniqueId", seenGroupIds, issues);
+
+        foreach (var parameterRef in group.ParameterRefs)
+        {
+            if (string.IsNullOrEmpty(parameterRef))
+            {
+                issues.Add(new ValidationIssue(path + ".ParameterRefs", "Parameter reference must not be empty."));
+                continue;
+            }
+
+            if (!parameterIds.Contains(parameterRef))
+            {
+                issues.Add(new ValidationIssue(
+                    path + ".ParameterRefs",
+                    "Parameter reference '" + parameterRef + "' does not match any parameter uniqueID."));
+            }
+        }
+
+        for (var index = 0; index < group.SubGroups.Count; index++)
+        {
+            ValidateParameterGroup(
+                group.SubGroups[index],
+                path + ".SubGroups[" + index.ToString(CultureInfo.InvariantCulture) + "]",
+                seenGroupIds,
+                parameterIds,
+                issues);
+        }
+    }
+
+    private static void ValidateFunctionInstanceList(
+        ApFunctionInstanceList instanceList,
+        string path,
+        HashSet<string> functionTypeIds,
+        List<ValidationIssue> issues)
+    {
+        var instanceIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < instanceList.FunctionInstances.Count; index++)
+        {
+            var instance = instanceList.FunctionInstances[index];
+            var instancePath = path + ".FunctionInstances[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(instance.UniqueId, instancePath + ".UniqueId", instanceIds, issues);
+
+            if (string.IsNullOrEmpty(instance.TypeIdRef))
+            {
+                issues.Add(new ValidationIssue(instancePath + ".TypeIdRef", "Function instance type reference must not be empty."));
+            }
+            else if (!functionTypeIds.Contains(instance.TypeIdRef))
+            {
+                issues.Add(new ValidationIssue(
+                    instancePath + ".TypeIdRef",
+                    "Function instance references unknown function type '" + instance.TypeIdRef + "'."));
+            }
+        }
+    }
+
+    private static void RegisterUniqueId(
+        string uniqueId,
+        string path,
+        HashSet<string> seenIds,
+        List<ValidationIssue> issues)
+    {
+        if (string.IsNullOrEmpty(uniqueId))
+        {
+            issues.Add(new ValidationIssue(path, "Unique ID must not be empty."));
+            return;
+        }
+
+        if (!seenIds.Add(uniqueId))
+            issues.Add(new ValidationIssue(path, "Duplicate unique ID '" + uniqueId + "'."));
     }
 
     private static void ThrowIfNull(object? value, string paramName)

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -570,14 +570,14 @@ public static class CanOpenModelValidator
         HashSet<string> dataTypeIds,
         List<ValidationIssue> issues)
     {
-        if (typeRef == null || string.IsNullOrEmpty(typeRef.DataTypeIdRef))
+        if (typeRef?.DataTypeIdRef is not { Length: > 0 } dataTypeIdRef)
             return;
 
-        if (!dataTypeIds.Contains(typeRef.DataTypeIdRef))
+        if (!dataTypeIds.Contains(dataTypeIdRef))
         {
             issues.Add(new ValidationIssue(
                 path,
-                "Data type reference '" + typeRef.DataTypeIdRef + "' does not match any dataTypeList uniqueID."));
+                "Data type reference '" + dataTypeIdRef + "' does not match any dataTypeList uniqueID."));
         }
     }
 

--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -332,6 +332,28 @@ public static class CanOpenModelValidator
         List<ValidationIssue> issues)
     {
         var allUniqueIds = new HashSet<string>(StringComparer.Ordinal);
+        var dataTypeIds = new HashSet<string>(StringComparer.Ordinal);
+
+        if (applicationProcess.DataTypeList != null)
+        {
+            ValidateDataTypeList(
+                applicationProcess.DataTypeList,
+                path + ".DataTypeList",
+                allUniqueIds,
+                dataTypeIds,
+                issues);
+        }
+
+        if (applicationProcess.TemplateList != null)
+        {
+            ValidateTemplateList(
+                applicationProcess.TemplateList,
+                path + ".TemplateList",
+                allUniqueIds,
+                dataTypeIds,
+                issues);
+        }
+
         var functionTypeIds = new HashSet<string>(StringComparer.Ordinal);
         for (var index = 0; index < applicationProcess.FunctionTypeList.Count; index++)
         {
@@ -346,6 +368,16 @@ public static class CanOpenModelValidator
                 issues.Add(new ValidationIssue(
                     functionTypePath + ".VersionInfos",
                     "At least one versionInfo entry is required."));
+            }
+
+            if (functionType.InterfaceList != null)
+            {
+                ValidateInterfaceList(
+                    functionType.InterfaceList,
+                    functionTypePath + ".InterfaceList",
+                    allUniqueIds,
+                    dataTypeIds,
+                    issues);
             }
         }
 
@@ -368,13 +400,16 @@ public static class CanOpenModelValidator
         for (var index = 0; index < applicationProcess.ParameterList.Count; index++)
         {
             var parameter = applicationProcess.ParameterList[index];
+            var parameterPath = path + ".ParameterList[" + index.ToString(CultureInfo.InvariantCulture) + "]";
             RegisterUniqueId(
                 parameter.UniqueId,
-                path + ".ParameterList[" + index.ToString(CultureInfo.InvariantCulture) + "].UniqueId",
+                parameterPath + ".UniqueId",
                 allUniqueIds,
                 issues);
             if (!string.IsNullOrEmpty(parameter.UniqueId))
                 parameterIds.Add(parameter.UniqueId);
+
+            ValidateDataTypeRef(parameter.TypeRef, parameterPath + ".TypeRef", dataTypeIds, issues);
         }
 
         for (var index = 0; index < applicationProcess.ParameterGroupList.Count; index++)
@@ -395,6 +430,154 @@ public static class CanOpenModelValidator
                 functionTypeIds,
                 allUniqueIds,
                 issues);
+        }
+    }
+
+    private static void ValidateDataTypeList(
+        ApDataTypeList dataTypeList,
+        string path,
+        HashSet<string> allUniqueIds,
+        HashSet<string> dataTypeIds,
+        List<ValidationIssue> issues)
+    {
+        for (var index = 0; index < dataTypeList.Arrays.Count; index++)
+        {
+            var arrayType = dataTypeList.Arrays[index];
+            var arrayPath = path + ".Arrays[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(arrayType.UniqueId, arrayPath + ".UniqueId", allUniqueIds, issues);
+            if (!string.IsNullOrEmpty(arrayType.UniqueId))
+                dataTypeIds.Add(arrayType.UniqueId);
+        }
+
+        for (var index = 0; index < dataTypeList.Structs.Count; index++)
+        {
+            var structType = dataTypeList.Structs[index];
+            var structPath = path + ".Structs[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(structType.UniqueId, structPath + ".UniqueId", allUniqueIds, issues);
+            if (!string.IsNullOrEmpty(structType.UniqueId))
+                dataTypeIds.Add(structType.UniqueId);
+        }
+
+        for (var index = 0; index < dataTypeList.Enums.Count; index++)
+        {
+            var enumType = dataTypeList.Enums[index];
+            var enumPath = path + ".Enums[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(enumType.UniqueId, enumPath + ".UniqueId", allUniqueIds, issues);
+            if (!string.IsNullOrEmpty(enumType.UniqueId))
+                dataTypeIds.Add(enumType.UniqueId);
+        }
+
+        for (var index = 0; index < dataTypeList.Derived.Count; index++)
+        {
+            var derivedType = dataTypeList.Derived[index];
+            var derivedPath = path + ".Derived[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(derivedType.UniqueId, derivedPath + ".UniqueId", allUniqueIds, issues);
+            if (!string.IsNullOrEmpty(derivedType.UniqueId))
+                dataTypeIds.Add(derivedType.UniqueId);
+
+            if (derivedType.Count != null)
+            {
+                RegisterUniqueId(
+                    derivedType.Count.UniqueId,
+                    derivedPath + ".Count.UniqueId",
+                    allUniqueIds,
+                    issues);
+            }
+        }
+
+        for (var index = 0; index < dataTypeList.Arrays.Count; index++)
+        {
+            var arrayType = dataTypeList.Arrays[index];
+            var arrayPath = path + ".Arrays[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            ValidateDataTypeRef(arrayType.ElementType, arrayPath + ".ElementType", dataTypeIds, issues);
+        }
+
+        for (var index = 0; index < dataTypeList.Structs.Count; index++)
+        {
+            ValidateVarDeclarations(
+                dataTypeList.Structs[index].VarDeclarations,
+                path + ".Structs[" + index.ToString(CultureInfo.InvariantCulture) + "].VarDeclarations",
+                allUniqueIds,
+                dataTypeIds,
+                issues);
+        }
+
+        for (var index = 0; index < dataTypeList.Derived.Count; index++)
+        {
+            var derivedPath = path + ".Derived[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            ValidateDataTypeRef(
+                dataTypeList.Derived[index].BaseType,
+                derivedPath + ".BaseType",
+                dataTypeIds,
+                issues);
+        }
+    }
+
+    private static void ValidateTemplateList(
+        ApTemplateList templateList,
+        string path,
+        HashSet<string> allUniqueIds,
+        HashSet<string> dataTypeIds,
+        List<ValidationIssue> issues)
+    {
+        for (var index = 0; index < templateList.ParameterTemplates.Count; index++)
+        {
+            var template = templateList.ParameterTemplates[index];
+            var templatePath = path + ".ParameterTemplates[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(template.UniqueId, templatePath + ".UniqueId", allUniqueIds, issues);
+            ValidateDataTypeRef(template.TypeRef, templatePath + ".TypeRef", dataTypeIds, issues);
+        }
+
+        for (var index = 0; index < templateList.AllowedValuesTemplates.Count; index++)
+        {
+            var template = templateList.AllowedValuesTemplates[index];
+            var templatePath = path + ".AllowedValuesTemplates[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(template.UniqueId, templatePath + ".UniqueId", allUniqueIds, issues);
+        }
+    }
+
+    private static void ValidateInterfaceList(
+        ApInterfaceList interfaceList,
+        string path,
+        HashSet<string> allUniqueIds,
+        HashSet<string> dataTypeIds,
+        List<ValidationIssue> issues)
+    {
+        ValidateVarDeclarations(interfaceList.InputVars, path + ".InputVars", allUniqueIds, dataTypeIds, issues);
+        ValidateVarDeclarations(interfaceList.OutputVars, path + ".OutputVars", allUniqueIds, dataTypeIds, issues);
+        ValidateVarDeclarations(interfaceList.ConfigVars, path + ".ConfigVars", allUniqueIds, dataTypeIds, issues);
+    }
+
+    private static void ValidateVarDeclarations(
+        List<ApVarDeclaration> varDeclarations,
+        string path,
+        HashSet<string> allUniqueIds,
+        HashSet<string> dataTypeIds,
+        List<ValidationIssue> issues)
+    {
+        for (var index = 0; index < varDeclarations.Count; index++)
+        {
+            var varDeclaration = varDeclarations[index];
+            var varPath = path + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+            RegisterUniqueId(varDeclaration.UniqueId, varPath + ".UniqueId", allUniqueIds, issues);
+            ValidateDataTypeRef(varDeclaration.Type, varPath + ".Type", dataTypeIds, issues);
+        }
+    }
+
+    private static void ValidateDataTypeRef(
+        ApTypeRef? typeRef,
+        string path,
+        HashSet<string> dataTypeIds,
+        List<ValidationIssue> issues)
+    {
+        if (typeRef == null || string.IsNullOrEmpty(typeRef.DataTypeIdRef))
+            return;
+
+        if (!dataTypeIds.Contains(typeRef.DataTypeIdRef))
+        {
+            issues.Add(new ValidationIssue(
+                path,
+                "Data type reference '" + typeRef.DataTypeIdRef + "' does not match any dataTypeList uniqueID."));
         }
     }
 

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -13,6 +13,7 @@ public class ModelValidationExceptionTests
         var exception = new ModelValidationException(issues);
 
         exception.Message.Should().Contain("DeviceCommissioning.NodeId");
+        exception.Message.Should().Be("Model validation failed: " + issues[0]);
         exception.Issues.Should().ContainSingle();
     }
 

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet.Tests.Exceptions;
 
+using System.Globalization;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Validation;
 
@@ -29,6 +30,11 @@ public class ModelValidationExceptionTests
         var exception = new ModelValidationException(issues);
 
         exception.Message.Should().Contain("2 issue(s)");
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed with {0} issue(s). First issue: {1}",
+            2,
+            issues[0]));
         exception.Issues.Should().HaveCount(2);
     }
 

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -39,4 +39,15 @@ public class ModelValidationExceptionTests
         exception.Message.Should().Be("Model validation failed.");
         exception.Issues.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Issues_ReturnsSnapshotNotLiveList()
+    {
+        var issues = new List<ValidationIssue> { new("Path", "Message") };
+        var exception = new ModelValidationException(issues);
+
+        issues.Add(new ValidationIssue("Other", "Changed"));
+
+        exception.Issues.Should().ContainSingle();
+    }
 }

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -1,0 +1,33 @@
+namespace EdsDcfNet.Tests.Exceptions;
+
+using EdsDcfNet.Exceptions;
+using EdsDcfNet.Validation;
+
+public class ModelValidationExceptionTests
+{
+    [Fact]
+    public void Constructor_WithSingleIssue_FormatsMessage()
+    {
+        var issues = new[] { new ValidationIssue("DeviceCommissioning.NodeId", "Invalid node id.") };
+
+        var exception = new ModelValidationException(issues);
+
+        exception.Message.Should().Contain("DeviceCommissioning.NodeId");
+        exception.Issues.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Constructor_WithMultipleIssues_IncludesCountInMessage()
+    {
+        var issues = new[]
+        {
+            new ValidationIssue("A", "First"),
+            new ValidationIssue("B", "Second")
+        };
+
+        var exception = new ModelValidationException(issues);
+
+        exception.Message.Should().Contain("2 issue(s)");
+        exception.Issues.Should().HaveCount(2);
+    }
+}

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -30,4 +30,13 @@ public class ModelValidationExceptionTests
         exception.Message.Should().Contain("2 issue(s)");
         exception.Issues.Should().HaveCount(2);
     }
+
+    [Fact]
+    public void Constructor_WithNoIssues_UsesDefaultMessage()
+    {
+        var exception = new ModelValidationException(Array.Empty<ValidationIssue>());
+
+        exception.Message.Should().Be("Model validation failed.");
+        exception.Issues.Should().BeEmpty();
+    }
 }

--- a/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
+++ b/tests/EdsDcfNet.Tests/Exceptions/ModelValidationExceptionTests.cs
@@ -1,7 +1,10 @@
 namespace EdsDcfNet.Tests.Exceptions;
 
+using System.Collections.ObjectModel;
 using System.Globalization;
+using EdsDcfNet;
 using EdsDcfNet.Exceptions;
+using EdsDcfNet.Models;
 using EdsDcfNet.Validation;
 
 public class ModelValidationExceptionTests
@@ -14,7 +17,10 @@ public class ModelValidationExceptionTests
         var exception = new ModelValidationException(issues);
 
         exception.Message.Should().Contain("DeviceCommissioning.NodeId");
-        exception.Message.Should().Be("Model validation failed: " + issues[0]);
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed: {0}",
+            issues[0]));
         exception.Issues.Should().ContainSingle();
     }
 
@@ -56,5 +62,38 @@ public class ModelValidationExceptionTests
         issues.Add(new ValidationIssue("Other", "Changed"));
 
         exception.Issues.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Constructor_WithSingleIssueFromReadOnlyCollection_FormatsMessageAndSnapshotsIssues()
+    {
+        var issues = new ReadOnlyCollection<ValidationIssue>(
+            new List<ValidationIssue> { new("DeviceCommissioning.NodeId", "Invalid node id.") });
+
+        var exception = new ModelValidationException(issues);
+
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed: {0}",
+            issues[0]));
+        exception.Issues.Should().ContainSingle().Which.Should().Be(issues[0]);
+    }
+
+    [Fact]
+    public void EnsureValid_SingleIssueFromValidationReadOnlyCollection_FormatsMessageAndIssues()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.EnsureValid(dcf);
+
+        var exception = act.Should().Throw<ModelValidationException>().Which;
+        exception.Issues.Should().ContainSingle();
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed: {0}",
+            exception.Issues[0]));
     }
 }

--- a/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/CanOpenFileTests.cs
@@ -2057,5 +2057,58 @@ PDOMapping=0
         issues.Should().BeEmpty();
     }
 
+    [Fact]
+    public void WriteDcfToString_WithValidatedOptions_ThrowsModelValidationExceptionForInvalidModel()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.WriteDcfToString(dcf, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>()
+            .Which.Issues.Should().Contain(i => i.Path == "DeviceCommissioning.NodeId");
+    }
+
+    [Fact]
+    public void WriteDcfToString_WithoutValidation_AllowsInvalidModelForBackwardCompatibility()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.WriteDcfToString(dcf);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureValid_InvalidDcf_ThrowsModelValidationExceptionWithIssues()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 0, Baudrate = 42 }
+        };
+
+        var act = () => CanOpenFile.EnsureValid(dcf);
+
+        act.Should().Throw<ModelValidationException>()
+            .Which.Issues.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WriteCpjToString_WithValidatedOptions_ThrowsForInvalidNodeId()
+    {
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        var act = () => CanOpenFile.WriteCpjToString(cpj, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
     #endregion
 }

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -17,6 +17,36 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public void EnsureValid_SingleIssueDcf_FormatsModelValidationExceptionMessage()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.EnsureValid(dcf);
+
+        var exception = act.Should().Throw<ModelValidationException>().Which;
+        exception.Issues.Should().ContainSingle();
+        exception.Message.Should().Be("Model validation failed: " + exception.Issues[0]);
+    }
+
+    [Fact]
+    public void WriteDcfToString_WithValidatedOptions_SingleIssue_FormatsModelValidationExceptionMessage()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.WriteDcfToString(dcf, CanOpenWriteOptions.Validated);
+
+        var exception = act.Should().Throw<ModelValidationException>().Which;
+        exception.Issues.Should().ContainSingle();
+        exception.Message.Should().Be("Model validation failed: " + exception.Issues[0]);
+    }
+
+    [Fact]
     public void EnsureValid_InvalidEds_ThrowsModelValidationException()
     {
         var eds = new ElectronicDataSheet();

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet.Tests.Integration;
 
+using System.Globalization;
 using EdsDcfNet;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
@@ -28,7 +29,10 @@ public class WriteValidationGuardTests
 
         var exception = act.Should().Throw<ModelValidationException>().Which;
         exception.Issues.Should().ContainSingle();
-        exception.Message.Should().Be("Model validation failed: " + exception.Issues[0]);
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed: {0}",
+            exception.Issues[0]));
     }
 
     [Fact]
@@ -43,7 +47,10 @@ public class WriteValidationGuardTests
 
         var exception = act.Should().Throw<ModelValidationException>().Which;
         exception.Issues.Should().ContainSingle();
-        exception.Message.Should().Be("Model validation failed: " + exception.Issues[0]);
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.InvariantCulture,
+            "Model validation failed: {0}",
+            exception.Issues[0]));
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -1,0 +1,167 @@
+namespace EdsDcfNet.Tests.Integration;
+
+using EdsDcfNet;
+using EdsDcfNet.Exceptions;
+using EdsDcfNet.Models;
+
+public class WriteValidationGuardTests
+{
+    [Fact]
+    public void EnsureValid_ValidDcf_DoesNotThrow()
+    {
+        var dcf = CreateValidDcf();
+
+        var act = () => CanOpenFile.EnsureValid(dcf);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureValid_InvalidEds_ThrowsModelValidationException()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.MandatoryObjects.Add(0x1000);
+
+        var act = () => CanOpenFile.EnsureValid(eds);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void EnsureValid_InvalidCpj_ThrowsModelValidationException()
+    {
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        var act = () => CanOpenFile.EnsureValid(cpj);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteEdsToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        var act = () => CanOpenFile.WriteEdsToString(eds, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteXddToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var xdd = new ElectronicDataSheet();
+        xdd.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        var act = () => CanOpenFile.WriteXddToString(xdd, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteXdcToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var xdc = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.WriteXdcToString(xdc, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteDcf_WithValidatedStreamOverload_ThrowsForInvalidModel()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteDcf(dcf, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteCpj_WithValidatedFileOverload_ThrowsForInvalidModel()
+    {
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var act = () => CanOpenFile.WriteCpj(cpj, tempFile, CanOpenWriteOptions.Validated);
+
+            act.Should().Throw<ModelValidationException>();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteEds_WithValidatedOptions_AllowsValidModel()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly
+        };
+
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteEds(eds, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().NotThrow();
+    }
+
+    private static DeviceConfigurationFile CreateValidDcf()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning
+            {
+                NodeId = 5,
+                Baudrate = 500
+            }
+        };
+
+        dcf.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        dcf.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly
+        };
+
+        return dcf;
+    }
+}

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -276,6 +276,86 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public void WriteWithDefaultOptions_SkipsValidationForInvalidModel()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.WriteDcfToString(dcf, CanOpenWriteOptions.Default);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void WriteXdd_WithValidatedOptions_Stream_Succeeds()
+    {
+        var xdd = CreateValidEds();
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteXdd(xdd, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().NotThrow();
+        stream.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void WriteXdd_WithValidatedOptions_Stream_ThrowsForInvalidModel()
+    {
+        var xdd = new ElectronicDataSheet();
+        xdd.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteXdd(xdd, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteXdc_WithValidatedOptions_Stream_Succeeds()
+    {
+        var xdc = CreateValidDcf();
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteXdc(xdc, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().NotThrow();
+        stream.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void WriteXdc_WithValidatedOptions_Stream_ThrowsForInvalidModel()
+    {
+        var xdc = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteXdc(xdc, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void WriteDcf_WithValidatedOptions_Stream_Succeeds()
+    {
+        var dcf = CreateValidDcf();
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteDcf(dcf, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().NotThrow();
+        stream.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     public void WriteEds_WithValidatedOptions_AllowsValidModel()
     {
         var eds = new ElectronicDataSheet();

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -93,6 +93,37 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public async Task WriteEdsAsync_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        using var stream = new MemoryStream();
+        var act = () => CanOpenFile.WriteEdsAsync(eds, stream, CanOpenWriteOptions.Validated);
+
+        await act.Should().ThrowAsync<ModelValidationException>();
+    }
+
+    [Fact]
+    public async Task WriteDcfAsync_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        using var stream = new MemoryStream();
+        var act = () => CanOpenFile.WriteDcfAsync(dcf, stream, CanOpenWriteOptions.Validated);
+
+        await act.Should().ThrowAsync<ModelValidationException>();
+    }
+
+    [Fact]
     public void WriteXddToString_WithValidatedOptions_ThrowsForInvalidModel()
     {
         var xdd = new ElectronicDataSheet();

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -289,6 +289,34 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public void WriteEdsToString_WithDefaultOptions_SkipsValidationForInvalidModel()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        var act = () => CanOpenFile.WriteEdsToString(eds, CanOpenWriteOptions.Default);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void WriteCpjToString_WithDefaultOptions_SkipsValidationForInvalidModel()
+    {
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        var act = () => CanOpenFile.WriteCpjToString(cpj, CanOpenWriteOptions.Default);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void WriteXdd_WithValidatedOptions_Stream_Succeeds()
     {
         var xdd = CreateValidEds();

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -121,6 +121,161 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public void EnsureValid_ValidEds_DoesNotThrow()
+    {
+        var eds = CreateValidEds();
+
+        var act = () => CanOpenFile.EnsureValid(eds);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureValid_ValidCpj_DoesNotThrow()
+    {
+        var cpj = CreateValidCpj();
+
+        var act = () => CanOpenFile.EnsureValid(cpj);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_CpjFacade_ReturnsNoIssuesForValidModel()
+    {
+        var cpj = CreateValidCpj();
+
+        CanOpenFile.Validate(cpj).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WriteEds_WithValidatedOptions_FilePath_Succeeds()
+    {
+        var eds = CreateValidEds();
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var act = () => CanOpenFile.WriteEds(eds, tempFile, CanOpenWriteOptions.Validated);
+
+            act.Should().NotThrow();
+            File.Exists(tempFile).Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteEdsToString_WithValidatedOptions_ValidModel_ReturnsContent()
+    {
+        var eds = CreateValidEds();
+
+        var content = CanOpenFile.WriteEdsToString(eds, CanOpenWriteOptions.Validated);
+
+        content.Should().Contain("[FileInfo]");
+    }
+
+    [Fact]
+    public void WriteDcf_WithValidatedOptions_FilePath_Succeeds()
+    {
+        var dcf = CreateValidDcf();
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var act = () => CanOpenFile.WriteDcf(dcf, tempFile, CanOpenWriteOptions.Validated);
+
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteDcfToString_WithValidatedOptions_ValidModel_ReturnsContent()
+    {
+        var content = CanOpenFile.WriteDcfToString(CreateValidDcf(), CanOpenWriteOptions.Validated);
+
+        content.Should().Contain("[DeviceCommissioning]");
+    }
+
+    [Fact]
+    public void WriteCpj_WithValidatedOptions_Stream_Succeeds()
+    {
+        var cpj = CreateValidCpj();
+        using var stream = new MemoryStream();
+
+        var act = () => CanOpenFile.WriteCpj(cpj, stream, CanOpenWriteOptions.Validated);
+
+        act.Should().NotThrow();
+        stream.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void WriteCpjToString_WithValidatedOptions_ValidModel_ReturnsContent()
+    {
+        var content = CanOpenFile.WriteCpjToString(CreateValidCpj(), CanOpenWriteOptions.Validated);
+
+        content.Should().Contain("[Topology]");
+    }
+
+    [Fact]
+    public void WriteXdd_WithValidatedOptions_FilePath_Succeeds()
+    {
+        var xdd = CreateValidEds();
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var act = () => CanOpenFile.WriteXdd(xdd, tempFile, CanOpenWriteOptions.Validated);
+
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteXddToString_WithValidatedOptions_ValidModel_ReturnsContent()
+    {
+        var content = CanOpenFile.WriteXddToString(CreateValidEds(), CanOpenWriteOptions.Validated);
+
+        content.Should().Contain("ISO15745ProfileContainer");
+    }
+
+    [Fact]
+    public void WriteXdc_WithValidatedOptions_FilePath_Succeeds()
+    {
+        var xdc = CreateValidDcf();
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var act = () => CanOpenFile.WriteXdc(xdc, tempFile, CanOpenWriteOptions.Validated);
+
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteXdcToString_WithValidatedOptions_ValidModel_ReturnsContent()
+    {
+        var content = CanOpenFile.WriteXdcToString(CreateValidDcf(), CanOpenWriteOptions.Validated);
+
+        content.Should().Contain("ISO15745ProfileContainer");
+    }
+
+    [Fact]
     public void WriteEds_WithValidatedOptions_AllowsValidModel()
     {
         var eds = new ElectronicDataSheet();
@@ -163,5 +318,30 @@ public class WriteValidationGuardTests
         };
 
         return dcf;
+    }
+
+    private static ElectronicDataSheet CreateValidEds()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly
+        };
+
+        return eds;
+    }
+
+    private static NodelistProject CreateValidCpj()
+    {
+        var cpj = new NodelistProject();
+        var network = new NetworkTopology { NetName = "Main Network" };
+        network.Nodes[2] = new NetworkNode { NodeId = 2, Present = true, Name = "Node-2" };
+        cpj.Networks.Add(network);
+        return cpj;
     }
 }

--- a/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
@@ -222,6 +222,7 @@ public class ApplicationProcessValidationCoverageTests
         var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
         ap.DataTypeList.Arrays.Add(new ApArrayType { Name = "Buf" });
         ap.DataTypeList.Enums.Add(new ApEnumType { Name = "Mode" });
+        ap.DataTypeList.Structs.Add(new ApStructType { Name = "Container" });
         ap.DataTypeList.Derived.Add(new ApDerivedType
         {
             Name = "Alias",
@@ -233,8 +234,63 @@ public class ApplicationProcessValidationCoverageTests
 
         issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Arrays[0].UniqueId");
         issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Enums[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Structs[0].UniqueId");
         issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Derived[0].UniqueId");
         issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Derived[0].Count.UniqueId");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithNullDataTypeIdRef_ReturnsNoTypeRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = null }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path.Contains("TypeRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ConfigVarWithValidDataTypeIdRef_ReturnsNoTypeRefIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Enums.Add(new ApEnumType { UniqueId = "DT_ENUM", Name = "Mode" });
+
+        var functionType = new ApFunctionType { UniqueId = "FT_1", Name = "Ctrl" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.InterfaceList = new ApInterfaceList();
+        functionType.InterfaceList.ConfigVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_CFG",
+            Name = "Cfg",
+            Type = new ApTypeRef { DataTypeIdRef = "DT_ENUM" }
+        });
+        ap.FunctionTypeList.Add(functionType);
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i =>
+            i.Path == "ApplicationProcess.FunctionTypeList[0].InterfaceList.ConfigVars[0].Type");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_DerivedWithoutCount_ReturnsNoCountUniqueIdIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            UniqueId = "DT_DERIVED",
+            Name = "Alias",
+            BaseType = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path.Contains(".Count.", StringComparison.Ordinal));
     }
 
     private static IReadOnlyList<ValidationIssue> ValidateEdsApplicationProcess(ApplicationProcess applicationProcess)

--- a/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
@@ -78,6 +78,55 @@ public class ApplicationProcessValidationCoverageTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_ParameterWithNullTypeRef_ReturnsNoTypeRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter { UniqueId = "P_1", TypeRef = null });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path.Contains("TypeRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithEmptyDataTypeIdRef_ReturnsNoTypeRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = string.Empty }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path.Contains("TypeRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_OutputVarWithValidDataTypeIdRef_ReturnsNoTypeRefIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Structs.Add(new ApStructType { UniqueId = "DT_STRUCT", Name = "Status" });
+
+        var functionType = new ApFunctionType { UniqueId = "FT_1", Name = "Ctrl" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.InterfaceList = new ApInterfaceList();
+        functionType.InterfaceList.OutputVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_OUT",
+            Name = "Out",
+            Type = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+        ap.FunctionTypeList.Add(functionType);
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i =>
+            i.Path == "ApplicationProcess.FunctionTypeList[0].InterfaceList.OutputVars[0].Type");
+    }
+
+    [Fact]
     public void Validate_ApplicationProcess_TemplateParameterMissingDataTypeRef_ReturnIssue()
     {
         var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };

--- a/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
@@ -1,0 +1,302 @@
+namespace EdsDcfNet.Tests.Models;
+
+using EdsDcfNet.Models;
+using EdsDcfNet.Validation;
+
+public class ApplicationProcessValidationCoverageTests
+{
+    [Fact]
+    public void Validate_FullyPopulatedApplicationProcess_ReturnsNoApplicationProcessIssues()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = BuildValidApplicationProcess() };
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().NotContain(i => i.Path.StartsWith("ApplicationProcess", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_DcfWithFullyPopulatedApplicationProcess_ReturnsNoApplicationProcessIssues()
+    {
+        var dcf = CreateValidDcf();
+        dcf.ApplicationProcess = BuildValidApplicationProcess();
+
+        var issues = CanOpenModelValidator.Validate(dcf);
+
+        issues.Should().NotContain(i => i.Path.StartsWith("ApplicationProcess", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ArrayElementTypeMissingDataTypeRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Arrays.Add(new ApArrayType
+        {
+            UniqueId = "DT_ARRAY",
+            Name = "Buf",
+            ElementType = new ApTypeRef { DataTypeIdRef = "MissingType" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Arrays[0].ElementType");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_DerivedBaseTypeMissingDataTypeRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            UniqueId = "DT_DERIVED",
+            Name = "Alias",
+            BaseType = new ApTypeRef { DataTypeIdRef = "MissingBase" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Derived[0].BaseType");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_StructVarDeclarationMissingDataTypeRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        var structType = new ApStructType { UniqueId = "DT_STRUCT", Name = "Container" };
+        structType.VarDeclarations.Add(new ApVarDeclaration
+        {
+            UniqueId = "VAR_1",
+            Name = "Field",
+            Type = new ApTypeRef { DataTypeIdRef = "MissingStruct" }
+        });
+        ap.DataTypeList.Structs.Add(structType);
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.DataTypeList.Structs[0].VarDeclarations[0].Type");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_TemplateParameterMissingDataTypeRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };
+        ap.TemplateList.ParameterTemplates.Add(new ApParameterTemplate
+        {
+            UniqueId = "TPL_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = "MissingType" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.TemplateList.ParameterTemplates[0].TypeRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_InterfaceInputVarMissingDataTypeRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess();
+        var functionType = new ApFunctionType { UniqueId = "FT_1", Name = "Ctrl" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.InterfaceList = new ApInterfaceList();
+        functionType.InterfaceList.InputVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_IN",
+            Name = "In",
+            Type = new ApTypeRef { DataTypeIdRef = "MissingType" }
+        });
+        ap.FunctionTypeList.Add(functionType);
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.FunctionTypeList[0].InterfaceList.InputVars[0].Type");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_DuplicateDerivedCountId_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            UniqueId = "DT_DERIVED",
+            Name = "Alias",
+            Count = new ApDerivedCount { UniqueId = "DUP_ID" },
+            BaseType = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+        ap.ParameterList.Add(new ApParameter { UniqueId = "DUP_ID" });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].UniqueId" &&
+            i.Message.Contains("Duplicate unique ID 'DUP_ID'", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("Arrays", "DT_ARRAY")]
+    [InlineData("Enums", "DT_ENUM")]
+    [InlineData("Derived", "DT_DERIVED")]
+    public void Validate_ApplicationProcess_DuplicateDataTypeIdAcrossKinds_ReturnIssue(string kind, string sharedId)
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        switch (kind)
+        {
+            case "Arrays":
+                ap.DataTypeList.Arrays.Add(new ApArrayType { UniqueId = sharedId, Name = "Buf" });
+                break;
+            case "Enums":
+                ap.DataTypeList.Enums.Add(new ApEnumType { UniqueId = sharedId, Name = "Mode" });
+                break;
+            case "Derived":
+                ap.DataTypeList.Derived.Add(new ApDerivedType
+                {
+                    UniqueId = sharedId,
+                    Name = "Alias",
+                    BaseType = new ApTypeRef { SimpleTypeName = "UINT" }
+                });
+                break;
+        }
+
+        ap.ParameterList.Add(new ApParameter { UniqueId = sharedId });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].UniqueId" &&
+            i.Message.Contains("Duplicate unique ID '" + sharedId + "'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_EmptyDataTypeUniqueIds_ReturnIssues()
+    {
+        var ap = new ApplicationProcess { DataTypeList = new ApDataTypeList() };
+        ap.DataTypeList.Arrays.Add(new ApArrayType { Name = "Buf" });
+        ap.DataTypeList.Enums.Add(new ApEnumType { Name = "Mode" });
+        ap.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            Name = "Alias",
+            Count = new ApDerivedCount(),
+            BaseType = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Arrays[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Enums[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Derived[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.DataTypeList.Derived[0].Count.UniqueId");
+    }
+
+    private static IReadOnlyList<ValidationIssue> ValidateEdsApplicationProcess(ApplicationProcess applicationProcess)
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = applicationProcess };
+        return CanOpenModelValidator.Validate(eds);
+    }
+
+    private static ApplicationProcess BuildValidApplicationProcess()
+    {
+        var ap = new ApplicationProcess
+        {
+            DataTypeList = new ApDataTypeList(),
+            TemplateList = new ApTemplateList(),
+            FunctionInstanceList = new ApFunctionInstanceList()
+        };
+
+        ap.DataTypeList.Structs.Add(new ApStructType { UniqueId = "DT_STRUCT", Name = "Status" });
+
+        ap.DataTypeList.Arrays.Add(new ApArrayType
+        {
+            UniqueId = "DT_ARRAY",
+            Name = "Buf",
+            ElementType = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+
+        ap.DataTypeList.Enums.Add(new ApEnumType { UniqueId = "DT_ENUM", Name = "Mode" });
+
+        ap.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            UniqueId = "DT_DERIVED",
+            Name = "DerivedStatus",
+            BaseType = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" },
+            Count = new ApDerivedCount { UniqueId = "DT_COUNT" }
+        });
+
+        var structWithMember = new ApStructType { UniqueId = "DT_MEMBER_STRUCT", Name = "Container" };
+        structWithMember.VarDeclarations.Add(new ApVarDeclaration
+        {
+            UniqueId = "VAR_MEMBER",
+            Name = "Field",
+            Type = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+        ap.DataTypeList.Structs.Add(structWithMember);
+
+        ap.TemplateList.ParameterTemplates.Add(new ApParameterTemplate
+        {
+            UniqueId = "TPL_PARAM",
+            TypeRef = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+        ap.TemplateList.AllowedValuesTemplates.Add(new ApAllowedValuesTemplate { UniqueId = "TPL_AV" });
+
+        var functionType = new ApFunctionType { UniqueId = "FT_1", Name = "Ctrl" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.InterfaceList = new ApInterfaceList();
+        functionType.InterfaceList.InputVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_IN",
+            Name = "In",
+            Type = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+        functionType.InterfaceList.OutputVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_OUT",
+            Name = "Out",
+            Type = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+        functionType.InterfaceList.ConfigVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "V_CFG",
+            Name = "Cfg",
+            Type = new ApTypeRef { SimpleTypeName = "BOOL" }
+        });
+        ap.FunctionTypeList.Add(functionType);
+
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+
+        ap.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_1",
+            TypeIdRef = "FT_1"
+        });
+
+        return ap;
+    }
+
+    private static DeviceConfigurationFile CreateValidDcf()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning
+            {
+                NodeId = 5,
+                Baudrate = 500
+            }
+        };
+
+        dcf.ObjectDictionary.MandatoryObjects.Add(0x1000);
+        dcf.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Device Type",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly
+        };
+
+        return dcf;
+    }
+}

--- a/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
@@ -193,6 +193,55 @@ public class ApplicationProcessValidationCoverageTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_ParameterWithNullAllowedValuesTemplateIdRef_ReturnsNoTemplateRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            AllowedValues = new ApAllowedValues { TemplateIdRef = null }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].AllowedValues.TemplateIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithEmptyAllowedValuesTemplateIdRef_ReturnsNoTemplateRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            AllowedValues = new ApAllowedValues { TemplateIdRef = string.Empty }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].AllowedValues.TemplateIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithValidAllowedValuesTemplateRef_ReturnsNoTemplateRefIssue()
+    {
+        var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };
+        ap.TemplateList.AllowedValuesTemplates.Add(new ApAllowedValuesTemplate { UniqueId = "TPL_AV" });
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            AllowedValues = new ApAllowedValues { TemplateIdRef = "TPL_AV" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].AllowedValues.TemplateIdRef");
+    }
+
+    [Fact]
     public void Validate_ApplicationProcess_InterfaceInputVarMissingDataTypeRef_ReturnIssue()
     {
         var ap = new ApplicationProcess();

--- a/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/ApplicationProcessValidationCoverageTests.cs
@@ -142,6 +142,57 @@ public class ApplicationProcessValidationCoverageTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_ParameterMissingParameterTemplateRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };
+        ap.TemplateList.ParameterTemplates.Add(new ApParameterTemplate { UniqueId = "TPL_PARAM" });
+        ap.ParameterList.Add(new ApParameter { UniqueId = "P_1", TemplateIdRef = "MissingTemplate" });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterList[0].TemplateIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithValidParameterTemplateRef_ReturnsNoTemplateRefIssue()
+    {
+        var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };
+        ap.TemplateList.ParameterTemplates.Add(new ApParameterTemplate { UniqueId = "TPL_PARAM" });
+        ap.ParameterList.Add(new ApParameter { UniqueId = "P_1", TemplateIdRef = "TPL_PARAM" });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path == "ApplicationProcess.ParameterList[0].TemplateIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterMissingAllowedValuesTemplateRef_ReturnIssue()
+    {
+        var ap = new ApplicationProcess { TemplateList = new ApTemplateList() };
+        ap.TemplateList.AllowedValuesTemplates.Add(new ApAllowedValuesTemplate { UniqueId = "TPL_AV" });
+        ap.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            AllowedValues = new ApAllowedValues { TemplateIdRef = "MissingAvTemplate" }
+        });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterList[0].AllowedValues.TemplateIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithNullTemplateIdRef_ReturnsNoTemplateRefIssue()
+    {
+        var ap = new ApplicationProcess();
+        ap.ParameterList.Add(new ApParameter { UniqueId = "P_1", TemplateIdRef = null });
+
+        var issues = ValidateEdsApplicationProcess(ap);
+
+        issues.Should().NotContain(i => i.Path.Contains("TemplateIdRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Validate_ApplicationProcess_InterfaceInputVarMissingDataTypeRef_ReturnIssue()
     {
         var ap = new ApplicationProcess();

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -670,6 +670,19 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_FunctionTypeWithoutNestedInstances_SkipsNestedValidation()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        var functionType = new ApFunctionType { UniqueId = "FT_1" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -683,6 +683,23 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_EmptyParameterUniqueId_SkipsParameterIdIndex()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter());
+        eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup
+        {
+            UniqueId = "PG_1",
+            ParameterRefs = { "MissingParam" }
+        });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterList[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterGroupList[0].ParameterRefs");
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -450,6 +450,66 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_NestedInstanceTypeRefToLaterFunctionType_ReturnsNoTypeRefIssue()
+    {
+        // Arrange — nested instance under FT_1 references FT_2 defined later in the list
+        var eds = new ElectronicDataSheet();
+        eds.ApplicationProcess = new ApplicationProcess();
+
+        var firstType = new ApFunctionType { UniqueId = "FT_1" };
+        firstType.VersionInfos.Add(new ApVersionInfo());
+        firstType.FunctionInstanceList = new ApFunctionInstanceList();
+        firstType.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_NESTED",
+            TypeIdRef = "FT_2"
+        });
+
+        var secondType = new ApFunctionType { UniqueId = "FT_2" };
+        secondType.VersionInfos.Add(new ApVersionInfo());
+
+        eds.ApplicationProcess.FunctionTypeList.Add(firstType);
+        eds.ApplicationProcess.FunctionTypeList.Add(secondType);
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        // Assert
+        issues.Should().NotContain(i => i.Path.Contains("TypeIdRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_DuplicateInstanceIdsAcrossLists_ReturnIssue()
+    {
+        // Arrange — same UniqueId in nested and top-level instance lists
+        var eds = new ElectronicDataSheet();
+        eds.ApplicationProcess = new ApplicationProcess();
+
+        var functionType = new ApFunctionType { UniqueId = "FT_1" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.FunctionInstanceList = new ApFunctionInstanceList();
+        functionType.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_DUP",
+            TypeIdRef = "FT_1"
+        });
+        eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+
+        eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+        eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_DUP",
+            TypeIdRef = "FT_1"
+        });
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        // Assert
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionInstanceList.FunctionInstances[0].UniqueId");
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -765,6 +765,49 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_ComplexGraphWithInterfacesAndDataTypes_ReturnsNoIssues()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.DataTypeList = new ApDataTypeList();
+        eds.ApplicationProcess.DataTypeList.Structs.Add(new ApStructType { UniqueId = "DT_STRUCT", Name = "Status" });
+        eds.ApplicationProcess.DataTypeList.Arrays.Add(new ApArrayType
+        {
+            UniqueId = "DT_ARRAY",
+            Name = "Values",
+            ElementType = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+        eds.ApplicationProcess.DataTypeList.Derived.Add(new ApDerivedType
+        {
+            UniqueId = "DT_DERIVED",
+            Name = "AliasStruct",
+            BaseType = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+        eds.ApplicationProcess.TemplateList = new ApTemplateList();
+        eds.ApplicationProcess.TemplateList.AllowedValuesTemplates.Add(
+            new ApAllowedValuesTemplate { UniqueId = "AVT_1" });
+
+        var functionType = new ApFunctionType { UniqueId = "FT_1", Name = "Controller" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        functionType.InterfaceList = new ApInterfaceList();
+        functionType.InterfaceList.InputVars.Add(new ApVarDeclaration
+        {
+            UniqueId = "VAR_IN",
+            Name = "Input",
+            Type = new ApTypeRef { SimpleTypeName = "UINT" }
+        });
+        eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = "DT_STRUCT" }
+        });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -345,6 +345,146 @@ public class CanOpenModelValidatorTests
         eds.ApplicationProcess.Should().BeSameAs(process);
     }
 
+    [Fact]
+    public void Validate_ValidCpj_ReturnsNoIssues()
+    {
+        // Arrange
+        var cpj = CreateValidCpj();
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(cpj);
+
+        // Assert
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_Cpj_InvalidNodeIdAndKeyMismatch_ReturnsIssues()
+    {
+        // Arrange
+        var cpj = CreateValidCpj();
+        cpj.Networks[0].Nodes[2] = new NetworkNode { NodeId = 3, Present = true, Name = "Mismatch" };
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(cpj);
+
+        // Assert
+        issues.Should().Contain(i => i.Path == "Networks[0].Nodes[2].NodeId");
+    }
+
+    [Fact]
+    public void Validate_Cpj_NodeIdOutOfRange_ReturnsIssue()
+    {
+        // Arrange
+        var cpj = new NodelistProject();
+        var network = new NetworkTopology();
+        network.Nodes[200] = new NetworkNode { NodeId = 200, Present = true };
+        cpj.Networks.Add(network);
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(cpj);
+
+        // Assert
+        issues.Should().Contain(i => i.Path == "Networks[0].Nodes[200]");
+        issues.Should().Contain(i => i.Path == "Networks[0].Nodes[200].NodeId");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_MissingReferencesAndDuplicateIds_ReturnIssues()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet();
+        eds.ApplicationProcess = new ApplicationProcess();
+        eds.ApplicationProcess.FunctionTypeList.Add(new ApFunctionType { UniqueId = "FT_1" });
+        eds.ApplicationProcess.FunctionTypeList.Add(new ApFunctionType { UniqueId = "FT_1" });
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = "P_1" });
+        eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup
+        {
+            UniqueId = "PG_1",
+            ParameterRefs = { "MissingParam" }
+        });
+        eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+        eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_1",
+            TypeIdRef = "MissingType"
+        });
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        // Assert
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionTypeList[1].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionTypeList[0].VersionInfos");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterGroupList[0].ParameterRefs");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionInstanceList.FunctionInstances[0].TypeIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ValidReferences_ReturnNoApplicationProcessIssues()
+    {
+        // Arrange
+        var eds = new ElectronicDataSheet();
+        eds.ApplicationProcess = new ApplicationProcess();
+        var functionType = new ApFunctionType { UniqueId = "FT_1" };
+        functionType.VersionInfos.Add(new ApVersionInfo());
+        eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = "P_1" });
+        eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup
+        {
+            UniqueId = "PG_1",
+            ParameterRefs = { "P_1" }
+        });
+        eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+        eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+        {
+            UniqueId = "FI_1",
+            TypeIdRef = "FT_1"
+        });
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        // Assert
+        issues.Should().NotContain(i => i.Path.StartsWith("ApplicationProcess", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
+    {
+        // Arrange
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        // Act
+        var facadeIssues = CanOpenFile.Validate(cpj);
+        var modelIssues = cpj.Validate();
+
+        // Assert
+        facadeIssues.Should().BeEquivalentTo(modelIssues);
+        facadeIssues.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_NodelistProject_Null_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => CanOpenModelValidator.Validate((NodelistProject)null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static NodelistProject CreateValidCpj()
+    {
+        var cpj = new NodelistProject();
+        var network = new NetworkTopology { NetName = "Main Network" };
+        network.Nodes[2] = new NetworkNode { NodeId = 2, Present = true, Name = "Node-2" };
+        cpj.Networks.Add(network);
+        return cpj;
+    }
+
     private static DeviceConfigurationFile CreateValidDcf()
     {
         var dcf = new DeviceConfigurationFile

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -700,6 +700,71 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_ApplicationProcess_DuplicateIdBetweenDataTypeAndParameter_ReturnIssue()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.DataTypeList = new ApDataTypeList();
+        eds.ApplicationProcess.DataTypeList.Structs.Add(new ApStructType { UniqueId = "SHARED_ID", Name = "MyStruct" });
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = "SHARED_ID" });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.ParameterList[0].UniqueId" &&
+            i.Message.Contains("Duplicate unique ID 'SHARED_ID'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterWithMissingDataTypeRef_ReturnIssue()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = "MissingStruct" }
+        });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterList[0].TypeRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ValidDataTypeRef_ReturnsNoTypeRefIssue()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.DataTypeList = new ApDataTypeList();
+        eds.ApplicationProcess.DataTypeList.Structs.Add(new ApStructType { UniqueId = "DT_1", Name = "MyStruct" });
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter
+        {
+            UniqueId = "P_1",
+            TypeRef = new ApTypeRef { DataTypeIdRef = "DT_1" }
+        });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().NotContain(i => i.Path.Contains("TypeRef", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_TemplateAndVarDeclarationIds_EnforceGlobalUniqueness()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.DataTypeList = new ApDataTypeList();
+        var structType = new ApStructType { UniqueId = "DT_1", Name = "MyStruct" };
+        structType.VarDeclarations.Add(new ApVarDeclaration { UniqueId = "VAR_1", Name = "Field1" });
+        eds.ApplicationProcess.DataTypeList.Structs.Add(structType);
+        eds.ApplicationProcess.TemplateList = new ApTemplateList();
+        eds.ApplicationProcess.TemplateList.ParameterTemplates.Add(new ApParameterTemplate { UniqueId = "VAR_1" });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i =>
+            i.Path == "ApplicationProcess.TemplateList.ParameterTemplates[0].UniqueId" &&
+            i.Message.Contains("Duplicate unique ID 'VAR_1'", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -579,6 +579,97 @@ public class CanOpenModelValidatorTests
     }
 
     [Fact]
+    public void Validate_DcfWithApplicationProcess_ValidatesApplicationProcessGraph()
+    {
+        var dcf = CreateValidDcf();
+        dcf.ApplicationProcess = new ApplicationProcess();
+        dcf.ApplicationProcess.FunctionTypeList.Add(new ApFunctionType { UniqueId = "FT_1" });
+
+        var issues = CanOpenModelValidator.Validate(dcf);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionTypeList[0].VersionInfos");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_EmptyUniqueIdAndTypeIdRef_ReturnIssues()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.FunctionTypeList.Add(new ApFunctionType());
+        eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+        eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance());
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionTypeList[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionTypeList[0].VersionInfos");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionInstanceList.FunctionInstances[0].UniqueId");
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionInstanceList.FunctionInstances[0].TypeIdRef");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_EmptyParameterRef_ReturnIssue()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup
+        {
+            UniqueId = "PG_1",
+            ParameterRefs = { string.Empty }
+        });
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterGroupList[0].ParameterRefs");
+    }
+
+    [Fact]
+    public void Validate_ApplicationProcess_ParameterGroupSubGroupMissingRef_ReturnIssue()
+    {
+        var eds = new ElectronicDataSheet { ApplicationProcess = new ApplicationProcess() };
+        eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = "P_1" });
+        var group = new ApParameterGroup { UniqueId = "PG_1", ParameterRefs = { "P_1" } };
+        group.SubGroups.Add(new ApParameterGroup
+        {
+            UniqueId = "PG_SUB",
+            ParameterRefs = { "MissingParam" }
+        });
+        eds.ApplicationProcess.ParameterGroupList.Add(group);
+
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        issues.Should().Contain(i => i.Path == "ApplicationProcess.ParameterGroupList[0].SubGroups[0].ParameterRefs");
+    }
+
+    [Fact]
+    public void Validate_Cpj_NetworkAndNodeFieldLengths_ReturnIssues()
+    {
+        var cpj = CreateValidCpj();
+        cpj.Networks[0].NetName = new string('N', 244);
+        cpj.Networks[0].NetRefd = new string('R', 250);
+        cpj.Networks[0].Nodes[2].Name = new string('X', 247);
+        cpj.Networks[0].Nodes[2].Refd = new string('Y', 250);
+
+        var issues = CanOpenModelValidator.Validate(cpj);
+
+        issues.Should().Contain(i => i.Path == "Networks[0].NetName");
+        issues.Should().Contain(i => i.Path == "Networks[0].NetRefd");
+        issues.Should().Contain(i => i.Path == "Networks[0].Nodes[2].Name");
+        issues.Should().Contain(i => i.Path == "Networks[0].Nodes[2].Refd");
+    }
+
+    [Fact]
+    public void Validate_ManufacturerObjectList_IsValidated()
+    {
+        var dcf = CreateValidDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2000);
+
+        var issues = CanOpenModelValidator.Validate(dcf);
+
+        issues.Should().Contain(i =>
+            i.Path == "ObjectDictionary.ManufacturerObjects" &&
+            i.Message.Contains("missing object 0x2000", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorTests.cs
@@ -509,6 +509,75 @@ public class CanOpenModelValidatorTests
         issues.Should().Contain(i => i.Path == "ApplicationProcess.FunctionInstanceList.FunctionInstances[0].UniqueId");
     }
 
+    [Theory]
+    [InlineData("FunctionTypeAndParameter")]
+    [InlineData("FunctionTypeAndParameterGroup")]
+    [InlineData("ParameterAndFunctionInstance")]
+    [InlineData("ParameterGroupAndFunctionInstance")]
+    public void Validate_ApplicationProcess_DuplicateIdsAcrossKinds_ReturnIssue(string scenario)
+    {
+        // Arrange — xsd:ID values must be unique across all applicationProcess ID-bearing elements
+        var eds = new ElectronicDataSheet();
+        eds.ApplicationProcess = new ApplicationProcess();
+        const string sharedId = "SHARED_ID";
+
+        switch (scenario)
+        {
+            case "FunctionTypeAndParameter":
+            {
+                var functionType = new ApFunctionType { UniqueId = sharedId };
+                functionType.VersionInfos.Add(new ApVersionInfo());
+                eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+                eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = sharedId });
+                break;
+            }
+            case "FunctionTypeAndParameterGroup":
+            {
+                var functionType = new ApFunctionType { UniqueId = sharedId };
+                functionType.VersionInfos.Add(new ApVersionInfo());
+                eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+                eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup { UniqueId = sharedId });
+                break;
+            }
+            case "ParameterAndFunctionInstance":
+            {
+                var functionType = new ApFunctionType { UniqueId = "FT_1" };
+                functionType.VersionInfos.Add(new ApVersionInfo());
+                eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+                eds.ApplicationProcess.ParameterList.Add(new ApParameter { UniqueId = sharedId });
+                eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+                eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+                {
+                    UniqueId = sharedId,
+                    TypeIdRef = "FT_1"
+                });
+                break;
+            }
+            case "ParameterGroupAndFunctionInstance":
+            {
+                var functionType = new ApFunctionType { UniqueId = "FT_1" };
+                functionType.VersionInfos.Add(new ApVersionInfo());
+                eds.ApplicationProcess.FunctionTypeList.Add(functionType);
+                eds.ApplicationProcess.ParameterGroupList.Add(new ApParameterGroup { UniqueId = sharedId });
+                eds.ApplicationProcess.FunctionInstanceList = new ApFunctionInstanceList();
+                eds.ApplicationProcess.FunctionInstanceList.FunctionInstances.Add(new ApFunctionInstance
+                {
+                    UniqueId = sharedId,
+                    TypeIdRef = "FT_1"
+                });
+                break;
+            }
+        }
+
+        // Act
+        var issues = CanOpenModelValidator.Validate(eds);
+
+        // Assert
+        issues.Should().Contain(i =>
+            i.Path.EndsWith(".UniqueId", StringComparison.Ordinal) &&
+            i.Message.Contains("Duplicate unique ID '" + sharedId + "'", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void Validate_Cpj_FacadeAndModelValidate_ReturnSameIssues()
     {


### PR DESCRIPTION
## Summary
- Extend `CanOpenModelValidator` with CPJ topology checks (NodeId range, key consistency, length limits) and CiA 311 `ApplicationProcess` integrity rules (unique IDs, versionInfo, parameter/function references, dataType and template refs)
- Add `CanOpenFile.Validate(NodelistProject)` and `NodelistProject.Validate()`
- Introduce `CanOpenWriteOptions` with `ValidateBeforeWrite` and `CanOpenWriteOptions.Validated` shortcut
- Add `ModelValidationException`, `CanOpenFile.EnsureValid(...)`, and options overloads for all sync and async `Write*` entry points (file, stream, ToString) across EDS/DCF/CPJ/XDD/XDC
- Add focused unit and integration tests

## Behavior notes
- **`Validate(eds)` / `Validate(dcf)` now also run `ApplicationProcess` validation** when the model carries an `ApplicationProcess` graph. Existing callers that invoke validation on EDS/DCF models may see new issues surfaced for previously unchecked ApplicationProcess constraints.
- Async `Write*` methods now accept optional `CanOpenWriteOptions` (same pre-write validation as sync overloads).

## Test plan
- [x] `dotnet test tests/EdsDcfNet.Tests/EdsDcfNet.Tests.csproj --configuration Release` (1162 tests passed)

Closes #286
Closes #287

Made with [Cursor](https://cursor.com)