### PR TITLE
test: guard ModelCloner against silent field-drop with reflection completeness test

### DIFF
--- a/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
@@ -89,6 +89,14 @@ internal static class ModelCloneSampleBuilder
             if (!property.CanWrite)
                 continue;
 
+            if (IsCollectionType(property.PropertyType))
+            {
+                var collection = CreateCollectionInstance(property.PropertyType);
+                PopulateCollection(collection, property.PropertyType, ref seed, depth);
+                property.SetValue(instance, collection);
+                continue;
+            }
+
             var value = CreatePropertyValue(property.PropertyType, ref seed, depth, property.Name);
             if (value != ModelCloneSampleBuilderSkippedMarker.Value)
                 property.SetValue(instance, value);
@@ -104,14 +112,14 @@ internal static class ModelCloneSampleBuilder
 
     private static void PopulateCollection(object? collection, Type collectionType, ref int seed, int depth)
     {
-        if (collection is not IList list)
-            return;
-
         if (collection is IDictionary dictionary)
         {
             PopulateDictionary(dictionary, collectionType, ref seed, depth);
             return;
         }
+
+        if (collection is not IList list)
+            return;
 
         var elementType = collectionType.IsGenericType
             ? collectionType.GetGenericArguments()[0]
@@ -178,11 +186,37 @@ internal static class ModelCloneSampleBuilder
         return ModelCloneSampleBuilderSkippedMarker.Value;
     }
 
+    private static bool IsCollectionType(Type type) =>
+        typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
+
     private static bool IsReadOnlyCollection(PropertyInfo property) =>
-        property.CanRead
-        && !property.CanWrite
-        && typeof(IEnumerable).IsAssignableFrom(property.PropertyType)
-        && property.PropertyType != typeof(string);
+        property.CanRead && !property.CanWrite && IsCollectionType(property.PropertyType);
+
+    private static object CreateCollectionInstance(Type collectionType)
+    {
+        if (collectionType.IsInterface && collectionType.IsGenericType)
+        {
+            var definition = collectionType.GetGenericTypeDefinition();
+            var typeArguments = collectionType.GetGenericArguments();
+
+            if (definition == typeof(IList<>)
+                || definition == typeof(ICollection<>)
+                || definition == typeof(IEnumerable<>)
+                || definition == typeof(IReadOnlyList<>)
+                || definition == typeof(IReadOnlyCollection<>))
+            {
+                return Activator.CreateInstance(typeof(List<>).MakeGenericType(typeArguments[0]))!;
+            }
+
+            if (definition == typeof(IDictionary<,>) || definition == typeof(IReadOnlyDictionary<,>))
+            {
+                return Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeArguments[0], typeArguments[1]))!;
+            }
+        }
+
+        return Activator.CreateInstance(collectionType)
+            ?? throw new InvalidOperationException($"Could not create a collection instance of {collectionType.FullName}.");
+    }
 
     private static object GetNonDefaultEnumValue(Type enumType, int seed)
     {
@@ -293,12 +327,6 @@ internal static class ModelCloneDeepAssert
             if (property.PropertyType == typeof(string) || property.PropertyType.IsValueType)
             {
                 cloneValue.Should().Be(sourceValue, $"{propertyPath} scalar values should match");
-                continue;
-            }
-
-            if (sourceValue is IEnumerable and not string)
-            {
-                AssertEquivalent(sourceValue, cloneValue!, propertyPath, assertDistinctInstances: true);
                 continue;
             }
 

--- a/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
@@ -98,8 +98,14 @@ internal static class ModelCloneSampleBuilder
             }
 
             var value = CreatePropertyValue(property.PropertyType, ref seed, depth, property.Name);
-            if (value != ModelCloneSampleBuilderSkippedMarker.Value)
-                property.SetValue(instance, value);
+            if (value == ModelCloneSampleBuilderSkippedMarker.Value)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot populate settable property {instance.GetType().Name}.{property.Name} " +
+                    $"of type {property.PropertyType.FullName} for clone completeness testing.");
+            }
+
+            property.SetValue(instance, value);
         }
     }
 
@@ -125,7 +131,7 @@ internal static class ModelCloneSampleBuilder
             ? collectionType.GetGenericArguments()[0]
             : typeof(object);
 
-        if (elementType == typeof(ApParameterGroup) && depth >= MaxParameterGroupDepth)
+        if (elementType == typeof(ApParameterGroup) && depth > MaxParameterGroupDepth)
             return;
 
         list.Add(CreateCollectionElement(elementType, ref seed, depth));
@@ -142,7 +148,11 @@ internal static class ModelCloneSampleBuilder
             : CreatePropertyValue(valueType, ref seed, depth + 1, dictionaryType.Name);
 
         if (value == ModelCloneSampleBuilderSkippedMarker.Value)
-            return;
+        {
+            throw new InvalidOperationException(
+                $"Cannot populate dictionary value of type {valueType.FullName} " +
+                $"for clone completeness testing.");
+        }
 
         dictionary[key] = value;
     }
@@ -177,11 +187,18 @@ internal static class ModelCloneSampleBuilder
         if (underlying != null)
             return CreateSample(underlying, ref seed, depth + 1);
 
-        if (propertyType == typeof(ApParameterGroup) && depth >= MaxParameterGroupDepth)
+        if (propertyType == typeof(ApParameterGroup) && depth > MaxParameterGroupDepth)
             return ModelCloneSampleBuilderSkippedMarker.Value;
 
         if (IsModelType(propertyType))
             return CreateSample(propertyType, ref seed, depth + 1);
+
+        if (IsCollectionType(propertyType))
+        {
+            var collection = CreateCollectionInstance(propertyType);
+            PopulateCollection(collection, propertyType, ref seed, depth);
+            return collection;
+        }
 
         return ModelCloneSampleBuilderSkippedMarker.Value;
     }
@@ -316,6 +333,13 @@ internal static class ModelCloneDeepAssert
             var cloneValue = property.GetValue(clone);
             var propertyPath = $"{path}.{property.Name}";
 
+            if (property.CanWrite && IsUnsetValue(sourceValue, property.PropertyType))
+            {
+                sourceValue.Should().NotBeNull(
+                    $"{propertyPath} must be populated in completeness test source; " +
+                    "settable properties left at default/null cannot verify clone coverage");
+            }
+
             if (sourceValue is null)
             {
                 cloneValue.Should().BeNull($"{propertyPath} should remain null");
@@ -400,6 +424,27 @@ internal static class ModelCloneDeepAssert
 
             AssertEquivalent(sourceValue, cloneValue!, keyPath, assertDistinctInstances: true);
         }
+    }
+
+    private static bool IsUnsetValue(object? value, Type propertyType)
+    {
+        if (value is null)
+            return true;
+
+        if (propertyType == typeof(string))
+            return string.IsNullOrEmpty((string)value);
+
+        var underlying = Nullable.GetUnderlyingType(propertyType);
+        if (underlying != null)
+            return false;
+
+        if (propertyType.IsValueType)
+        {
+            var defaultValue = Activator.CreateInstance(propertyType)!;
+            return value.Equals(defaultValue);
+        }
+
+        return false;
     }
 }
 

--- a/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ModelCloneCompletenessSupport.cs
@@ -1,0 +1,392 @@
+namespace EdsDcfNet.Tests.Utilities;
+
+using System.Collections;
+using System.Reflection;
+using EdsDcfNet;
+using EdsDcfNet.Models;
+using FluentAssertions;
+
+/// <summary>
+/// Builds model instances with every public settable property and collection entry
+/// populated to a distinct non-default value for clone completeness testing.
+/// </summary>
+internal static class ModelCloneSampleBuilder
+{
+    private const int MaxParameterGroupDepth = 2;
+
+    public static object CreateSourceArgument(ParameterInfo parameter, ref int seed)
+    {
+        var parameterType = parameter.ParameterType;
+
+        if (parameterType == typeof(List<ModuleInfo>))
+        {
+            var list = new List<ModuleInfo> { (ModuleInfo)CreateSample(typeof(ModuleInfo), ref seed) };
+            return list;
+        }
+
+        if (parameterType == typeof(List<ToolInfo>))
+        {
+            var list = new List<ToolInfo> { (ToolInfo)CreateSample(typeof(ToolInfo), ref seed) };
+            return list;
+        }
+
+        if (parameterType == typeof(Dictionary<string, Dictionary<string, string>>))
+        {
+            var section = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [$"key_{seed++}"] = $"value_{seed++}"
+            };
+            return new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                [$"Section_{seed++}"] = section
+            };
+        }
+
+        var underlying = Nullable.GetUnderlyingType(parameterType);
+        if (underlying != null)
+            return CreateSample(underlying, ref seed);
+
+        return CreateSample(parameterType, ref seed);
+    }
+
+    public static object CreateSample(Type type, ref int seed) =>
+        CreateSample(type, ref seed, depth: 0);
+
+    private static object CreateSample(Type type, ref int seed, int depth)
+    {
+        if (type == typeof(string))
+            return $"sample_{seed++}";
+
+        if (type.IsEnum)
+            return GetNonDefaultEnumValue(type, seed++);
+
+        if (type.IsPrimitive)
+            return GetNonDefaultPrimitive(type, seed++);
+
+        var instance = Activator.CreateInstance(type)
+            ?? throw new InvalidOperationException($"Could not create an instance of {type.FullName}.");
+
+        Populate(instance, ref seed, depth);
+        return instance;
+    }
+
+    public static void Populate(object instance, ref int seed, int depth = 0)
+    {
+        foreach (var property in instance.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (property.PropertyType == typeof(ApLabelGroup) && property.CanRead && !property.CanWrite)
+            {
+                PopulateLabelGroup((ApLabelGroup)property.GetValue(instance)!, ref seed);
+                continue;
+            }
+
+            if (IsReadOnlyCollection(property))
+            {
+                PopulateCollection(property.GetValue(instance), property.PropertyType, ref seed, depth);
+                continue;
+            }
+
+            if (!property.CanWrite)
+                continue;
+
+            var value = CreatePropertyValue(property.PropertyType, ref seed, depth, property.Name);
+            if (value != ModelCloneSampleBuilderSkippedMarker.Value)
+                property.SetValue(instance, value);
+        }
+    }
+
+    private static void PopulateLabelGroup(ApLabelGroup labelGroup, ref int seed)
+    {
+        labelGroup.Labels.Add((ApLabel)CreateSample(typeof(ApLabel), ref seed));
+        labelGroup.Descriptions.Add((ApDescription)CreateSample(typeof(ApDescription), ref seed));
+        labelGroup.TextRefs.Add((ApTextRef)CreateSample(typeof(ApTextRef), ref seed));
+    }
+
+    private static void PopulateCollection(object? collection, Type collectionType, ref int seed, int depth)
+    {
+        if (collection is not IList list)
+            return;
+
+        if (collection is IDictionary dictionary)
+        {
+            PopulateDictionary(dictionary, collectionType, ref seed, depth);
+            return;
+        }
+
+        var elementType = collectionType.IsGenericType
+            ? collectionType.GetGenericArguments()[0]
+            : typeof(object);
+
+        if (elementType == typeof(ApParameterGroup) && depth >= MaxParameterGroupDepth)
+            return;
+
+        list.Add(CreateCollectionElement(elementType, ref seed, depth));
+    }
+
+    private static void PopulateDictionary(IDictionary dictionary, Type dictionaryType, ref int seed, int depth)
+    {
+        var keyType = dictionaryType.GenericTypeArguments[0];
+        var valueType = dictionaryType.GenericTypeArguments[1];
+
+        var key = CreateDictionaryKey(keyType, ref seed);
+        var value = IsModelType(valueType)
+            ? CreateSample(valueType, ref seed, depth + 1)
+            : CreatePropertyValue(valueType, ref seed, depth + 1, dictionaryType.Name);
+
+        if (value == ModelCloneSampleBuilderSkippedMarker.Value)
+            return;
+
+        dictionary[key] = value;
+    }
+
+    private static object CreateDictionaryKey(Type keyType, ref int seed) =>
+        keyType switch
+        {
+            _ when keyType == typeof(string) => $"dict_key_{seed++}",
+            _ when keyType == typeof(ushort) => (ushort)(0x1000 + seed++),
+            _ when keyType == typeof(byte) => (byte)((seed++ % 254) + 1),
+            _ when keyType == typeof(int) => seed++,
+            _ => CreateSample(keyType, ref seed)
+        };
+
+    private static object CreateCollectionElement(Type elementType, ref int seed, int depth) =>
+        elementType == typeof(string)
+            ? $"item_{seed++}"
+            : CreateSample(elementType, ref seed, depth + 1);
+
+    private static object CreatePropertyValue(Type propertyType, ref int seed, int depth, string propertyName)
+    {
+        if (propertyType == typeof(string))
+            return $"prop_{propertyName}_{seed++}";
+
+        if (propertyType.IsEnum)
+            return GetNonDefaultEnumValue(propertyType, seed++);
+
+        if (propertyType.IsPrimitive)
+            return GetNonDefaultPrimitive(propertyType, seed++);
+
+        var underlying = Nullable.GetUnderlyingType(propertyType);
+        if (underlying != null)
+            return CreateSample(underlying, ref seed, depth + 1);
+
+        if (propertyType == typeof(ApParameterGroup) && depth >= MaxParameterGroupDepth)
+            return ModelCloneSampleBuilderSkippedMarker.Value;
+
+        if (IsModelType(propertyType))
+            return CreateSample(propertyType, ref seed, depth + 1);
+
+        return ModelCloneSampleBuilderSkippedMarker.Value;
+    }
+
+    private static bool IsReadOnlyCollection(PropertyInfo property) =>
+        property.CanRead
+        && !property.CanWrite
+        && typeof(IEnumerable).IsAssignableFrom(property.PropertyType)
+        && property.PropertyType != typeof(string);
+
+    private static object GetNonDefaultEnumValue(Type enumType, int seed)
+    {
+        var values = Enum.GetValues(enumType);
+        if (values.Length == 1)
+            return values.GetValue(0)!;
+
+        var index = Math.Abs(seed % values.Length) % values.Length;
+        return values.GetValue(index)!;
+    }
+
+    private static object GetNonDefaultPrimitive(Type type, int seed) =>
+        Type.GetTypeCode(type) switch
+        {
+            TypeCode.Boolean => true,
+            TypeCode.Byte => (byte)((seed % 254) + 1),
+            TypeCode.SByte => (sbyte)1,
+            TypeCode.Int16 => (short)(seed + 1),
+            TypeCode.UInt16 => (ushort)(seed + 1),
+            TypeCode.Int32 => seed + 1,
+            TypeCode.UInt32 => (uint)(seed + 1),
+            TypeCode.Int64 => (long)seed + 1,
+            TypeCode.UInt64 => (ulong)seed + 1,
+            TypeCode.Single => seed + 0.5f,
+            TypeCode.Double => seed + 0.5d,
+            TypeCode.Char => (char)('A' + (seed % 26)),
+            _ => Activator.CreateInstance(type)!
+        };
+
+    private static bool IsModelType(Type type) =>
+        type.Namespace?.StartsWith("EdsDcfNet.Models", StringComparison.Ordinal) == true;
+}
+
+internal static class ModelCloneSampleBuilderSkippedMarker
+{
+    internal static readonly object Value = new();
+}
+
+/// <summary>
+/// Asserts deep structural equality and deep-copy semantics between a source model graph
+/// and its clone.
+/// </summary>
+internal static class ModelCloneDeepAssert
+{
+    public static void AssertDeepClone(object? source, object? clone, string path = "root")
+    {
+        if (source is null || clone is null)
+        {
+            source.Should().BeSameAs(clone, $"both sides should be null at {path}");
+            return;
+        }
+
+        clone.Should().NotBeSameAs(source, $"top-level clone must be a new instance at {path}");
+        AssertEquivalent(source, clone, path, assertDistinctInstances: true);
+    }
+
+    private static void AssertEquivalent(
+        object source,
+        object clone,
+        string path,
+        bool assertDistinctInstances)
+    {
+        if (source is string sourceString)
+        {
+            clone.Should().BeOfType<string>($"{path} should remain a string");
+            clone.Should().Be(sourceString, $"{path} string values should match");
+            return;
+        }
+
+        if (source.GetType().IsValueType)
+        {
+            clone.Should().Be(source, $"{path} value-type members should match");
+            return;
+        }
+
+        if (source is IDictionary sourceDictionary)
+        {
+            AssertDictionaryEquivalent(sourceDictionary, (IDictionary)clone, path, assertDistinctInstances);
+            return;
+        }
+
+        if (source is IList sourceList)
+        {
+            AssertListEquivalent(sourceList, (IList)clone, path, assertDistinctInstances);
+            return;
+        }
+
+        if (assertDistinctInstances)
+            clone.Should().NotBeSameAs(source, $"{path} should be a deep-copied instance");
+
+        foreach (var property in source.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (!property.CanRead)
+                continue;
+
+            var sourceValue = property.GetValue(source);
+            var cloneValue = property.GetValue(clone);
+            var propertyPath = $"{path}.{property.Name}";
+
+            if (sourceValue is null)
+            {
+                cloneValue.Should().BeNull($"{propertyPath} should remain null");
+                continue;
+            }
+
+            cloneValue.Should().NotBeNull($"{propertyPath} should be cloned");
+
+            if (property.PropertyType == typeof(string) || property.PropertyType.IsValueType)
+            {
+                cloneValue.Should().Be(sourceValue, $"{propertyPath} scalar values should match");
+                continue;
+            }
+
+            if (sourceValue is IEnumerable and not string)
+            {
+                AssertEquivalent(sourceValue, cloneValue!, propertyPath, assertDistinctInstances: true);
+                continue;
+            }
+
+            AssertEquivalent(sourceValue, cloneValue!, propertyPath, assertDistinctInstances: true);
+        }
+    }
+
+    private static void AssertListEquivalent(
+        IList source,
+        IList clone,
+        string path,
+        bool assertDistinctInstances)
+    {
+        if (assertDistinctInstances)
+            clone.Should().NotBeSameAs(source, $"{path} collection should be a new instance");
+
+        clone.Count.Should().Be(source.Count, $"{path} collection counts should match");
+
+        for (var i = 0; i < source.Count; i++)
+        {
+            var itemPath = $"{path}[{i}]";
+            var sourceItem = source[i];
+            var cloneItem = clone[i];
+
+            if (sourceItem is null)
+            {
+                cloneItem.Should().BeNull(itemPath);
+                continue;
+            }
+
+            if (sourceItem is string or ValueType)
+            {
+                cloneItem.Should().Be(sourceItem, $"{itemPath} element values should match");
+                continue;
+            }
+
+            AssertEquivalent(sourceItem, cloneItem!, itemPath, assertDistinctInstances: true);
+        }
+    }
+
+    private static void AssertDictionaryEquivalent(
+        IDictionary source,
+        IDictionary clone,
+        string path,
+        bool assertDistinctInstances)
+    {
+        if (assertDistinctInstances)
+            clone.Should().NotBeSameAs(source, $"{path} dictionary should be a new instance");
+
+        clone.Count.Should().Be(source.Count, $"{path} dictionary counts should match");
+
+        foreach (DictionaryEntry entry in source)
+        {
+            var keyPath = $"{path}[{entry.Key}]";
+            clone.Contains(entry.Key).Should().BeTrue($"{keyPath} key should exist in clone");
+
+            var sourceValue = entry.Value;
+            var cloneValue = clone[entry.Key];
+
+            if (sourceValue is null)
+            {
+                cloneValue.Should().BeNull(keyPath);
+                continue;
+            }
+
+            if (sourceValue is string or ValueType)
+            {
+                cloneValue.Should().Be(sourceValue, $"{keyPath} values should match");
+                continue;
+            }
+
+            AssertEquivalent(sourceValue, cloneValue!, keyPath, assertDistinctInstances: true);
+        }
+    }
+}
+
+/// <summary>
+/// Discovers <see cref="EdsDcfNet.Utilities.ModelCloner"/> clone entry points via reflection.
+/// </summary>
+internal static class ModelClonerTestCatalog
+{
+  private static readonly Type ModelClonerType =
+      typeof(CanOpenFile).Assembly.GetType("EdsDcfNet.Utilities.ModelCloner", throwOnError: true)!;
+
+  public static IEnumerable<object[]> CloneMethods =>
+      ModelClonerType
+          .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+          .Where(method => method.Name.StartsWith("Clone", StringComparison.Ordinal))
+          .OrderBy(method => method.Name, StringComparer.Ordinal)
+          .Select(method => new object[] { method.Name });
+}

--- a/tests/EdsDcfNet.Tests/Utilities/ModelClonerCompletenessTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ModelClonerCompletenessTests.cs
@@ -1,0 +1,52 @@
+namespace EdsDcfNet.Tests.Utilities;
+
+using System.Reflection;
+using EdsDcfNet;
+using EdsDcfNet.Models;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Reflection-based completeness guard for <c>ModelCloner</c>: every public settable
+/// property on cloned model types must be deep-copied.
+/// </summary>
+public class ModelClonerCompletenessTests
+{
+    private static readonly Type ModelClonerType =
+        typeof(CanOpenFile).Assembly.GetType("EdsDcfNet.Utilities.ModelCloner", throwOnError: true)!;
+
+    [Theory]
+    [MemberData(nameof(ModelClonerTestCatalog.CloneMethods), MemberType = typeof(ModelClonerTestCatalog))]
+    public void CloneMethod_PopulatedSource_ProducesDeepEqualDistinctClone(string cloneMethodName)
+    {
+        // Arrange
+        var method = ModelClonerType.GetMethod(
+            cloneMethodName,
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        method.Should().NotBeNull($"expected ModelCloner.{cloneMethodName} to exist");
+
+        var seed = cloneMethodName.GetHashCode(StringComparison.Ordinal);
+        var sourceArgument = ModelCloneSampleBuilder.CreateSourceArgument(method!.GetParameters()[0], ref seed);
+
+        // Act
+        var clone = method.Invoke(null, new[] { sourceArgument });
+
+        // Assert
+        ModelCloneDeepAssert.AssertDeepClone(sourceArgument, clone, cloneMethodName);
+    }
+
+    [Fact]
+    public void CloneMethod_PopulatedCanOpenObject_FailsWhenPropertyNotCopied()
+    {
+        // Guard-rail: the completeness harness must detect a deliberate omission.
+        var seed = 0;
+        var source = (CanOpenObject)ModelCloneSampleBuilder.CreateSample(typeof(CanOpenObject), ref seed);
+        var incompleteClone = (CanOpenObject)ModelCloneSampleBuilder.CreateSample(typeof(CanOpenObject), ref seed);
+        incompleteClone.ParameterName = source.ParameterName;
+        incompleteClone.Index = source.Index;
+
+        var act = () => ModelCloneDeepAssert.AssertDeepClone(source, incompleteClone, "CanOpenObject");
+
+        act.Should().Throw<Exception>();
+    }
+}

--- a/tests/EdsDcfNet.Tests/Utilities/ModelClonerCompletenessTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ModelClonerCompletenessTests.cs
@@ -49,4 +49,16 @@ public class ModelClonerCompletenessTests
 
         act.Should().Throw<Exception>();
     }
+
+    [Fact]
+    public void DeepAssert_FailsWhenSettablePropertyLeftAtDefaultInSource()
+    {
+        // Guard-rail: null/default on both sides must not count as a successful clone check.
+        var source = new CanOpenObject();
+        var clone = new CanOpenObject();
+
+        var act = () => ModelCloneDeepAssert.AssertDeepClone(source, clone, "CanOpenObject");
+
+        act.Should().Throw<Exception>();
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes a blind spot in the `ModelCloner` reflection completeness harness where settable properties left at default/null could not verify clone coverage.

## Problem

`ModelCloneSampleBuilder` silently skipped settable properties when `CreatePropertyValue` returned the skipped marker (non-model reference types, depth-capped `ApParameterGroup`, etc.). `ModelCloneDeepAssert` then treated matching null/defaults on source and clone as success, allowing `ModelCloner` to omit copying those members without failing completeness tests.

## Fix

- **Sample builder**: populate non-model collection types (e.g. nested `Dictionary<string,string>`) via `CreateCollectionInstance`; throw when a settable property cannot be populated; throw on skipped dictionary values instead of silently omitting entries.
- **Deep assert**: fail when a settable property remains at default/null in the test source.
- **Depth cap**: allow one additional `ApParameterGroup` nesting level in collection samples (`depth > MaxParameterGroupDepth`).

## Tests

- All 37 `ModelClonerCompleteness` tests pass.
- Added `DeepAssert_FailsWhenSettablePropertyLeftAtDefaultInSource` guard-rail test.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cc786e9-27c6-43ef-a93f-36b276d12aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cc786e9-27c6-43ef-a93f-36b276d12aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

