### PR TITLE
fix: run legacy async write validation synchronously on caller thread

### DIFF
--- a/src/EdsDcfNet/FormatCanOpenOperations.cs
+++ b/src/EdsDcfNet/FormatCanOpenOperations.cs
@@ -321,7 +321,9 @@ public class FormatCanOpenOperations<TModel>
         if (_ensureValidForWriteAsync != null)
             return _ensureValidForWriteAsync(model, options, cancellationToken);
 
-        return Task.Run(() => _ensureValidForWrite(model, options), cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        _ensureValidForWrite(model, options);
+        return Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Replace the `Task.Run` fallback in `FormatCanOpenOperations.EnsureValidForWriteAsync` with inline synchronous validation when no async delegate is supplied (legacy 11-arg constructor path).
- Honors pre-start cancellation via `ThrowIfCancellationRequested` and avoids an unnecessary thread-pool hop per validated write, matching 1.9.x behavior for external subclasses.

Fixes #361

## Test plan
- [x] `FormatCanOpenOperationsAsyncValidationTests` (7 tests)
- [x] Existing sync-only and async-delegate subclass scenarios still pass

## Boundary & regression matrix
N/A — internal async validation dispatch only; no parser/writer/converter changes.

Made with [Cursor](https://cursor.com)