### PR TITLE
refactor: consolidate CanOpenWriteGuard model dispatch and validation gate

### DIFF
--- a/src/EdsDcfNet/CanOpenWriteGuard.cs
+++ b/src/EdsDcfNet/CanOpenWriteGuard.cs
@@ -9,12 +9,31 @@ internal static class CanOpenWriteGuard
 {
     internal static void EnsureValidForWrite<T>(T model, CanOpenWriteOptions? options)
     {
-        if (options?.ValidateBeforeWrite != true)
+        if (!ShouldValidateBeforeWrite(options))
             return;
 
+        ValidateKnownModel(model);
+    }
+
+    internal static Task EnsureValidForWriteAsync<T>(
+        T model,
+        CanOpenWriteOptions? options,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ShouldValidateBeforeWrite(options))
+            return Task.CompletedTask;
+
+        return ValidateKnownModelAsync(model, cancellationToken);
+    }
+
+    internal static bool ShouldValidateBeforeWrite(CanOpenWriteOptions? options) =>
+        options?.ValidateBeforeWrite == true;
+
+    private static void ValidateKnownModel(object? model)
+    {
         ThrowIfNull(model, nameof(model));
 
-        switch (model)
+        switch (model!)
         {
             case ElectronicDataSheet eds:
                 CanOpenFile.EnsureValid(eds);
@@ -27,28 +46,22 @@ internal static class CanOpenWriteGuard
                 break;
             default:
                 throw new ArgumentException(
-                    "Unsupported model type: " + typeof(T).Name,
+                    "Unsupported model type: " + model!.GetType().Name,
                     nameof(model));
         }
     }
 
-    internal static Task EnsureValidForWriteAsync<T>(
-        T model,
-        CanOpenWriteOptions? options,
-        CancellationToken cancellationToken = default)
+    private static Task ValidateKnownModelAsync(object? model, CancellationToken cancellationToken)
     {
-        if (options?.ValidateBeforeWrite != true)
-            return Task.CompletedTask;
-
         ThrowIfNull(model, nameof(model));
 
-        return model switch
+        return model! switch
         {
             ElectronicDataSheet eds => CanOpenFile.EnsureValidAsync(eds, cancellationToken),
             DeviceConfigurationFile dcf => CanOpenFile.EnsureValidAsync(dcf, cancellationToken),
             NodelistProject cpj => CanOpenFile.EnsureValidAsync(cpj, cancellationToken),
             _ => throw new ArgumentException(
-                "Unsupported model type: " + typeof(T).Name,
+                "Unsupported model type: " + model!.GetType().Name,
                 nameof(model))
         };
     }

--- a/src/EdsDcfNet/FormatCanOpenOperations.cs
+++ b/src/EdsDcfNet/FormatCanOpenOperations.cs
@@ -315,7 +315,7 @@ public class FormatCanOpenOperations<TModel>
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken)
     {
-        if (options?.ValidateBeforeWrite != true)
+        if (!CanOpenWriteGuard.ShouldValidateBeforeWrite(options))
             return Task.CompletedTask;
 
         if (_ensureValidForWriteAsync != null)


### PR DESCRIPTION
## Summary
- Extract `ShouldValidateBeforeWrite` as the single gate-condition helper, reused by sync/async guard entry points and `FormatCanOpenOperations.EnsureValidForWriteAsync`.
- Consolidate the duplicated model-type switch into `ValidateKnownModel` / `ValidateKnownModelAsync` private helpers.

Fixes #364

## Test plan
- [x] `WriteValidationGuardTests` and `FormatCanOpenOperationsAsyncValidationTests` (80 tests)

## Boundary & regression matrix
N/A — internal write-guard refactor; public write behavior unchanged.

Made with [Cursor](https://cursor.com)