### PR TITLE
docs(utilities): document lenient fallback semantics in ValueConverter

### DIFF
--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -58,6 +58,19 @@ public static class ValueConverter
     /// <summary>
     /// Parses a boolean value from string.
     /// </summary>
+    /// <remarks>
+    /// This parser is intentionally lenient to tolerate real-world EDS/DCF files:
+    /// only <c>"1"</c>, <c>"true"</c>, and <c>"yes"</c> (case-insensitive) are treated as
+    /// <see langword="true"/>. Any other value — including typos, <c>"0"</c>, <c>"false"</c>,
+    /// <c>"no"</c>, and empty strings — silently maps to <see langword="false"/> without
+    /// raising an error. Unlike the numeric parsers in this class, malformed input is not
+    /// reported via <see cref="EdsParseException"/>.
+    /// </remarks>
+    /// <param name="value">String value to parse.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is a recognized true token;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
     public static bool ParseBoolean(string value)
     {
         value = value.Trim();
@@ -119,6 +132,21 @@ public static class ValueConverter
     /// <summary>
     /// Parses an AccessType from string.
     /// </summary>
+    /// <remarks>
+    /// This parser is intentionally lenient to tolerate real-world EDS/DCF files:
+    /// recognized tokens are <c>"ro"</c>, <c>"wo"</c>, <c>"rw"</c>, <c>"rwr"</c>,
+    /// <c>"rww"</c>, and <c>"const"</c> (case-insensitive, surrounding whitespace ignored).
+    /// Any unrecognized value — including typos and <see langword="null"/> — silently maps to
+    /// <see cref="AccessType.ReadOnly"/> without raising an error. Unlike the numeric parsers
+    /// in this class, malformed input is not reported via <see cref="EdsParseException"/>.
+    /// Note that this can change round-trip output: an unknown access type in the source file
+    /// is written back as <c>"ro"</c>.
+    /// </remarks>
+    /// <param name="value">String value to parse.</param>
+    /// <returns>
+    /// The parsed <see cref="AccessType"/>, or <see cref="AccessType.ReadOnly"/> if
+    /// <paramref name="value"/> is not a recognized access type token.
+    /// </returns>
     public static AccessType ParseAccessType(string value)
     {
         return value?.Trim().ToLowerInvariant() switch


### PR DESCRIPTION
Closes #341

## Summary

Implements **option 1** from #341: the lenient fallback behavior of `ValueConverter.ParseAccessType` and `ValueConverter.ParseBoolean` is now explicitly documented in XML docs as an intentional design decision for real-world file tolerance.

## Changes

- `ParseAccessType` — documents that unrecognized tokens (including `null` and typos) silently map to `AccessType.ReadOnly`, and notes the round-trip implication (unknown access types are written back as `"ro"`).
- `ParseBoolean` — documents that only `"1"`, `"true"`, `"yes"` (case-insensitive) are true; everything else silently maps to `false`.
- Both remarks explicitly contrast this with the strict numeric parsers (`ParseInteger`/`ParseByte`/`ParseUInt16`), which throw `EdsParseException`.

## Design decision (per issue acceptance criteria)

**Keep lenient as default.** A strict/opt-in mode (option 2) is deferred until format-specific parse options (#336) land — if wanted then, it should be tracked as a separate issue. No default behavior change, so no `BREAKING CHANGE` handling needed.

## Test plan

- [x] `dotnet build --configuration Release` passes with 0 warnings (XML docs valid under `TreatWarningsAsErrors`)
- [x] Docs-only change, no behavior change — existing test suite covers the unchanged semantics

Made with [Cursor](https://cursor.com)