### PR TITLE
fix: migrate non-test callers to CanOpenFile format entry points

### DIFF
--- a/benchmarks/EdsDcfNet.Benchmarks/ParserBenchmarks.cs
+++ b/benchmarks/EdsDcfNet.Benchmarks/ParserBenchmarks.cs
@@ -21,16 +21,16 @@ public class ParserBenchmarks
     }
 
     [Benchmark(Baseline = true, Description = "EDS parse (string)")]
-    public object EdsParseFromString() => CanOpenFile.ReadEdsFromString(_edsContent);
+    public object EdsParseFromString() => CanOpenFile.Eds.ReadString(_edsContent);
 
     [Benchmark(Description = "DCF parse (string)")]
-    public object DcfParseFromString() => CanOpenFile.ReadDcfFromString(_dcfContent);
+    public object DcfParseFromString() => CanOpenFile.Dcf.ReadString(_dcfContent);
 
     [Benchmark(Description = "CPJ parse (string)")]
-    public object CpjParseFromString() => CanOpenFile.ReadCpjFromString(_cpjContent);
+    public object CpjParseFromString() => CanOpenFile.Cpj.ReadString(_cpjContent);
 
     [Benchmark(Description = "XDD parse (string)")]
-    public object XddParseFromString() => CanOpenFile.ReadXddFromString(_xddContent);
+    public object XddParseFromString() => CanOpenFile.Xdd.ReadString(_xddContent);
 
     private static string GetFixturePath(string fileName)
     {

--- a/benchmarks/EdsDcfNet.Benchmarks/RoundTripBenchmarks.cs
+++ b/benchmarks/EdsDcfNet.Benchmarks/RoundTripBenchmarks.cs
@@ -21,29 +21,29 @@ public class RoundTripBenchmarks
     [Benchmark(Baseline = true, Description = "EDS round-trip (parse + write)")]
     public string EdsRoundTrip()
     {
-        var eds = CanOpenFile.ReadEdsFromString(_edsContent);
-        return CanOpenFile.WriteEdsToString(eds);
+        var eds = CanOpenFile.Eds.ReadString(_edsContent);
+        return CanOpenFile.Eds.WriteToString(eds);
     }
 
     [Benchmark(Description = "DCF round-trip (parse + write)")]
     public string DcfRoundTrip()
     {
-        var dcf = CanOpenFile.ReadDcfFromString(_dcfContent);
-        return CanOpenFile.WriteDcfToString(dcf);
+        var dcf = CanOpenFile.Dcf.ReadString(_dcfContent);
+        return CanOpenFile.Dcf.WriteToString(dcf);
     }
 
     [Benchmark(Description = "CPJ round-trip (parse + write)")]
     public string CpjRoundTrip()
     {
-        var cpj = CanOpenFile.ReadCpjFromString(_cpjContent);
-        return CanOpenFile.WriteCpjToString(cpj);
+        var cpj = CanOpenFile.Cpj.ReadString(_cpjContent);
+        return CanOpenFile.Cpj.WriteToString(cpj);
     }
 
     [Benchmark(Description = "EDS → DCF conversion")]
     public object EdsToDcfConversion()
     {
-        var eds = CanOpenFile.ReadEdsFromString(_edsContent);
-        return CanOpenFile.EdsToDcf(eds, nodeId: 1, baudrate: 250);
+        var eds = CanOpenFile.Eds.ReadString(_edsContent);
+        return CanOpenFile.Eds.ConvertToDcf(eds, nodeId: 1, baudrate: 250);
     }
 
     private static string GetFixturePath(string fileName)

--- a/benchmarks/EdsDcfNet.Benchmarks/WriterBenchmarks.cs
+++ b/benchmarks/EdsDcfNet.Benchmarks/WriterBenchmarks.cs
@@ -14,22 +14,22 @@ public class WriterBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _eds = CanOpenFile.ReadEds(GetFixturePath("sample_device.eds"));
-        _dcf = CanOpenFile.ReadDcf(GetFixturePath("minimal.dcf"));
-        _cpj = CanOpenFile.ReadCpj(GetFixturePath("minimal.cpj"));
+        _eds = CanOpenFile.Eds.ReadFile(GetFixturePath("sample_device.eds"));
+        _dcf = CanOpenFile.Dcf.ReadFile(GetFixturePath("minimal.dcf"));
+        _cpj = CanOpenFile.Cpj.ReadFile(GetFixturePath("minimal.cpj"));
     }
 
     [Benchmark(Baseline = true, Description = "EDS write (string)")]
-    public string EdsWriteToString() => CanOpenFile.WriteEdsToString(_eds);
+    public string EdsWriteToString() => CanOpenFile.Eds.WriteToString(_eds);
 
     [Benchmark(Description = "DCF write (string)")]
-    public string DcfWriteToString() => CanOpenFile.WriteDcfToString(_dcf);
+    public string DcfWriteToString() => CanOpenFile.Dcf.WriteToString(_dcf);
 
     [Benchmark(Description = "CPJ write (string)")]
-    public string CpjWriteToString() => CanOpenFile.WriteCpjToString(_cpj);
+    public string CpjWriteToString() => CanOpenFile.Cpj.WriteToString(_cpj);
 
     [Benchmark(Description = "XDD write (string)")]
-    public string XddWriteToString() => CanOpenFile.WriteXddToString(_eds);
+    public string XddWriteToString() => CanOpenFile.Xdd.WriteToString(_eds);
 
     private static string GetFixturePath(string fileName)
     {

--- a/examples/EdsDcfNet.Examples/Program.cs
+++ b/examples/EdsDcfNet.Examples/Program.cs
@@ -152,7 +152,7 @@ PDOMapping=1
 
         try
         {
-            var eds = CanOpenFile.ReadEdsFromString(sampleEds);
+            var eds = CanOpenFile.Eds.ReadString(sampleEds);
 
             Console.WriteLine($"Device: {eds.DeviceInfo.ProductName}");
             Console.WriteLine($"Vendor: {eds.DeviceInfo.VendorName} (ID: 0x{eds.DeviceInfo.VendorNumber:X})");
@@ -221,10 +221,10 @@ PDOMapping=1
         try
         {
             // Read EDS
-            var eds = CanOpenFile.ReadEdsFromString(sampleEds);
+            var eds = CanOpenFile.Eds.ReadString(sampleEds);
 
             // Convert to DCF with Node ID 3 and 500 kbit/s
-            var dcf = CanOpenFile.EdsToDcf(eds, nodeId: 3, baudrate: 500, nodeName: "IO_Module_Node3");
+            var dcf = CanOpenFile.Eds.ConvertToDcf(eds, nodeId: 3, baudrate: 500, nodeName: "IO_Module_Node3");
 
             Console.WriteLine($"Created DCF for Node {dcf.DeviceCommissioning.NodeId}");
             Console.WriteLine($"Node Name: {dcf.DeviceCommissioning.NodeName}");
@@ -232,7 +232,7 @@ PDOMapping=1
             Console.WriteLine($"Device: {dcf.DeviceInfo.ProductName}");
 
             // Generate DCF content
-            var dcfContent = CanOpenFile.WriteDcfToString(dcf);
+            var dcfContent = CanOpenFile.Dcf.WriteToString(dcf);
             Console.WriteLine($"\nDCF Content Length: {dcfContent.Length} bytes");
             Console.WriteLine("First 200 characters:");
             Console.WriteLine(dcfContent.Substring(0, Math.Min(200, dcfContent.Length)));

--- a/tests/EdsDcfNet.TestHost/Program.cs
+++ b/tests/EdsDcfNet.TestHost/Program.cs
@@ -26,8 +26,8 @@ internal static class Program
         {
             var eds = mode switch
             {
-                "sync" => CanOpenFile.ReadEds(filePath),
-                "async" => await CanOpenFile.ReadEdsAsync(filePath).ConfigureAwait(false),
+                "sync" => CanOpenFile.Eds.ReadFile(filePath),
+                "async" => await CanOpenFile.Eds.ReadFileAsync(filePath).ConfigureAwait(false),
                 _ => throw new ArgumentException($"Unknown mode '{mode}'. Expected 'sync' or 'async'.", nameof(args))
             };
 


### PR DESCRIPTION
## Summary
- Replace obsolete `CanOpenFile.Read*` / `Write*` / `EdsToDcf` calls in examples, benchmarks, and the test host with the canonical format entry points (`CanOpenFile.Eds`, `.Dcf`, `.Cpj`, `.Xdd`).
- Keeps legacy facade usage confined to `EdsDcfNet.Tests`, where `CS0618` is intentionally suppressed for compatibility coverage.

Fixes #322

## Test plan
- [x] `dotnet build --disable-build-servers -m:1` (0 warnings, 0 errors)
- [ ] CI green on PR checks


Made with [Cursor](https://cursor.com)