### PR TITLE
feat: add write validation to format entry points (#294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ Current checks include:
 - object dictionary consistency (list membership, duplicates, missing entries)
 - object-level constraints (object type validity, parameter-name length, SubNumber mismatch)
 
+To validate automatically before writing, pass `CanOpenWriteOptions.Validated` to the
+format-specific entry points:
+
+```csharp
+using EdsDcfNet;
+
+var dcf = CanOpenFile.ReadDcf("configured_device.dcf");
+
+// Throws ModelValidationException when the model has validation issues.
+CanOpenFile.Dcf.WriteFile(dcf, "updated.dcf", CanOpenWriteOptions.Validated);
+```
+
+The same option works on `CanOpenFile.Eds`, `.Cpj`, `.Xdd`, and `.Xdc` write methods.
+Legacy `CanOpenFile.WriteDcf(...)` overloads delegate to these entry points.
+
 ### Working with Nodelist Projects (CPJ)
 
 ```csharp

--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -5,7 +5,6 @@ using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Utilities;
 using EdsDcfNet.Validation;
-using EdsDcfNet.Writers;
 using System.Globalization;
 
 /// <summary>
@@ -26,7 +25,8 @@ public static class CanOpenFile
 {
     /// <summary>
     /// EDS read/write operations. Prefer this entry point for new code that needs
-    /// <see cref="CanOpenFileOptions"/> instead of additional <see cref="CanOpenFile"/> overloads.
+    /// <see cref="CanOpenFileOptions"/> and <see cref="CanOpenWriteOptions"/> instead of additional
+    /// <see cref="CanOpenFile"/> overloads.
     /// </summary>
     public static EdsCanOpenOperations Eds { get; } = EdsCanOpenOperations.Instance;
     /// <summary>
@@ -241,10 +241,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteEds(ElectronicDataSheet eds, string filePath, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(eds, options);
-        Eds.WriteFile(eds, filePath);
-    }
+        => Eds.WriteFile(eds, filePath, options);
 
     /// <summary>
     /// Writes an Electronic Data Sheet (EDS) to a stream.
@@ -267,10 +264,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteEds(ElectronicDataSheet eds, Stream stream, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(eds, options);
-        Eds.WriteStream(eds, stream);
-    }
+        => Eds.WriteStream(eds, stream, options);
 
     /// <summary>
     /// Writes an Electronic Data Sheet (EDS) to disk asynchronously.
@@ -300,10 +294,7 @@ public static class CanOpenFile
         string filePath,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidEdsForWrite(eds, options);
-        return Eds.WriteFileAsync(eds, filePath, cancellationToken);
-    }
+        => Eds.WriteFileAsync(eds, filePath, options, cancellationToken);
 
     /// <summary>
     /// Writes an Electronic Data Sheet (EDS) to a stream asynchronously.
@@ -335,10 +326,7 @@ public static class CanOpenFile
         Stream stream,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidEdsForWrite(eds, options);
-        return Eds.WriteStreamAsync(eds, stream, cancellationToken);
-    }
+        => Eds.WriteStreamAsync(eds, stream, options, cancellationToken);
 
     /// <summary>
     /// Generates an EDS file content as string.
@@ -359,10 +347,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static string WriteEdsToString(ElectronicDataSheet eds, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(eds, options);
-        return Eds.WriteToString(eds);
-    }
+        => Eds.WriteToString(eds, options);
 
     #endregion
 
@@ -546,11 +531,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteDcf(DeviceConfigurationFile dcf, string filePath, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(dcf, options);
-        var writer = new DcfWriter();
-        writer.WriteFile(dcf, filePath);
-    }
+        => Dcf.WriteFile(dcf, filePath, options);
 
     /// <summary>
     /// Writes a Device Configuration File (DCF) to a stream.
@@ -573,11 +554,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteDcf(DeviceConfigurationFile dcf, Stream stream, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(dcf, options);
-        var writer = new DcfWriter();
-        writer.WriteStream(dcf, stream);
-    }
+        => Dcf.WriteStream(dcf, stream, options);
 
     /// <summary>
     /// Writes a Device Configuration File (DCF) to disk asynchronously.
@@ -607,11 +584,7 @@ public static class CanOpenFile
         string filePath,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidDcfForWrite(dcf, options);
-        var writer = new DcfWriter();
-        return writer.WriteFileAsync(dcf, filePath, cancellationToken);
-    }
+        => Dcf.WriteFileAsync(dcf, filePath, options, cancellationToken);
 
     /// <summary>
     /// Writes a Device Configuration File (DCF) to a stream asynchronously.
@@ -643,11 +616,7 @@ public static class CanOpenFile
         Stream stream,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidDcfForWrite(dcf, options);
-        var writer = new DcfWriter();
-        return writer.WriteStreamAsync(dcf, stream, cancellationToken);
-    }
+        => Dcf.WriteStreamAsync(dcf, stream, options, cancellationToken);
 
     /// <summary>
     /// Generates a DCF file content as string.
@@ -668,11 +637,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static string WriteDcfToString(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(dcf, options);
-        var writer = new DcfWriter();
-        return writer.GenerateString(dcf);
-    }
+        => Dcf.WriteToString(dcf, options);
 
     #endregion
 
@@ -841,11 +806,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteCpj(NodelistProject cpj, string filePath, CanOpenWriteOptions? options)
-    {
-        EnsureValidCpjForWrite(cpj, options);
-        var writer = new CpjWriter();
-        writer.WriteFile(cpj, filePath);
-    }
+        => Cpj.WriteFile(cpj, filePath, options);
 
     /// <summary>
     /// Writes a CiA 306-3 nodelist project (.cpj) to a stream.
@@ -868,11 +829,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteCpj(NodelistProject cpj, Stream stream, CanOpenWriteOptions? options)
-    {
-        EnsureValidCpjForWrite(cpj, options);
-        var writer = new CpjWriter();
-        writer.WriteStream(cpj, stream);
-    }
+        => Cpj.WriteStream(cpj, stream, options);
 
     /// <summary>
     /// Writes a CiA 306-3 nodelist project (.cpj) to disk asynchronously.
@@ -902,11 +859,7 @@ public static class CanOpenFile
         string filePath,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidCpjForWrite(cpj, options);
-        var writer = new CpjWriter();
-        return writer.WriteFileAsync(cpj, filePath, cancellationToken);
-    }
+        => Cpj.WriteFileAsync(cpj, filePath, options, cancellationToken);
 
     /// <summary>
     /// Writes a CiA 306-3 nodelist project (.cpj) to a stream asynchronously.
@@ -938,11 +891,7 @@ public static class CanOpenFile
         Stream stream,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidCpjForWrite(cpj, options);
-        var writer = new CpjWriter();
-        return writer.WriteStreamAsync(cpj, stream, cancellationToken);
-    }
+        => Cpj.WriteStreamAsync(cpj, stream, options, cancellationToken);
 
     /// <summary>
     /// Generates CPJ file content as string.
@@ -963,11 +912,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static string WriteCpjToString(NodelistProject cpj, CanOpenWriteOptions? options)
-    {
-        EnsureValidCpjForWrite(cpj, options);
-        var writer = new CpjWriter();
-        return writer.GenerateString(cpj);
-    }
+        => Cpj.WriteToString(cpj, options);
 
     #endregion
 
@@ -1136,11 +1081,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteXdd(ElectronicDataSheet xdd, string filePath, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(xdd, options);
-        var writer = new XddWriter();
-        writer.WriteFile(xdd, filePath);
-    }
+        => Xdd.WriteFile(xdd, filePath, options);
 
     /// <summary>
     /// Writes an ElectronicDataSheet as a CiA 311 XDD stream.
@@ -1163,11 +1104,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteXdd(ElectronicDataSheet xdd, Stream stream, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(xdd, options);
-        var writer = new XddWriter();
-        writer.WriteStream(xdd, stream);
-    }
+        => Xdd.WriteStream(xdd, stream, options);
 
     /// <summary>
     /// Writes an ElectronicDataSheet as a CiA 311 XDD file asynchronously.
@@ -1197,11 +1134,7 @@ public static class CanOpenFile
         string filePath,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidEdsForWrite(xdd, options);
-        var writer = new XddWriter();
-        return writer.WriteFileAsync(xdd, filePath, cancellationToken);
-    }
+        => Xdd.WriteFileAsync(xdd, filePath, options, cancellationToken);
 
     /// <summary>
     /// Writes an ElectronicDataSheet as a CiA 311 XDD stream asynchronously.
@@ -1233,11 +1166,7 @@ public static class CanOpenFile
         Stream stream,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidEdsForWrite(xdd, options);
-        var writer = new XddWriter();
-        return writer.WriteStreamAsync(xdd, stream, cancellationToken);
-    }
+        => Xdd.WriteStreamAsync(xdd, stream, options, cancellationToken);
 
     /// <summary>
     /// Generates XDD file content as string.
@@ -1258,11 +1187,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static string WriteXddToString(ElectronicDataSheet xdd, CanOpenWriteOptions? options)
-    {
-        EnsureValidEdsForWrite(xdd, options);
-        var writer = new XddWriter();
-        return writer.GenerateString(xdd);
-    }
+        => Xdd.WriteToString(xdd, options);
 
     #endregion
 
@@ -1431,11 +1356,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteXdc(DeviceConfigurationFile xdc, string filePath, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(xdc, options);
-        var writer = new XdcWriter();
-        writer.WriteFile(xdc, filePath);
-    }
+        => Xdc.WriteFile(xdc, filePath, options);
 
     /// <summary>
     /// Writes a DeviceConfigurationFile as a CiA 311 XDC stream.
@@ -1458,11 +1379,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static void WriteXdc(DeviceConfigurationFile xdc, Stream stream, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(xdc, options);
-        var writer = new XdcWriter();
-        writer.WriteStream(xdc, stream);
-    }
+        => Xdc.WriteStream(xdc, stream, options);
 
     /// <summary>
     /// Writes a DeviceConfigurationFile as a CiA 311 XDC file asynchronously.
@@ -1492,11 +1409,7 @@ public static class CanOpenFile
         string filePath,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidDcfForWrite(xdc, options);
-        var writer = new XdcWriter();
-        return writer.WriteFileAsync(xdc, filePath, cancellationToken);
-    }
+        => Xdc.WriteFileAsync(xdc, filePath, options, cancellationToken);
 
     /// <summary>
     /// Writes a DeviceConfigurationFile as a CiA 311 XDC stream asynchronously.
@@ -1528,11 +1441,7 @@ public static class CanOpenFile
         Stream stream,
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
-    {
-        EnsureValidDcfForWrite(xdc, options);
-        var writer = new XdcWriter();
-        return writer.WriteStreamAsync(xdc, stream, cancellationToken);
-    }
+        => Xdc.WriteStreamAsync(xdc, stream, options, cancellationToken);
 
     /// <summary>
     /// Generates XDC file content as string.
@@ -1553,11 +1462,7 @@ public static class CanOpenFile
     /// <see langword="true"/> and the model has validation issues.
     /// </exception>
     public static string WriteXdcToString(DeviceConfigurationFile xdc, CanOpenWriteOptions? options)
-    {
-        EnsureValidDcfForWrite(xdc, options);
-        var writer = new XdcWriter();
-        return writer.GenerateString(xdc);
-    }
+        => Xdc.WriteToString(xdc, options);
 
     #endregion
 
@@ -1651,28 +1556,6 @@ public static class CanOpenFile
             dcf.AdditionalSections[kvp.Key] = kvp.Value;
 
         return dcf;
-    }
-
-    #endregion
-
-    #region Write validation helpers
-
-    private static void EnsureValidEdsForWrite(ElectronicDataSheet eds, CanOpenWriteOptions? options)
-    {
-        if (options?.ValidateBeforeWrite == true)
-            EnsureValid(eds);
-    }
-
-    private static void EnsureValidDcfForWrite(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
-    {
-        if (options?.ValidateBeforeWrite == true)
-            EnsureValid(dcf);
-    }
-
-    private static void EnsureValidCpjForWrite(NodelistProject cpj, CanOpenWriteOptions? options)
-    {
-        if (options?.ValidateBeforeWrite == true)
-            EnsureValid(cpj);
     }
 
     private static void ThrowIfInvalid(IReadOnlyList<ValidationIssue> issues)

--- a/src/EdsDcfNet/CanOpenWriteGuard.cs
+++ b/src/EdsDcfNet/CanOpenWriteGuard.cs
@@ -1,0 +1,27 @@
+namespace EdsDcfNet;
+
+using EdsDcfNet.Models;
+
+/// <summary>
+/// Shared pre-write validation for format-specific operations entry points.
+/// </summary>
+internal static class CanOpenWriteGuard
+{
+    internal static void EnsureValidEdsForWrite(ElectronicDataSheet eds, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            CanOpenFile.EnsureValid(eds);
+    }
+
+    internal static void EnsureValidDcfForWrite(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            CanOpenFile.EnsureValid(dcf);
+    }
+
+    internal static void EnsureValidCpjForWrite(NodelistProject cpj, CanOpenWriteOptions? options)
+    {
+        if (options?.ValidateBeforeWrite == true)
+            CanOpenFile.EnsureValid(cpj);
+    }
+}

--- a/src/EdsDcfNet/CanOpenWriteOptions.cs
+++ b/src/EdsDcfNet/CanOpenWriteOptions.cs
@@ -1,7 +1,9 @@
 namespace EdsDcfNet;
 
 /// <summary>
-/// Optional behavior for <see cref="CanOpenFile"/> write operations.
+/// Optional behavior for <see cref="CanOpenFile"/> and format-specific operations
+/// (<see cref="CanOpenFile.Eds"/>, <see cref="CanOpenFile.Dcf"/>, <see cref="CanOpenFile.Cpj"/>,
+/// <see cref="CanOpenFile.Xdd"/>, <see cref="CanOpenFile.Xdc"/>) write methods.
 /// </summary>
 public sealed class CanOpenWriteOptions
 {

--- a/src/EdsDcfNet/CpjCanOpenOperations.cs
+++ b/src/EdsDcfNet/CpjCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -71,8 +72,12 @@ public sealed class CpjCanOpenOperations
     /// <summary>
     /// Writes a CPJ to disk.
     /// </summary>
-    public void WriteFile(NodelistProject cpj, string filePath)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteFile(NodelistProject cpj, string filePath, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         writer.WriteFile(cpj, filePath);
     }
@@ -80,8 +85,12 @@ public sealed class CpjCanOpenOperations
     /// <summary>
     /// Writes a CPJ to a stream. The stream is not disposed.
     /// </summary>
-    public void WriteStream(NodelistProject cpj, Stream stream)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteStream(NodelistProject cpj, Stream stream, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         writer.WriteStream(cpj, stream);
     }
@@ -89,11 +98,16 @@ public sealed class CpjCanOpenOperations
     /// <summary>
     /// Writes a CPJ to disk asynchronously.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteFileAsync(
         NodelistProject cpj,
         string filePath,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.WriteFileAsync(cpj, filePath, cancellationToken);
     }
@@ -101,11 +115,16 @@ public sealed class CpjCanOpenOperations
     /// <summary>
     /// Writes a CPJ to a stream asynchronously. The stream is not disposed.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteStreamAsync(
         NodelistProject cpj,
         Stream stream,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.WriteStreamAsync(cpj, stream, cancellationToken);
     }
@@ -113,8 +132,12 @@ public sealed class CpjCanOpenOperations
     /// <summary>
     /// Serializes a CPJ to a string.
     /// </summary>
-    public string WriteToString(NodelistProject cpj)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public string WriteToString(NodelistProject cpj, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidCpjForWrite(cpj, options);
         var writer = new CpjWriter();
         return writer.GenerateString(cpj);
     }

--- a/src/EdsDcfNet/DcfCanOpenOperations.cs
+++ b/src/EdsDcfNet/DcfCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -71,8 +72,12 @@ public sealed class DcfCanOpenOperations
     /// <summary>
     /// Writes a DCF to disk.
     /// </summary>
-    public void WriteFile(DeviceConfigurationFile dcf, string filePath)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteFile(DeviceConfigurationFile dcf, string filePath, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         writer.WriteFile(dcf, filePath);
     }
@@ -80,8 +85,12 @@ public sealed class DcfCanOpenOperations
     /// <summary>
     /// Writes a DCF to a stream. The stream is not disposed.
     /// </summary>
-    public void WriteStream(DeviceConfigurationFile dcf, Stream stream)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteStream(DeviceConfigurationFile dcf, Stream stream, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         writer.WriteStream(dcf, stream);
     }
@@ -89,11 +98,16 @@ public sealed class DcfCanOpenOperations
     /// <summary>
     /// Writes a DCF to disk asynchronously.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteFileAsync(
         DeviceConfigurationFile dcf,
         string filePath,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.WriteFileAsync(dcf, filePath, cancellationToken);
     }
@@ -101,11 +115,16 @@ public sealed class DcfCanOpenOperations
     /// <summary>
     /// Writes a DCF to a stream asynchronously. The stream is not disposed.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteStreamAsync(
         DeviceConfigurationFile dcf,
         Stream stream,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.WriteStreamAsync(dcf, stream, cancellationToken);
     }
@@ -113,8 +132,12 @@ public sealed class DcfCanOpenOperations
     /// <summary>
     /// Serializes a DCF to a string.
     /// </summary>
-    public string WriteToString(DeviceConfigurationFile dcf)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public string WriteToString(DeviceConfigurationFile dcf, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(dcf, options);
         var writer = new DcfWriter();
         return writer.GenerateString(dcf);
     }

--- a/src/EdsDcfNet/EdsCanOpenOperations.cs
+++ b/src/EdsDcfNet/EdsCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -71,8 +72,12 @@ public sealed class EdsCanOpenOperations
     /// <summary>
     /// Writes an EDS to disk.
     /// </summary>
-    public void WriteFile(ElectronicDataSheet eds, string filePath)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteFile(ElectronicDataSheet eds, string filePath, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         writer.WriteFile(eds, filePath);
     }
@@ -80,8 +85,12 @@ public sealed class EdsCanOpenOperations
     /// <summary>
     /// Writes an EDS to a stream. The stream is not disposed.
     /// </summary>
-    public void WriteStream(ElectronicDataSheet eds, Stream stream)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteStream(ElectronicDataSheet eds, Stream stream, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         writer.WriteStream(eds, stream);
     }
@@ -89,11 +98,16 @@ public sealed class EdsCanOpenOperations
     /// <summary>
     /// Writes an EDS to disk asynchronously.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteFileAsync(
         ElectronicDataSheet eds,
         string filePath,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.WriteFileAsync(eds, filePath, cancellationToken);
     }
@@ -101,11 +115,16 @@ public sealed class EdsCanOpenOperations
     /// <summary>
     /// Writes an EDS to a stream asynchronously. The stream is not disposed.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteStreamAsync(
         ElectronicDataSheet eds,
         Stream stream,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.WriteStreamAsync(eds, stream, cancellationToken);
     }
@@ -113,8 +132,12 @@ public sealed class EdsCanOpenOperations
     /// <summary>
     /// Serializes an EDS to a string.
     /// </summary>
-    public string WriteToString(ElectronicDataSheet eds)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public string WriteToString(ElectronicDataSheet eds, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(eds, options);
         var writer = new EdsWriter();
         return writer.GenerateString(eds);
     }

--- a/src/EdsDcfNet/XdcCanOpenOperations.cs
+++ b/src/EdsDcfNet/XdcCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -71,8 +72,12 @@ public sealed class XdcCanOpenOperations
     /// <summary>
     /// Writes an XDC to disk.
     /// </summary>
-    public void WriteFile(DeviceConfigurationFile xdc, string filePath)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteFile(DeviceConfigurationFile xdc, string filePath, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         writer.WriteFile(xdc, filePath);
     }
@@ -80,8 +85,12 @@ public sealed class XdcCanOpenOperations
     /// <summary>
     /// Writes an XDC to a stream. The stream is not disposed.
     /// </summary>
-    public void WriteStream(DeviceConfigurationFile xdc, Stream stream)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteStream(DeviceConfigurationFile xdc, Stream stream, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         writer.WriteStream(xdc, stream);
     }
@@ -89,11 +98,16 @@ public sealed class XdcCanOpenOperations
     /// <summary>
     /// Writes an XDC to disk asynchronously.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteFileAsync(
         DeviceConfigurationFile xdc,
         string filePath,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.WriteFileAsync(xdc, filePath, cancellationToken);
     }
@@ -101,11 +115,16 @@ public sealed class XdcCanOpenOperations
     /// <summary>
     /// Writes an XDC to a stream asynchronously. The stream is not disposed.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteStreamAsync(
         DeviceConfigurationFile xdc,
         Stream stream,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.WriteStreamAsync(xdc, stream, cancellationToken);
     }
@@ -113,8 +132,12 @@ public sealed class XdcCanOpenOperations
     /// <summary>
     /// Serializes an XDC to a string.
     /// </summary>
-    public string WriteToString(DeviceConfigurationFile xdc)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public string WriteToString(DeviceConfigurationFile xdc, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidDcfForWrite(xdc, options);
         var writer = new XdcWriter();
         return writer.GenerateString(xdc);
     }

--- a/src/EdsDcfNet/XddCanOpenOperations.cs
+++ b/src/EdsDcfNet/XddCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -71,8 +72,12 @@ public sealed class XddCanOpenOperations
     /// <summary>
     /// Writes an XDD to disk.
     /// </summary>
-    public void WriteFile(ElectronicDataSheet xdd, string filePath)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteFile(ElectronicDataSheet xdd, string filePath, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         writer.WriteFile(xdd, filePath);
     }
@@ -80,8 +85,12 @@ public sealed class XddCanOpenOperations
     /// <summary>
     /// Writes an XDD to a stream. The stream is not disposed.
     /// </summary>
-    public void WriteStream(ElectronicDataSheet xdd, Stream stream)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public void WriteStream(ElectronicDataSheet xdd, Stream stream, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         writer.WriteStream(xdd, stream);
     }
@@ -89,11 +98,16 @@ public sealed class XddCanOpenOperations
     /// <summary>
     /// Writes an XDD to disk asynchronously.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteFileAsync(
         ElectronicDataSheet xdd,
         string filePath,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.WriteFileAsync(xdd, filePath, cancellationToken);
     }
@@ -101,11 +115,16 @@ public sealed class XddCanOpenOperations
     /// <summary>
     /// Writes an XDD to a stream asynchronously. The stream is not disposed.
     /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
     public Task WriteStreamAsync(
         ElectronicDataSheet xdd,
         Stream stream,
+        CanOpenWriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.WriteStreamAsync(xdd, stream, cancellationToken);
     }
@@ -113,8 +132,12 @@ public sealed class XddCanOpenOperations
     /// <summary>
     /// Serializes an XDD to a string.
     /// </summary>
-    public string WriteToString(ElectronicDataSheet xdd)
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public string WriteToString(ElectronicDataSheet xdd, CanOpenWriteOptions? options = null)
     {
+        CanOpenWriteGuard.EnsureValidEdsForWrite(xdd, options);
         var writer = new XddWriter();
         return writer.GenerateString(xdd);
     }

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -472,6 +472,97 @@ public class WriteValidationGuardTests
         act.Should().NotThrow();
     }
 
+    [Theory]
+    [InlineData("Eds")]
+    [InlineData("Dcf")]
+    [InlineData("Cpj")]
+    [InlineData("Xdd")]
+    [InlineData("Xdc")]
+    public void FormatEntryPoint_WriteToString_WithValidatedOptions_ValidModel_ReturnsContent(string format)
+    {
+        var content = format switch
+        {
+            "Eds" => CanOpenFile.Eds.WriteToString(CreateValidEds(), CanOpenWriteOptions.Validated),
+            "Dcf" => CanOpenFile.Dcf.WriteToString(CreateValidDcf(), CanOpenWriteOptions.Validated),
+            "Cpj" => CanOpenFile.Cpj.WriteToString(CreateValidCpj(), CanOpenWriteOptions.Validated),
+            "Xdd" => CanOpenFile.Xdd.WriteToString(CreateValidEds(), CanOpenWriteOptions.Validated),
+            "Xdc" => CanOpenFile.Xdc.WriteToString(CreateValidDcf(), CanOpenWriteOptions.Validated),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
+        };
+
+        content.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void EdsEntryPoint_WriteToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var eds = new ElectronicDataSheet();
+        eds.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        var act = () => CanOpenFile.Eds.WriteToString(eds, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void DcfEntryPoint_WriteToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var dcf = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.Dcf.WriteToString(dcf, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void CpjEntryPoint_WriteToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var cpj = new NodelistProject();
+        cpj.Networks.Add(new NetworkTopology());
+        cpj.Networks[0].Nodes[0] = new NetworkNode { NodeId = 0, Present = true };
+
+        var act = () => CanOpenFile.Cpj.WriteToString(cpj, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void XddEntryPoint_WriteToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var xdd = new ElectronicDataSheet();
+        xdd.ObjectDictionary.Objects[0x1000] = new CanOpenObject
+        {
+            Index = 0x1000,
+            ParameterName = "Unclassified",
+            ObjectType = 0x7
+        };
+
+        var act = () => CanOpenFile.Xdd.WriteToString(xdd, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
+    [Fact]
+    public void XdcEntryPoint_WriteToString_WithValidatedOptions_ThrowsForInvalidModel()
+    {
+        var xdc = new DeviceConfigurationFile
+        {
+            DeviceCommissioning = new DeviceCommissioning { NodeId = 200, Baudrate = 250 }
+        };
+
+        var act = () => CanOpenFile.Xdc.WriteToString(xdc, CanOpenWriteOptions.Validated);
+
+        act.Should().Throw<ModelValidationException>();
+    }
+
     private static DeviceConfigurationFile CreateValidDcf()
     {
         var dcf = new DeviceConfigurationFile


### PR DESCRIPTION
## Summary
- Add optional `CanOpenWriteOptions` to all `Write*` methods on `CanOpenFile.Eds`, `.Dcf`, `.Cpj`, `.Xdd`, and `.Xdc`.
- Centralize pre-write validation in `CanOpenWriteGuard` and delegate legacy `CanOpenFile.Write*` overloads through the format entry points.
- Document validated writes in README and add entry-point coverage in `WriteValidationGuardTests`.

Closes #294.

## Test plan
- [x] `dotnet test` (1220 tests passing)
- [ ] Review that `CanOpenWriteOptions.Validated` throws `ModelValidationException` for invalid models on all five entry points
- [ ] Confirm legacy `CanOpenFile.Write*` overloads still behave the same via delegation


Made with [Cursor](https://cursor.com)