### PR TITLE
feat(api): add CanOpenFileOptions overloads for EDS read methods

### DIFF
--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -131,6 +131,10 @@ public static class CanOpenFile
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
+    /// <inheritdoc cref="EdsCanOpenOperations.ReadFile"/>
+    public static ElectronicDataSheet ReadEds(string filePath, CanOpenFileOptions options)
+        => Eds.ReadFile(filePath, options);
+
     /// <inheritdoc cref="EdsCanOpenOperations.ReadFileAsync"/>
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         string filePath,
@@ -144,17 +148,32 @@ public static class CanOpenFile
         CancellationToken cancellationToken = default)
         => Eds.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
+    /// <inheritdoc cref="EdsCanOpenOperations.ReadFileAsync"/>
+    public static Task<ElectronicDataSheet> ReadEdsAsync(
+        string filePath,
+        CanOpenFileOptions options,
+        CancellationToken cancellationToken = default)
+        => Eds.ReadFileAsync(filePath, options, cancellationToken);
+
     /// <inheritdoc cref="EdsCanOpenOperations.ReadString"/>
     public static ElectronicDataSheet ReadEdsFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
+    /// <inheritdoc cref="EdsCanOpenOperations.ReadString"/>
+    public static ElectronicDataSheet ReadEdsFromString(string content, CanOpenFileOptions options)
+        => Eds.ReadString(content, options);
+
     /// <inheritdoc cref="EdsCanOpenOperations.ReadStream"/>
     public static ElectronicDataSheet ReadEds(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
+
+    /// <inheritdoc cref="EdsCanOpenOperations.ReadStream"/>
+    public static ElectronicDataSheet ReadEds(Stream stream, CanOpenFileOptions options)
+        => Eds.ReadStream(stream, options);
 
     /// <inheritdoc cref="EdsCanOpenOperations.ReadStreamAsync"/>
     public static Task<ElectronicDataSheet> ReadEdsAsync(
@@ -168,6 +187,13 @@ public static class CanOpenFile
         long maxInputSize,
         CancellationToken cancellationToken = default)
         => Eds.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
+
+    /// <inheritdoc cref="EdsCanOpenOperations.ReadStreamAsync"/>
+    public static Task<ElectronicDataSheet> ReadEdsAsync(
+        Stream stream,
+        CanOpenFileOptions options,
+        CancellationToken cancellationToken = default)
+        => Eds.ReadStreamAsync(stream, options, cancellationToken);
 
     #endregion
 

--- a/tests/EdsDcfNet.Tests/Integration/EdsCanOpenOperationsTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/EdsCanOpenOperationsTests.cs
@@ -6,6 +6,9 @@ using EdsDcfNet.Parsers;
 
 public class EdsCanOpenOperationsTests
 {
+    private static CanOpenFileOptions DefaultReadOptions =>
+        new() { MaxInputSize = IniParser.DefaultMaxInputSize };
+
     [Fact]
     public void CanOpenFileOptions_Default_UsesReaderDefaultMaxInputSize()
     {
@@ -29,6 +32,17 @@ public class EdsCanOpenOperationsTests
         var optionsResult = CanOpenFile.Eds.ReadFile(
             "Fixtures/sample_device.eds",
             new CanOpenFileOptions { MaxInputSize = IniParser.DefaultMaxInputSize });
+        var legacyResult = CanOpenFile.ReadEds("Fixtures/sample_device.eds", IniParser.DefaultMaxInputSize);
+
+        legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
+    }
+
+    [Fact]
+    public void ReadEds_WithCanOpenFileOptionsOverload_MatchesMaxInputSizeOverload()
+    {
+        var optionsResult = CanOpenFile.ReadEds(
+            "Fixtures/sample_device.eds",
+            DefaultReadOptions);
         var legacyResult = CanOpenFile.ReadEds("Fixtures/sample_device.eds", IniParser.DefaultMaxInputSize);
 
         legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
@@ -68,6 +82,17 @@ public class EdsCanOpenOperationsTests
     }
 
     [Fact]
+    public void ReadEdsFromString_WithCanOpenFileOptionsOverload_MatchesMaxInputSizeOverload()
+    {
+        var content = File.ReadAllText("Fixtures/sample_device.eds");
+
+        var optionsResult = CanOpenFile.ReadEdsFromString(content, DefaultReadOptions);
+        var legacyResult = CanOpenFile.ReadEdsFromString(content, IniParser.DefaultMaxInputSize);
+
+        legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
+    }
+
+    [Fact]
     public void Eds_ReadStream_WithOptions_MatchesMaxInputSizeOverload()
     {
         var content = File.ReadAllText("Fixtures/sample_device.eds");
@@ -76,6 +101,19 @@ public class EdsCanOpenOperationsTests
         var options = new CanOpenFileOptions { MaxInputSize = IniParser.DefaultMaxInputSize };
 
         var optionsResult = CanOpenFile.Eds.ReadStream(optionsStream, options);
+        var legacyResult = CanOpenFile.ReadEds(legacyStream, IniParser.DefaultMaxInputSize);
+
+        legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
+    }
+
+    [Fact]
+    public void ReadEds_StreamWithCanOpenFileOptionsOverload_MatchesMaxInputSizeOverload()
+    {
+        var content = File.ReadAllText("Fixtures/sample_device.eds");
+        using var optionsStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+        using var legacyStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+
+        var optionsResult = CanOpenFile.ReadEds(optionsStream, DefaultReadOptions);
         var legacyResult = CanOpenFile.ReadEds(legacyStream, IniParser.DefaultMaxInputSize);
 
         legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
@@ -93,6 +131,15 @@ public class EdsCanOpenOperationsTests
     }
 
     [Fact]
+    public async Task ReadEdsAsync_WithCanOpenFileOptionsOverload_MatchesMaxInputSizeOverload()
+    {
+        var optionsResult = await CanOpenFile.ReadEdsAsync("Fixtures/sample_device.eds", DefaultReadOptions);
+        var legacyResult = await CanOpenFile.ReadEdsAsync("Fixtures/sample_device.eds", IniParser.DefaultMaxInputSize);
+
+        legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
+    }
+
+    [Fact]
     public async Task Eds_ReadStreamAsync_WithOptions_MatchesMaxInputSizeOverload()
     {
         var content = File.ReadAllText("Fixtures/sample_device.eds");
@@ -101,6 +148,19 @@ public class EdsCanOpenOperationsTests
         var options = new CanOpenFileOptions { MaxInputSize = IniParser.DefaultMaxInputSize };
 
         var optionsResult = await CanOpenFile.Eds.ReadStreamAsync(optionsStream, options);
+        var legacyResult = await CanOpenFile.ReadEdsAsync(legacyStream, IniParser.DefaultMaxInputSize);
+
+        legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);
+    }
+
+    [Fact]
+    public async Task ReadEdsAsync_StreamWithCanOpenFileOptionsOverload_MatchesMaxInputSizeOverload()
+    {
+        var content = File.ReadAllText("Fixtures/sample_device.eds");
+        using var optionsStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+        using var legacyStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+
+        var optionsResult = await CanOpenFile.ReadEdsAsync(optionsStream, DefaultReadOptions);
         var legacyResult = await CanOpenFile.ReadEdsAsync(legacyStream, IniParser.DefaultMaxInputSize);
 
         legacyResult.DeviceInfo.ProductName.Should().Be(optionsResult.DeviceInfo.ProductName);


### PR DESCRIPTION
## Summary
- Add `CanOpenFileOptions` overloads to `ReadEds`, `ReadEdsFromString`, and async variants on the `CanOpenFile` facade
- Brings EDS read API in line with DCF/CPJ/XDD/XDC (same surface introduced in 1.9.0)
- Add integration tests verifying the new overloads match the legacy `maxInputSize` paths

Fixes #304

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~EdsCanOpenOperationsTests`
- [x] New overload tests pass for file, string, stream, and async paths


Made with [Cursor](https://cursor.com)