### PR TITLE
feat(api): expose CanOpenNodeId constants and range helper publicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,19 @@ Current checks include:
 - object dictionary consistency (list membership, duplicates, missing entries)
 - object-level constraints (object type validity, parameter-name length, SubNumber mismatch)
 
+The CiA 306 Node-ID range used by these checks is exposed publicly via
+`CanOpenNodeId`, so consumers can validate or document node IDs without
+duplicating the `1..127` literals:
+
+```csharp
+using EdsDcfNet;
+
+bool valid = CanOpenNodeId.IsInRange(nodeId);          // true for 1..127
+byte min = CanOpenNodeId.MinValue;                     // 1
+byte max = CanOpenNodeId.MaxValue;                     // 127
+string range = CanOpenNodeId.RangeDescription;         // "1..127"
+```
+
 To validate automatically before writing, pass `CanOpenWriteOptions.Validated` to the
 format-specific entry points:
 

--- a/src/EdsDcfNet/CanOpenNodeId.cs
+++ b/src/EdsDcfNet/CanOpenNodeId.cs
@@ -3,11 +3,32 @@ namespace EdsDcfNet;
 /// <summary>
 /// CANopen Node-ID range constants and helpers (CiA 306: 1..127).
 /// </summary>
-internal static class CanOpenNodeId
+/// <remarks>
+/// Validation error messages produced by <see cref="CanOpenFile.Validate(Models.DeviceConfigurationFile)"/>
+/// reference this range via <see cref="RangeDescription"/>.
+/// </remarks>
+public static class CanOpenNodeId
 {
-    internal const byte MinValue = 1;
-    internal const byte MaxValue = 127;
-    internal const string RangeDescription = "1..127";
+    /// <summary>
+    /// The smallest valid CANopen Node-ID (1).
+    /// </summary>
+    public const byte MinValue = 1;
 
-    internal static bool IsInRange(int nodeId) => nodeId >= MinValue && nodeId <= MaxValue;
+    /// <summary>
+    /// The largest valid CANopen Node-ID (127).
+    /// </summary>
+    public const byte MaxValue = 127;
+
+    /// <summary>
+    /// Human-readable description of the valid Node-ID range ("1..127"),
+    /// as used in validation error messages.
+    /// </summary>
+    public const string RangeDescription = "1..127";
+
+    /// <summary>
+    /// Returns whether <paramref name="nodeId"/> is a valid CANopen Node-ID (1..127).
+    /// </summary>
+    /// <param name="nodeId">The node ID to check.</param>
+    /// <returns><see langword="true"/> if the value is within 1..127; otherwise <see langword="false"/>.</returns>
+    public static bool IsInRange(int nodeId) => nodeId >= MinValue && nodeId <= MaxValue;
 }

--- a/tests/EdsDcfNet.Tests/CanOpenNodeIdTests.cs
+++ b/tests/EdsDcfNet.Tests/CanOpenNodeIdTests.cs
@@ -1,0 +1,47 @@
+namespace EdsDcfNet.Tests;
+
+using EdsDcfNet;
+
+public class CanOpenNodeIdTests
+{
+    [Fact]
+    public void MinValue_Is1()
+    {
+        CanOpenNodeId.MinValue.Should().Be(1);
+    }
+
+    [Fact]
+    public void MaxValue_Is127()
+    {
+        CanOpenNodeId.MaxValue.Should().Be(127);
+    }
+
+    [Fact]
+    public void RangeDescription_MatchesMinAndMax()
+    {
+        CanOpenNodeId.RangeDescription.Should().Be("1..127");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(64)]
+    [InlineData(126)]
+    [InlineData(127)]
+    public void IsInRange_ValidNodeIds_ReturnsTrue(int nodeId)
+    {
+        CanOpenNodeId.IsInRange(nodeId).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(int.MinValue)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(128)]
+    [InlineData(255)]
+    [InlineData(int.MaxValue)]
+    public void IsInRange_InvalidNodeIds_ReturnsFalse(int nodeId)
+    {
+        CanOpenNodeId.IsInRange(nodeId).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Closes #333

## Summary

Makes `CanOpenNodeId` (CiA 306 Node-ID range 1..127) public so consumers can validate or document node IDs without duplicating the range literals. The type was introduced internal when #308 consolidated duplicated range checks; the name is kept as `CanOpenNodeId` for brevity.

## Changes

- `src/EdsDcfNet/CanOpenNodeId.cs` — `internal` → `public` with full XML docs; `RangeDescription` stays a string constant (it must remain `const`-compatible for use in validation messages and attribute-like contexts, and formatting it from min/max would gain nothing).
- `tests/EdsDcfNet.Tests/CanOpenNodeIdTests.cs` — explicit edge-case tests: 0, 1, 127, 128 plus negatives/extremes, and constants/`RangeDescription` assertions.
- `README.md` — documented in the validation section with a usage snippet.

## Public API compatibility checklist

- Binary ABI: additive only (new public type), nothing removed.
- Named arguments / overload shape: n/a (new surface).
- XML docs: build passes with `TreatWarningsAsErrors=true`, 0 warnings.

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings/errors
- [x] New `CanOpenNodeIdTests` — 14/14 passing

Made with [Cursor](https://cursor.com)