### PR TITLE
fix(api): extend Obsolete attributes across the CanOpenFile facade

### DIFF
--- a/src/EdsDcfNet/CanOpenFile.cs
+++ b/src/EdsDcfNet/CanOpenFile.cs
@@ -126,22 +126,26 @@ public static class CanOpenFile
     #region EDS Read
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadFile instead.")]
     public static ElectronicDataSheet ReadEds(
         string filePath,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadFile instead.")]
     public static ElectronicDataSheet ReadEds(string filePath, CanOpenFileOptions options)
         => Eds.ReadFile(filePath, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         string filePath,
         CancellationToken cancellationToken = default)
         => Eds.ReadFileAsync(filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         string filePath,
         long maxInputSize,
@@ -149,6 +153,7 @@ public static class CanOpenFile
         => Eds.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         string filePath,
         CanOpenFileOptions options,
@@ -156,32 +161,38 @@ public static class CanOpenFile
         => Eds.ReadFileAsync(filePath, options, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadString instead.")]
     public static ElectronicDataSheet ReadEdsFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadString instead.")]
     public static ElectronicDataSheet ReadEdsFromString(string content, CanOpenFileOptions options)
         => Eds.ReadString(content, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadStream instead.")]
     public static ElectronicDataSheet ReadEds(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Eds.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadStream instead.")]
     public static ElectronicDataSheet ReadEds(Stream stream, CanOpenFileOptions options)
         => Eds.ReadStream(stream, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         Stream stream,
         CancellationToken cancellationToken = default)
         => Eds.ReadStreamAsync(stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         Stream stream,
         long maxInputSize,
@@ -189,6 +200,7 @@ public static class CanOpenFile
         => Eds.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Eds.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadEdsAsync(
         Stream stream,
         CanOpenFileOptions options,
@@ -202,15 +214,20 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFile(ElectronicDataSheet, string)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Eds.WriteFile instead.")]
     public static void WriteEds(ElectronicDataSheet eds, string filePath)
         => Eds.WriteFile(eds, filePath, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFile(ElectronicDataSheet, string, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Eds.WriteFile instead.")]
     public static void WriteEds(ElectronicDataSheet eds, string filePath, CanOpenWriteOptions? options)
         => Eds.WriteFile(eds, filePath, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStream(ElectronicDataSheet, Stream)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Eds.WriteStream instead.")]
@@ -218,10 +235,13 @@ public static class CanOpenFile
         => Eds.WriteStream(eds, stream);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStream(ElectronicDataSheet, Stream, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Eds.WriteStream instead.")]
     public static void WriteEds(ElectronicDataSheet eds, Stream stream, CanOpenWriteOptions? options)
         => Eds.WriteStream(eds, stream, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFileAsync(ElectronicDataSheet, string, CancellationToken)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Eds.WriteFileAsync instead.")]
@@ -232,6 +252,7 @@ public static class CanOpenFile
         => Eds.WriteFileAsync(eds, filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFileAsync(ElectronicDataSheet, string, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Eds.WriteFileAsync instead.")]
     public static Task WriteEdsAsync(
         ElectronicDataSheet eds,
         string filePath,
@@ -242,6 +263,8 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStreamAsync(ElectronicDataSheet, Stream, CancellationToken)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Eds.WriteStreamAsync instead.")]
     public static Task WriteEdsAsync(
         ElectronicDataSheet eds,
@@ -250,6 +273,7 @@ public static class CanOpenFile
         => Eds.WriteStreamAsync(eds, stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStreamAsync(ElectronicDataSheet, Stream, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Eds.WriteStreamAsync instead.")]
     public static Task WriteEdsAsync(
         ElectronicDataSheet eds,
         Stream stream,
@@ -260,11 +284,14 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteToString(ElectronicDataSheet)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Eds.WriteToString instead.")]
     public static string WriteEdsToString(ElectronicDataSheet eds)
         => Eds.WriteToString(eds, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteToString(ElectronicDataSheet, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Eds.WriteToString instead.")]
     public static string WriteEdsToString(ElectronicDataSheet eds, CanOpenWriteOptions? options)
         => Eds.WriteToString(eds, options);
 
@@ -273,22 +300,26 @@ public static class CanOpenFile
     #region DCF Read
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadFile instead.")]
     public static DeviceConfigurationFile ReadDcf(
         string filePath,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Dcf.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadFile instead.")]
     public static DeviceConfigurationFile ReadDcf(string filePath, CanOpenFileOptions options)
         => Dcf.ReadFile(filePath, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         string filePath,
         CancellationToken cancellationToken = default)
         => Dcf.ReadFileAsync(filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         string filePath,
         long maxInputSize,
@@ -296,6 +327,7 @@ public static class CanOpenFile
         => Dcf.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         string filePath,
         CanOpenFileOptions options,
@@ -303,32 +335,38 @@ public static class CanOpenFile
         => Dcf.ReadFileAsync(filePath, options, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadString instead.")]
     public static DeviceConfigurationFile ReadDcfFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Dcf.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadString instead.")]
     public static DeviceConfigurationFile ReadDcfFromString(string content, CanOpenFileOptions options)
         => Dcf.ReadString(content, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadStream instead.")]
     public static DeviceConfigurationFile ReadDcf(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Dcf.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadStream instead.")]
     public static DeviceConfigurationFile ReadDcf(Stream stream, CanOpenFileOptions options)
         => Dcf.ReadStream(stream, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         Stream stream,
         CancellationToken cancellationToken = default)
         => Dcf.ReadStreamAsync(stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         Stream stream,
         long maxInputSize,
@@ -336,6 +374,7 @@ public static class CanOpenFile
         => Dcf.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Dcf.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadDcfAsync(
         Stream stream,
         CanOpenFileOptions options,
@@ -350,15 +389,20 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFile(DeviceConfigurationFile, string)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Dcf.WriteFile instead.")]
     public static void WriteDcf(DeviceConfigurationFile dcf, string filePath)
         => Dcf.WriteFile(dcf, filePath, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFile(DeviceConfigurationFile, string, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Dcf.WriteFile instead.")]
     public static void WriteDcf(DeviceConfigurationFile dcf, string filePath, CanOpenWriteOptions? options)
         => Dcf.WriteFile(dcf, filePath, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStream(DeviceConfigurationFile, Stream)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Dcf.WriteStream instead.")]
@@ -366,10 +410,13 @@ public static class CanOpenFile
         => Dcf.WriteStream(dcf, stream);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStream(DeviceConfigurationFile, Stream, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Dcf.WriteStream instead.")]
     public static void WriteDcf(DeviceConfigurationFile dcf, Stream stream, CanOpenWriteOptions? options)
         => Dcf.WriteStream(dcf, stream, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFileAsync(DeviceConfigurationFile, string, CancellationToken)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Dcf.WriteFileAsync instead.")]
@@ -380,6 +427,7 @@ public static class CanOpenFile
         => Dcf.WriteFileAsync(dcf, filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFileAsync(DeviceConfigurationFile, string, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Dcf.WriteFileAsync instead.")]
     public static Task WriteDcfAsync(
         DeviceConfigurationFile dcf,
         string filePath,
@@ -390,6 +438,8 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStreamAsync(DeviceConfigurationFile, Stream, CancellationToken)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Dcf.WriteStreamAsync instead.")]
     public static Task WriteDcfAsync(
         DeviceConfigurationFile dcf,
@@ -398,6 +448,7 @@ public static class CanOpenFile
         => Dcf.WriteStreamAsync(dcf, stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStreamAsync(DeviceConfigurationFile, Stream, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Dcf.WriteStreamAsync instead.")]
     public static Task WriteDcfAsync(
         DeviceConfigurationFile dcf,
         Stream stream,
@@ -408,11 +459,14 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteToString(DeviceConfigurationFile)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Dcf.WriteToString instead.")]
     public static string WriteDcfToString(DeviceConfigurationFile dcf)
         => Dcf.WriteToString(dcf, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteToString(DeviceConfigurationFile, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Dcf.WriteToString instead.")]
     public static string WriteDcfToString(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
         => Dcf.WriteToString(dcf, options);
 
@@ -421,22 +475,26 @@ public static class CanOpenFile
     #region CPJ Read
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadFile instead.")]
     public static NodelistProject ReadCpj(
         string filePath,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Cpj.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadFile instead.")]
     public static NodelistProject ReadCpj(string filePath, CanOpenFileOptions options)
         => Cpj.ReadFile(filePath, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadFileAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         string filePath,
         CancellationToken cancellationToken = default)
         => Cpj.ReadFileAsync(filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadFileAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         string filePath,
         long maxInputSize,
@@ -444,6 +502,7 @@ public static class CanOpenFile
         => Cpj.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadFileAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         string filePath,
         CanOpenFileOptions options,
@@ -451,32 +510,38 @@ public static class CanOpenFile
         => Cpj.ReadFileAsync(filePath, options, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadString instead.")]
     public static NodelistProject ReadCpjFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Cpj.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadString instead.")]
     public static NodelistProject ReadCpjFromString(string content, CanOpenFileOptions options)
         => Cpj.ReadString(content, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadStream instead.")]
     public static NodelistProject ReadCpj(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Cpj.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadStream instead.")]
     public static NodelistProject ReadCpj(Stream stream, CanOpenFileOptions options)
         => Cpj.ReadStream(stream, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadStreamAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         Stream stream,
         CancellationToken cancellationToken = default)
         => Cpj.ReadStreamAsync(stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadStreamAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         Stream stream,
         long maxInputSize,
@@ -484,6 +549,7 @@ public static class CanOpenFile
         => Cpj.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Cpj.ReadStreamAsync instead.")]
     public static Task<NodelistProject> ReadCpjAsync(
         Stream stream,
         CanOpenFileOptions options,
@@ -498,15 +564,20 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteFile(NodelistProject, string)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Cpj.WriteFile instead.")]
     public static void WriteCpj(NodelistProject cpj, string filePath)
         => Cpj.WriteFile(cpj, filePath, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteFile(NodelistProject, string, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Cpj.WriteFile instead.")]
     public static void WriteCpj(NodelistProject cpj, string filePath, CanOpenWriteOptions? options)
         => Cpj.WriteFile(cpj, filePath, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteStream(NodelistProject, Stream)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Cpj.WriteStream instead.")]
@@ -514,10 +585,13 @@ public static class CanOpenFile
         => Cpj.WriteStream(cpj, stream);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteStream(NodelistProject, Stream, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Cpj.WriteStream instead.")]
     public static void WriteCpj(NodelistProject cpj, Stream stream, CanOpenWriteOptions? options)
         => Cpj.WriteStream(cpj, stream, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteFileAsync(NodelistProject, string, CancellationToken)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Cpj.WriteFileAsync instead.")]
@@ -528,6 +602,7 @@ public static class CanOpenFile
         => Cpj.WriteFileAsync(cpj, filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteFileAsync(NodelistProject, string, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Cpj.WriteFileAsync instead.")]
     public static Task WriteCpjAsync(
         NodelistProject cpj,
         string filePath,
@@ -538,6 +613,8 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteStreamAsync(NodelistProject, Stream, CancellationToken)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Cpj.WriteStreamAsync instead.")]
     public static Task WriteCpjAsync(
         NodelistProject cpj,
@@ -546,6 +623,7 @@ public static class CanOpenFile
         => Cpj.WriteStreamAsync(cpj, stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteStreamAsync(NodelistProject, Stream, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Cpj.WriteStreamAsync instead.")]
     public static Task WriteCpjAsync(
         NodelistProject cpj,
         Stream stream,
@@ -556,11 +634,14 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteToString(NodelistProject)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Cpj.WriteToString instead.")]
     public static string WriteCpjToString(NodelistProject cpj)
         => Cpj.WriteToString(cpj, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{NodelistProject}.WriteToString(NodelistProject, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Cpj.WriteToString instead.")]
     public static string WriteCpjToString(NodelistProject cpj, CanOpenWriteOptions? options)
         => Cpj.WriteToString(cpj, options);
 
@@ -569,22 +650,26 @@ public static class CanOpenFile
     #region XDD Read
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadFile instead.")]
     public static ElectronicDataSheet ReadXdd(
         string filePath,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdd.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadFile instead.")]
     public static ElectronicDataSheet ReadXdd(string filePath, CanOpenFileOptions options)
         => Xdd.ReadFile(filePath, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         string filePath,
         CancellationToken cancellationToken = default)
         => Xdd.ReadFileAsync(filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         string filePath,
         long maxInputSize,
@@ -592,6 +677,7 @@ public static class CanOpenFile
         => Xdd.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadFileAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         string filePath,
         CanOpenFileOptions options,
@@ -599,32 +685,38 @@ public static class CanOpenFile
         => Xdd.ReadFileAsync(filePath, options, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadString instead.")]
     public static ElectronicDataSheet ReadXddFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdd.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadString instead.")]
     public static ElectronicDataSheet ReadXddFromString(string content, CanOpenFileOptions options)
         => Xdd.ReadString(content, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadStream instead.")]
     public static ElectronicDataSheet ReadXdd(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdd.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadStream instead.")]
     public static ElectronicDataSheet ReadXdd(Stream stream, CanOpenFileOptions options)
         => Xdd.ReadStream(stream, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         Stream stream,
         CancellationToken cancellationToken = default)
         => Xdd.ReadStreamAsync(stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         Stream stream,
         long maxInputSize,
@@ -632,6 +724,7 @@ public static class CanOpenFile
         => Xdd.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdd.ReadStreamAsync instead.")]
     public static Task<ElectronicDataSheet> ReadXddAsync(
         Stream stream,
         CanOpenFileOptions options,
@@ -646,15 +739,20 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFile(ElectronicDataSheet, string)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdd.WriteFile instead.")]
     public static void WriteXdd(ElectronicDataSheet xdd, string filePath)
         => Xdd.WriteFile(xdd, filePath, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFile(ElectronicDataSheet, string, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdd.WriteFile instead.")]
     public static void WriteXdd(ElectronicDataSheet xdd, string filePath, CanOpenWriteOptions? options)
         => Xdd.WriteFile(xdd, filePath, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStream(ElectronicDataSheet, Stream)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Xdd.WriteStream instead.")]
@@ -662,10 +760,13 @@ public static class CanOpenFile
         => Xdd.WriteStream(xdd, stream);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStream(ElectronicDataSheet, Stream, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdd.WriteStream instead.")]
     public static void WriteXdd(ElectronicDataSheet xdd, Stream stream, CanOpenWriteOptions? options)
         => Xdd.WriteStream(xdd, stream, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFileAsync(ElectronicDataSheet, string, CancellationToken)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Xdd.WriteFileAsync instead.")]
@@ -676,6 +777,7 @@ public static class CanOpenFile
         => Xdd.WriteFileAsync(xdd, filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteFileAsync(ElectronicDataSheet, string, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Xdd.WriteFileAsync instead.")]
     public static Task WriteXddAsync(
         ElectronicDataSheet xdd,
         string filePath,
@@ -686,6 +788,8 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStreamAsync(ElectronicDataSheet, Stream, CancellationToken)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdd.WriteStreamAsync instead.")]
     public static Task WriteXddAsync(
         ElectronicDataSheet xdd,
@@ -694,6 +798,7 @@ public static class CanOpenFile
         => Xdd.WriteStreamAsync(xdd, stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteStreamAsync(ElectronicDataSheet, Stream, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Xdd.WriteStreamAsync instead.")]
     public static Task WriteXddAsync(
         ElectronicDataSheet xdd,
         Stream stream,
@@ -704,11 +809,14 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteToString(ElectronicDataSheet)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdd.WriteToString instead.")]
     public static string WriteXddToString(ElectronicDataSheet xdd)
         => Xdd.WriteToString(xdd, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{ElectronicDataSheet}.WriteToString(ElectronicDataSheet, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdd.WriteToString instead.")]
     public static string WriteXddToString(ElectronicDataSheet xdd, CanOpenWriteOptions? options)
         => Xdd.WriteToString(xdd, options);
 
@@ -717,22 +825,26 @@ public static class CanOpenFile
     #region XDC Read
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadFile instead.")]
     public static DeviceConfigurationFile ReadXdc(
         string filePath,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdc.ReadFile(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFile"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadFile instead.")]
     public static DeviceConfigurationFile ReadXdc(string filePath, CanOpenFileOptions options)
         => Xdc.ReadFile(filePath, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         string filePath,
         CancellationToken cancellationToken = default)
         => Xdc.ReadFileAsync(filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         string filePath,
         long maxInputSize,
@@ -740,6 +852,7 @@ public static class CanOpenFile
         => Xdc.ReadFileAsync(filePath, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadFileAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadFileAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         string filePath,
         CanOpenFileOptions options,
@@ -747,32 +860,38 @@ public static class CanOpenFile
         => Xdc.ReadFileAsync(filePath, options, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadString instead.")]
     public static DeviceConfigurationFile ReadXdcFromString(
         string content,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdc.ReadString(content, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadString"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadString instead.")]
     public static DeviceConfigurationFile ReadXdcFromString(string content, CanOpenFileOptions options)
         => Xdc.ReadString(content, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadStream instead.")]
     public static DeviceConfigurationFile ReadXdc(
         Stream stream,
         long maxInputSize = ReaderDefaults.DefaultMaxInputSize)
         => Xdc.ReadStream(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize });
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStream"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadStream instead.")]
     public static DeviceConfigurationFile ReadXdc(Stream stream, CanOpenFileOptions options)
         => Xdc.ReadStream(stream, options);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         Stream stream,
         CancellationToken cancellationToken = default)
         => Xdc.ReadStreamAsync(stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         Stream stream,
         long maxInputSize,
@@ -780,6 +899,7 @@ public static class CanOpenFile
         => Xdc.ReadStreamAsync(stream, new CanOpenFileOptions { MaxInputSize = maxInputSize }, cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.ReadStreamAsync"/>
+    [Obsolete("Use CanOpenFile.Xdc.ReadStreamAsync instead.")]
     public static Task<DeviceConfigurationFile> ReadXdcAsync(
         Stream stream,
         CanOpenFileOptions options,
@@ -794,15 +914,20 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFile(DeviceConfigurationFile, string)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdc.WriteFile instead.")]
     public static void WriteXdc(DeviceConfigurationFile xdc, string filePath)
         => Xdc.WriteFile(xdc, filePath, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFile(DeviceConfigurationFile, string, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdc.WriteFile instead.")]
     public static void WriteXdc(DeviceConfigurationFile xdc, string filePath, CanOpenWriteOptions? options)
         => Xdc.WriteFile(xdc, filePath, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStream(DeviceConfigurationFile, Stream)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Xdc.WriteStream instead.")]
@@ -810,10 +935,13 @@ public static class CanOpenFile
         => Xdc.WriteStream(xdc, stream);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStream(DeviceConfigurationFile, Stream, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdc.WriteStream instead.")]
     public static void WriteXdc(DeviceConfigurationFile xdc, Stream stream, CanOpenWriteOptions? options)
         => Xdc.WriteStream(xdc, stream, options);
 
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFileAsync(DeviceConfigurationFile, string, CancellationToken)"/>
+
+
 
 
     [Obsolete("Use CanOpenFile.Xdc.WriteFileAsync instead.")]
@@ -824,6 +952,7 @@ public static class CanOpenFile
         => Xdc.WriteFileAsync(xdc, filePath, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteFileAsync(DeviceConfigurationFile, string, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Xdc.WriteFileAsync instead.")]
     public static Task WriteXdcAsync(
         DeviceConfigurationFile xdc,
         string filePath,
@@ -834,6 +963,8 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStreamAsync(DeviceConfigurationFile, Stream, CancellationToken)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdc.WriteStreamAsync instead.")]
     public static Task WriteXdcAsync(
         DeviceConfigurationFile xdc,
@@ -842,6 +973,7 @@ public static class CanOpenFile
         => Xdc.WriteStreamAsync(xdc, stream, cancellationToken: cancellationToken);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteStreamAsync(DeviceConfigurationFile, Stream, CanOpenWriteOptions?, CancellationToken)"/>
+    [Obsolete("Use CanOpenFile.Xdc.WriteStreamAsync instead.")]
     public static Task WriteXdcAsync(
         DeviceConfigurationFile xdc,
         Stream stream,
@@ -852,11 +984,14 @@ public static class CanOpenFile
         /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteToString(DeviceConfigurationFile)"/>
 
 
+
+
     [Obsolete("Use CanOpenFile.Xdc.WriteToString instead.")]
     public static string WriteXdcToString(DeviceConfigurationFile xdc)
         => Xdc.WriteToString(xdc, options: null);
 
     /// <inheritdoc cref="FormatCanOpenOperations{DeviceConfigurationFile}.WriteToString(DeviceConfigurationFile, CanOpenWriteOptions?)"/>
+    [Obsolete("Use CanOpenFile.Xdc.WriteToString instead.")]
     public static string WriteXdcToString(DeviceConfigurationFile xdc, CanOpenWriteOptions? options)
         => Xdc.WriteToString(xdc, options);
 


### PR DESCRIPTION
## Summary
- Mark all `Read*` facade methods obsolete with pointers to `CanOpenFile.{Eds,Dcf,Cpj,Xdd,Xdc}` entry points
- Mark all `Write*` overloads that accept `CanOpenWriteOptions` obsolete (matching the existing default-overload guidance)

Fixes #310

## Test plan
- [x] `dotnet build src/EdsDcfNet/EdsDcfNet.csproj`


Made with [Cursor](https://cursor.com)