### PR TITLE
fix: throw ArgumentNullException for null model in write guard

### DIFF
--- a/src/EdsDcfNet/CanOpenWriteGuard.cs
+++ b/src/EdsDcfNet/CanOpenWriteGuard.cs
@@ -12,6 +12,8 @@ internal static class CanOpenWriteGuard
         if (options?.ValidateBeforeWrite != true)
             return;
 
+        ThrowIfNull(model, nameof(model));
+
         switch (model)
         {
             case ElectronicDataSheet eds:
@@ -38,6 +40,8 @@ internal static class CanOpenWriteGuard
         if (options?.ValidateBeforeWrite != true)
             return Task.CompletedTask;
 
+        ThrowIfNull(model, nameof(model));
+
         return model switch
         {
             ElectronicDataSheet eds => CanOpenFile.EnsureValidAsync(eds, cancellationToken),
@@ -47,5 +51,11 @@ internal static class CanOpenWriteGuard
                 "Unsupported model type: " + typeof(T).Name,
                 nameof(model))
         };
+    }
+
+    private static void ThrowIfNull(object? value, string paramName)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
     }
 }

--- a/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/WriteValidationGuardTests.cs
@@ -670,6 +670,20 @@ public class WriteValidationGuardTests
     }
 
     [Fact]
+    public void EnsureValidForWrite_WithNullModelAndValidatedOptions_ThrowsArgumentNullException()
+    {
+        var ensureValidForWrite = GetEnsureValidForWriteMethod(typeof(ElectronicDataSheet));
+
+        var act = () => ensureValidForWrite.Invoke(
+            null,
+            new object?[] { null, CanOpenWriteOptions.Validated });
+
+        var exception = act.Should().Throw<TargetInvocationException>().Which.InnerException;
+        exception.Should().BeOfType<ArgumentNullException>()
+            .Which.ParamName.Should().Be("model");
+    }
+
+    [Fact]
     public void EnsureValidForWrite_WithUnsupportedModelType_ThrowsArgumentException()
     {
         var ensureValidForWrite = GetEnsureValidForWriteMethod(typeof(string));
@@ -698,6 +712,20 @@ public class WriteValidationGuardTests
             new object?[] { CreateValidEds(), CanOpenWriteOptions.Default, CancellationToken.None })!;
         defaultOptionsTask.IsCompletedSuccessfully.Should().BeTrue();
         await defaultOptionsTask;
+    }
+
+    [Fact]
+    public async Task EnsureValidForWriteAsync_WithNullModelAndValidatedOptions_ThrowsArgumentNullException()
+    {
+        var ensureValidForWriteAsync = GetEnsureValidForWriteAsyncMethod(typeof(ElectronicDataSheet));
+
+        var act = async () => await (Task)ensureValidForWriteAsync.Invoke(
+            null,
+            new object?[] { null, CanOpenWriteOptions.Validated, CancellationToken.None })!;
+
+        var exception = (await act.Should().ThrowAsync<TargetInvocationException>()).Which.InnerException;
+        exception.Should().BeOfType<ArgumentNullException>()
+            .Which.ParamName.Should().Be("model");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- When `ValidateBeforeWrite` is enabled and the model argument is null, `CanOpenWriteGuard` now throws `ArgumentNullException` instead of the misleading `ArgumentException("Unsupported model type")`.
- Fixes #363.

## Test plan
- [x] Existing write-guard tests cover null model with validated options
- [x] Full test suite passes locally


Made with [Cursor](https://cursor.com)