### PR TITLE
docs: add public API compatibility pre-merge checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Description
+
+<!-- What does this PR do? Link related issues with "Closes #…" when applicable. -->
+
+## Type of change
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature (`feat:`)
+- [ ] Refactor (`refactor:`)
+- [ ] Documentation (`docs:`)
+- [ ] Tests (`test:`)
+- [ ] CI / build (`ci:` / `build:`)
+- [ ] Other (`chore:`)
+
+## Public API changes
+
+Does this PR modify public members in `EdsDcfNet` (for example `CanOpenFile`,
+format entry points, or models consumed by library callers)?
+
+- [ ] **No** public API changes
+- [ ] **Yes** — I completed the
+      [Public API compatibility checklist](../CONTRIBUTING.md#public-api-compatibility-checklist)
+      in `CONTRIBUTING.md` (binary ABI, named arguments, overload shape, XML
+      doc / warnings-as-errors)
+
+<!-- If "Yes", briefly note preserved overloads, `[Obsolete]` attributes, or
+     parameter renames reviewers should verify. -->
+
+## Testing
+
+- [ ] `dotnet test --configuration Release` passes locally
+- [ ] `dotnet build --configuration Release` passes locally (required when
+      public API or XML docs changed)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ format entry points, or models consumed by library callers)?
 
 - [ ] **No** public API changes
 - [ ] **Yes** — I completed the
-      [Public API compatibility checklist](../CONTRIBUTING.md#public-api-compatibility-checklist)
+      [Public API compatibility checklist](https://github.com/dborgards/eds-dcf-net/blob/develop/CONTRIBUTING.md#public-api-compatibility-checklist)
       in `CONTRIBUTING.md` (binary ABI, named arguments, overload shape, XML
       doc / warnings-as-errors)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,6 +141,24 @@ This project uses a **develop → main** integration model:
 
 Direct commits to `main` or `develop` are not allowed; all changes go through PRs.
 
+## Public API compatibility
+
+When a change touches public surface area on `EdsDcfNet` (for example
+`CanOpenFile`, format entry points, or public models), follow the
+**[Public API compatibility checklist](../CONTRIBUTING.md#public-api-compatibility-checklist)**
+in `CONTRIBUTING.md` before opening a PR. It covers:
+
+- **Binary ABI** — no silent removal of public overloads (see #302)
+- **Named arguments** — parameter names are a source contract; shared generic
+  bases must not rename parameters visible on format entry points (see #314,
+  #321)
+- **Overload shape** — preserve or obsolete every sibling overload in the same
+  PR (see #302, #314)
+- **XML doc / warnings-as-errors** — no new CS15xx/CS16xx under
+  `TreatWarningsAsErrors`
+
+PRs that modify public API should confirm the checklist in the PR template.
+
 ## Code Style
 
 - XML doc comments on all public members

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,11 @@ refactor/xyz    ──┘      │           │
 
 5. **Open a PR targeting `develop`** (not `main`).
 
-6. Wait for CI (build + tests) to pass and for review.
+6. If your change touches public surface area on `EdsDcfNet`, complete the
+   [Public API compatibility checklist](#public-api-compatibility-checklist)
+   below and confirm it in the PR template.
+
+7. Wait for CI (build + tests) to pass and for review.
 
 ## Coding conventions
 
@@ -105,6 +109,55 @@ feat: redesign public API
 
 BREAKING CHANGE: CanOpenFile.Eds.ReadFile now returns a Result type
 ```
+
+## Public API compatibility checklist
+
+Use this checklist for any PR that adds, removes, renames, or reshapes public
+members in `EdsDcfNet` — especially `CanOpenFile`, format entry points
+(`.Eds`, `.Dcf`, `.Cpj`, `.Xdd`, `.Xdc`), and models consumed by library
+callers.
+
+Recent refactors surfaced gaps that were caught only after merge or by
+downstream consumers. Each item below maps to a real incident so reviewers
+know why it matters.
+
+- [ ] **Binary ABI** — Do not remove existing public methods or overloads
+  without a **major** release and an explicit `BREAKING CHANGE` note in the
+  commit body or PR description. Precompiled consumers may still call
+  signatures marked `[Obsolete]`; removing them causes
+  `MissingMethodException` at runtime. When in doubt, keep the signature and
+  mark it obsolete instead of deleting it.
+  *(Incident: [#302](https://github.com/dborgards/eds-dcf-net/pull/302) —
+  removed legacy `Write*` overloads broke precompiled consumers; binary-compatible
+  overloads were restored.)*
+
+- [ ] **Named arguments** — Parameter names on public methods are part of the
+  **source contract**. Shared generic bases must not silently rename parameters
+  that appear on derived or format-specific entry points; callers using named
+  arguments will fail to compile even when overload resolution still succeeds.
+  *(Incident: [#314](https://github.com/dborgards/eds-dcf-net/pull/314) /
+  [#321](https://github.com/dborgards/eds-dcf-net/pull/321) — a shared generic
+  base changed parameter names on format entry points; #321 restored
+  named-argument compatibility.)*
+
+- [ ] **Overload shape** — When slimming or redirecting facades, preserve or
+  explicitly obsolete **every sibling overload** in the same PR — both
+  default-argument and options-taking variants. Do not remove one overload
+  shape while leaving its sibling in place without an `[Obsolete]` migration
+  path.
+  *(Incident: [#302](https://github.com/dborgards/eds-dcf-net/pull/302) —
+  partial removal of `Write*` overload shapes; same facade refactor series as
+  [#314](https://github.com/dborgards/eds-dcf-net/pull/314).)*
+
+- [ ] **XML documentation / warnings-as-errors** — Public API changes must not
+  introduce new CS15xx (documentation) or CS16xx (analyzer) warnings. The
+  library builds with `TreatWarningsAsErrors=true`. Run
+  `dotnet build --configuration Release` locally and resolve any new warnings
+  on touched public members before opening the PR.
+  *(Enforced by existing build policy; easy to miss during large refactors.)*
+
+> **Optional follow-up (separate work):** evaluate automated enforcement such
+> as `Microsoft.CodeAnalysis.PublicApiAnalyzers` or a compat baseline file.
 
 ## Release process
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #329

## Summary

Adds a documented pre-merge checklist for PRs that touch public surface area on `EdsDcfNet`, based on real compatibility incidents from the CanOpenFile facade refactor series.

## Changes

- **`CONTRIBUTING.md`** — New "Public API compatibility checklist" section with four items:
  - Binary ABI (maps to #302)
  - Named arguments (maps to #314 / #321)
  - Overload shape (maps to #302 / #314)
  - XML doc / warnings-as-errors
- **`.github/copilot-instructions.md`** — Cross-reference to the checklist for AI-assisted contributors and reviewers.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — New PR template with a "Public API changes" section that links to the checklist.

## Acceptance criteria

- [x] Checklist linked from contributor docs (`CONTRIBUTING.md` how-to-contribute step + dedicated section)
- [x] Referenced in PR template and copilot review guidance
- [x] Each checklist item maps to at least one real incident (#302, #314, #321)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1134c929-78aa-4582-80cc-077548135c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1134c929-78aa-4582-80cc-077548135c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

