### PR TITLE
fix(api): preserve format-specific write parameter names (#314 review)

### DIFF
--- a/src/EdsDcfNet/CpjCanOpenOperations.cs
+++ b/src/EdsDcfNet/CpjCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -31,4 +32,93 @@ public sealed class CpjCanOpenOperations : FormatCanOpenOperations<NodelistProje
             cpj => new CpjWriter().GenerateString(cpj))
     {
     }
+
+    /// <summary>
+    /// Writes a CPJ to disk.
+    /// </summary>
+    public new void WriteFile(NodelistProject cpj, string filePath)
+        => base.WriteFile(cpj, filePath);
+
+    /// <summary>
+    /// Writes a CPJ to disk.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteFile(NodelistProject cpj, string filePath, CanOpenWriteOptions? options)
+        => base.WriteFile(cpj, filePath, options);
+
+    /// <summary>
+    /// Writes a CPJ to a stream. The stream is not disposed.
+    /// </summary>
+    public new void WriteStream(NodelistProject cpj, Stream stream)
+        => base.WriteStream(cpj, stream);
+
+    /// <summary>
+    /// Writes a CPJ to a stream. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteStream(NodelistProject cpj, Stream stream, CanOpenWriteOptions? options)
+        => base.WriteStream(cpj, stream, options);
+
+    /// <summary>
+    /// Writes a CPJ to disk asynchronously.
+    /// </summary>
+    public new Task WriteFileAsync(
+        NodelistProject cpj,
+        string filePath,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(cpj, filePath, cancellationToken);
+
+    /// <summary>
+    /// Writes a CPJ to disk asynchronously.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteFileAsync(
+        NodelistProject cpj,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(cpj, filePath, options, cancellationToken);
+
+    /// <summary>
+    /// Writes a CPJ to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    public new Task WriteStreamAsync(
+        NodelistProject cpj,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(cpj, stream, cancellationToken);
+
+    /// <summary>
+    /// Writes a CPJ to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteStreamAsync(
+        NodelistProject cpj,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(cpj, stream, options, cancellationToken);
+
+    /// <summary>
+    /// Serializes a CPJ to a string.
+    /// </summary>
+    public new string WriteToString(NodelistProject cpj)
+        => base.WriteToString(cpj);
+
+    /// <summary>
+    /// Serializes a CPJ to a string.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new string WriteToString(NodelistProject cpj, CanOpenWriteOptions? options)
+        => base.WriteToString(cpj, options);
 }

--- a/src/EdsDcfNet/DcfCanOpenOperations.cs
+++ b/src/EdsDcfNet/DcfCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -31,4 +32,93 @@ public sealed class DcfCanOpenOperations : FormatCanOpenOperations<DeviceConfigu
             dcf => new DcfWriter().GenerateString(dcf))
     {
     }
+
+    /// <summary>
+    /// Writes a DCF to disk.
+    /// </summary>
+    public new void WriteFile(DeviceConfigurationFile dcf, string filePath)
+        => base.WriteFile(dcf, filePath);
+
+    /// <summary>
+    /// Writes a DCF to disk.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteFile(DeviceConfigurationFile dcf, string filePath, CanOpenWriteOptions? options)
+        => base.WriteFile(dcf, filePath, options);
+
+    /// <summary>
+    /// Writes a DCF to a stream. The stream is not disposed.
+    /// </summary>
+    public new void WriteStream(DeviceConfigurationFile dcf, Stream stream)
+        => base.WriteStream(dcf, stream);
+
+    /// <summary>
+    /// Writes a DCF to a stream. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteStream(DeviceConfigurationFile dcf, Stream stream, CanOpenWriteOptions? options)
+        => base.WriteStream(dcf, stream, options);
+
+    /// <summary>
+    /// Writes a DCF to disk asynchronously.
+    /// </summary>
+    public new Task WriteFileAsync(
+        DeviceConfigurationFile dcf,
+        string filePath,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(dcf, filePath, cancellationToken);
+
+    /// <summary>
+    /// Writes a DCF to disk asynchronously.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteFileAsync(
+        DeviceConfigurationFile dcf,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(dcf, filePath, options, cancellationToken);
+
+    /// <summary>
+    /// Writes a DCF to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    public new Task WriteStreamAsync(
+        DeviceConfigurationFile dcf,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(dcf, stream, cancellationToken);
+
+    /// <summary>
+    /// Writes a DCF to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteStreamAsync(
+        DeviceConfigurationFile dcf,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(dcf, stream, options, cancellationToken);
+
+    /// <summary>
+    /// Serializes a DCF to a string.
+    /// </summary>
+    public new string WriteToString(DeviceConfigurationFile dcf)
+        => base.WriteToString(dcf);
+
+    /// <summary>
+    /// Serializes a DCF to a string.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new string WriteToString(DeviceConfigurationFile dcf, CanOpenWriteOptions? options)
+        => base.WriteToString(dcf, options);
 }

--- a/src/EdsDcfNet/EdsCanOpenOperations.cs
+++ b/src/EdsDcfNet/EdsCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Utilities;
@@ -115,5 +116,94 @@ public sealed class EdsCanOpenOperations : FormatCanOpenOperations<ElectronicDat
         ushort baudrate = 250,
         string? nodeName = null)
         => ConvertToDcf(eds, nodeId, DateTime.UtcNow, baudrate, nodeName);
+
+    /// <summary>
+    /// Writes an EDS to disk.
+    /// </summary>
+    public new void WriteFile(ElectronicDataSheet eds, string filePath)
+        => base.WriteFile(eds, filePath);
+
+    /// <summary>
+    /// Writes an EDS to disk.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteFile(ElectronicDataSheet eds, string filePath, CanOpenWriteOptions? options)
+        => base.WriteFile(eds, filePath, options);
+
+    /// <summary>
+    /// Writes an EDS to a stream. The stream is not disposed.
+    /// </summary>
+    public new void WriteStream(ElectronicDataSheet eds, Stream stream)
+        => base.WriteStream(eds, stream);
+
+    /// <summary>
+    /// Writes an EDS to a stream. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteStream(ElectronicDataSheet eds, Stream stream, CanOpenWriteOptions? options)
+        => base.WriteStream(eds, stream, options);
+
+    /// <summary>
+    /// Writes an EDS to disk asynchronously.
+    /// </summary>
+    public new Task WriteFileAsync(
+        ElectronicDataSheet eds,
+        string filePath,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(eds, filePath, cancellationToken);
+
+    /// <summary>
+    /// Writes an EDS to disk asynchronously.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteFileAsync(
+        ElectronicDataSheet eds,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(eds, filePath, options, cancellationToken);
+
+    /// <summary>
+    /// Writes an EDS to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    public new Task WriteStreamAsync(
+        ElectronicDataSheet eds,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(eds, stream, cancellationToken);
+
+    /// <summary>
+    /// Writes an EDS to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteStreamAsync(
+        ElectronicDataSheet eds,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(eds, stream, options, cancellationToken);
+
+    /// <summary>
+    /// Serializes an EDS to a string.
+    /// </summary>
+    public new string WriteToString(ElectronicDataSheet eds)
+        => base.WriteToString(eds);
+
+    /// <summary>
+    /// Serializes an EDS to a string.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new string WriteToString(ElectronicDataSheet eds, CanOpenWriteOptions? options)
+        => base.WriteToString(eds, options);
 }
 #pragma warning restore CA1822

--- a/src/EdsDcfNet/XdcCanOpenOperations.cs
+++ b/src/EdsDcfNet/XdcCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -31,4 +32,93 @@ public sealed class XdcCanOpenOperations : FormatCanOpenOperations<DeviceConfigu
             xdc => new XdcWriter().GenerateString(xdc))
     {
     }
+
+    /// <summary>
+    /// Writes an XDC to disk.
+    /// </summary>
+    public new void WriteFile(DeviceConfigurationFile xdc, string filePath)
+        => base.WriteFile(xdc, filePath);
+
+    /// <summary>
+    /// Writes an XDC to disk.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteFile(DeviceConfigurationFile xdc, string filePath, CanOpenWriteOptions? options)
+        => base.WriteFile(xdc, filePath, options);
+
+    /// <summary>
+    /// Writes an XDC to a stream. The stream is not disposed.
+    /// </summary>
+    public new void WriteStream(DeviceConfigurationFile xdc, Stream stream)
+        => base.WriteStream(xdc, stream);
+
+    /// <summary>
+    /// Writes an XDC to a stream. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteStream(DeviceConfigurationFile xdc, Stream stream, CanOpenWriteOptions? options)
+        => base.WriteStream(xdc, stream, options);
+
+    /// <summary>
+    /// Writes an XDC to disk asynchronously.
+    /// </summary>
+    public new Task WriteFileAsync(
+        DeviceConfigurationFile xdc,
+        string filePath,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(xdc, filePath, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDC to disk asynchronously.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteFileAsync(
+        DeviceConfigurationFile xdc,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(xdc, filePath, options, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDC to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    public new Task WriteStreamAsync(
+        DeviceConfigurationFile xdc,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(xdc, stream, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDC to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteStreamAsync(
+        DeviceConfigurationFile xdc,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(xdc, stream, options, cancellationToken);
+
+    /// <summary>
+    /// Serializes an XDC to a string.
+    /// </summary>
+    public new string WriteToString(DeviceConfigurationFile xdc)
+        => base.WriteToString(xdc);
+
+    /// <summary>
+    /// Serializes an XDC to a string.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new string WriteToString(DeviceConfigurationFile xdc, CanOpenWriteOptions? options)
+        => base.WriteToString(xdc, options);
 }

--- a/src/EdsDcfNet/XddCanOpenOperations.cs
+++ b/src/EdsDcfNet/XddCanOpenOperations.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet;
 
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -31,4 +32,93 @@ public sealed class XddCanOpenOperations : FormatCanOpenOperations<ElectronicDat
             xdd => new XddWriter().GenerateString(xdd))
     {
     }
+
+    /// <summary>
+    /// Writes an XDD to disk.
+    /// </summary>
+    public new void WriteFile(ElectronicDataSheet xdd, string filePath)
+        => base.WriteFile(xdd, filePath);
+
+    /// <summary>
+    /// Writes an XDD to disk.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteFile(ElectronicDataSheet xdd, string filePath, CanOpenWriteOptions? options)
+        => base.WriteFile(xdd, filePath, options);
+
+    /// <summary>
+    /// Writes an XDD to a stream. The stream is not disposed.
+    /// </summary>
+    public new void WriteStream(ElectronicDataSheet xdd, Stream stream)
+        => base.WriteStream(xdd, stream);
+
+    /// <summary>
+    /// Writes an XDD to a stream. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new void WriteStream(ElectronicDataSheet xdd, Stream stream, CanOpenWriteOptions? options)
+        => base.WriteStream(xdd, stream, options);
+
+    /// <summary>
+    /// Writes an XDD to disk asynchronously.
+    /// </summary>
+    public new Task WriteFileAsync(
+        ElectronicDataSheet xdd,
+        string filePath,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(xdd, filePath, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDD to disk asynchronously.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteFileAsync(
+        ElectronicDataSheet xdd,
+        string filePath,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteFileAsync(xdd, filePath, options, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDD to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    public new Task WriteStreamAsync(
+        ElectronicDataSheet xdd,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(xdd, stream, cancellationToken);
+
+    /// <summary>
+    /// Writes an XDD to a stream asynchronously. The stream is not disposed.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new Task WriteStreamAsync(
+        ElectronicDataSheet xdd,
+        Stream stream,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+        => base.WriteStreamAsync(xdd, stream, options, cancellationToken);
+
+    /// <summary>
+    /// Serializes an XDD to a string.
+    /// </summary>
+    public new string WriteToString(ElectronicDataSheet xdd)
+        => base.WriteToString(xdd);
+
+    /// <summary>
+    /// Serializes an XDD to a string.
+    /// </summary>
+    /// <exception cref="ModelValidationException">
+    /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
+    /// </exception>
+    public new string WriteToString(ElectronicDataSheet xdd, CanOpenWriteOptions? options)
+        => base.WriteToString(xdd, options);
 }

--- a/tests/EdsDcfNet.Tests/Integration/FormatCanOpenOperationsTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/FormatCanOpenOperationsTests.cs
@@ -550,4 +550,119 @@ public class FormatCanOpenOperationsTests
                 File.Delete(asyncTempFile);
         }
     }
+
+    [Fact]
+    public async Task Eds_AsyncWritePathsWithOptions_ProduceReadableOutput()
+    {
+        var eds = CanOpenFile.ReadEds("Fixtures/sample_device.eds");
+        var asyncTempFile = Path.GetTempFileName();
+
+        try
+        {
+            await CanOpenFile.WriteEdsAsync(eds, asyncTempFile, CanOpenWriteOptions.Default);
+            CanOpenFile.ReadEds(asyncTempFile).DeviceInfo.ProductName.Should().Be(eds.DeviceInfo.ProductName);
+
+            using var asyncStream = new MemoryStream();
+            await CanOpenFile.WriteEdsAsync(eds, asyncStream, CanOpenWriteOptions.Default);
+            asyncStream.Position = 0;
+            CanOpenFile.ReadEds(asyncStream).DeviceInfo.ProductName.Should().Be(eds.DeviceInfo.ProductName);
+        }
+        finally
+        {
+            if (File.Exists(asyncTempFile))
+                File.Delete(asyncTempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Dcf_AsyncWritePathsWithOptions_ProduceReadableOutput()
+    {
+        var dcf = CanOpenFile.ReadDcf("Fixtures/minimal.dcf");
+        var asyncTempFile = Path.GetTempFileName();
+
+        try
+        {
+            await CanOpenFile.WriteDcfAsync(dcf, asyncTempFile, CanOpenWriteOptions.Default);
+            CanOpenFile.ReadDcf(asyncTempFile).DeviceCommissioning.NodeId.Should().Be(dcf.DeviceCommissioning.NodeId);
+
+            using var asyncStream = new MemoryStream();
+            await CanOpenFile.WriteDcfAsync(dcf, asyncStream, CanOpenWriteOptions.Default);
+            asyncStream.Position = 0;
+            CanOpenFile.ReadDcf(asyncStream).DeviceCommissioning.NodeId.Should().Be(dcf.DeviceCommissioning.NodeId);
+        }
+        finally
+        {
+            if (File.Exists(asyncTempFile))
+                File.Delete(asyncTempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Cpj_AsyncWritePathsWithOptions_ProduceReadableOutput()
+    {
+        var cpj = CanOpenFile.ReadCpjFromString(MinimalCpjContent);
+        var asyncTempFile = Path.GetTempFileName();
+
+        try
+        {
+            await CanOpenFile.WriteCpjAsync(cpj, asyncTempFile, CanOpenWriteOptions.Default);
+            CanOpenFile.ReadCpj(asyncTempFile).Networks[0].NetName.Should().Be(cpj.Networks[0].NetName);
+
+            using var asyncStream = new MemoryStream();
+            await CanOpenFile.WriteCpjAsync(cpj, asyncStream, CanOpenWriteOptions.Default);
+            asyncStream.Position = 0;
+            CanOpenFile.ReadCpj(asyncStream).Networks[0].NetName.Should().Be(cpj.Networks[0].NetName);
+        }
+        finally
+        {
+            if (File.Exists(asyncTempFile))
+                File.Delete(asyncTempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Xdd_AsyncWritePathsWithOptions_ProduceReadableOutput()
+    {
+        var xdd = CanOpenFile.ReadXdd("Fixtures/sample_device.xdd");
+        var asyncTempFile = Path.GetTempFileName();
+
+        try
+        {
+            await CanOpenFile.WriteXddAsync(xdd, asyncTempFile, CanOpenWriteOptions.Default);
+            CanOpenFile.ReadXdd(asyncTempFile).DeviceInfo.ProductName.Should().Be(xdd.DeviceInfo.ProductName);
+
+            using var asyncStream = new MemoryStream();
+            await CanOpenFile.WriteXddAsync(xdd, asyncStream, CanOpenWriteOptions.Default);
+            asyncStream.Position = 0;
+            CanOpenFile.ReadXdd(asyncStream).DeviceInfo.ProductName.Should().Be(xdd.DeviceInfo.ProductName);
+        }
+        finally
+        {
+            if (File.Exists(asyncTempFile))
+                File.Delete(asyncTempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Xdc_AsyncWritePathsWithOptions_ProduceReadableOutput()
+    {
+        var xdc = CanOpenFile.ReadXdc("Fixtures/minimal.xdc");
+        var asyncTempFile = Path.GetTempFileName();
+
+        try
+        {
+            await CanOpenFile.WriteXdcAsync(xdc, asyncTempFile, CanOpenWriteOptions.Default);
+            CanOpenFile.ReadXdc(asyncTempFile).DeviceCommissioning.NodeId.Should().Be(xdc.DeviceCommissioning.NodeId);
+
+            using var asyncStream = new MemoryStream();
+            await CanOpenFile.WriteXdcAsync(xdc, asyncStream, CanOpenWriteOptions.Default);
+            asyncStream.Position = 0;
+            CanOpenFile.ReadXdc(asyncStream).DeviceCommissioning.NodeId.Should().Be(xdc.DeviceCommissioning.NodeId);
+        }
+        finally
+        {
+            if (File.Exists(asyncTempFile))
+                File.Delete(asyncTempFile);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the codex review comment on #314: collapsing the format operations into `FormatCanOpenOperations<TModel>` renamed the first write parameter to `model`, a source-breaking change for consumers calling the canonical entry points with named arguments (e.g. `CanOpenFile.Dcf.WriteFile(dcf: dcf, filePath: path)`).

- Re-add thin forwarding write overloads (`WriteFile`/`WriteStream`/`WriteFileAsync`/`WriteStreamAsync`/`WriteToString`, both `options` variants) on each format operations class (`Eds`/`Dcf`/`Cpj`/`Xdd`/`Xdc`). They keep the original format-specific parameter names (`eds`/`dcf`/`cpj`/`xdd`/`xdc`) and delegate to the shared generic base via `base.Write*(...)`, restoring source compatibility while keeping the shared implementation.
- Read overloads were unaffected — their parameter names (`filePath`/`content`/`stream`) did not change.
- Add round-trip tests covering the async write-with-options paths for every format (`CanOpenFile.Write*Async(model, path, options)` and `(model, stream, options)`), which exercise both the static wrappers and the new forwarding overloads, closing the Codecov patch-coverage gap.

## Test plan

- [x] Build and Test workflow green (build, test, coverage threshold all pass)

Targets `refactor/306-format-canopen-operations-base` so the fix flows into #314.