### PR TITLE
fix(validation): preserve public param names in async null checks

### DIFF
--- a/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
+++ b/src/EdsDcfNet/Validation/CanOpenModelValidator.cs
@@ -49,7 +49,7 @@ public static class CanOpenModelValidator
     public static Task<IReadOnlyList<ValidationIssue>> ValidateAsync(
         ElectronicDataSheet eds,
         CancellationToken cancellationToken = default)
-        => RunValidationAsync(eds, ValidateEdsCore, cancellationToken);
+        => RunValidationAsync(eds, nameof(eds), ValidateEdsCore, cancellationToken);
 
     /// <summary>
     /// Validates a <see cref="DeviceConfigurationFile"/> instance.
@@ -74,7 +74,7 @@ public static class CanOpenModelValidator
     public static Task<IReadOnlyList<ValidationIssue>> ValidateAsync(
         DeviceConfigurationFile dcf,
         CancellationToken cancellationToken = default)
-        => RunValidationAsync(dcf, ValidateDcfCore, cancellationToken);
+        => RunValidationAsync(dcf, nameof(dcf), ValidateDcfCore, cancellationToken);
 
     /// <summary>
     /// Validates a <see cref="NodelistProject"/> instance.
@@ -99,14 +99,15 @@ public static class CanOpenModelValidator
     public static Task<IReadOnlyList<ValidationIssue>> ValidateAsync(
         NodelistProject cpj,
         CancellationToken cancellationToken = default)
-        => RunValidationAsync(cpj, ValidateCpjCore, cancellationToken);
+        => RunValidationAsync(cpj, nameof(cpj), ValidateCpjCore, cancellationToken);
 
     private static Task<IReadOnlyList<ValidationIssue>> RunValidationAsync<T>(
         T model,
+        string paramName,
         Func<T, CancellationToken, ReadOnlyCollection<ValidationIssue>> core,
         CancellationToken cancellationToken)
     {
-        ThrowIfNull(model, nameof(model));
+        ThrowIfNull(model, paramName);
 
         return Task.Run<IReadOnlyList<ValidationIssue>>(() => core(model, cancellationToken), cancellationToken);
     }

--- a/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorAsyncTests.cs
+++ b/tests/EdsDcfNet.Tests/Models/CanOpenModelValidatorAsyncTests.cs
@@ -323,4 +323,21 @@ public class CanOpenModelValidatorAsyncTests
 
         return eds;
     }
+
+    [Fact]
+    public async Task ValidateAsync_NullModels_ThrowArgumentNullExceptionWithPublicParameterNames()
+    {
+        // Act
+        var validateEds = () => CanOpenModelValidator.ValidateAsync((ElectronicDataSheet)null!);
+        var validateDcf = () => CanOpenModelValidator.ValidateAsync((DeviceConfigurationFile)null!);
+        var validateCpj = () => CanOpenModelValidator.ValidateAsync((NodelistProject)null!);
+
+        // Assert
+        (await validateEds.Should().ThrowAsync<ArgumentNullException>())
+            .Which.ParamName.Should().Be("eds");
+        (await validateDcf.Should().ThrowAsync<ArgumentNullException>())
+            .Which.ParamName.Should().Be("dcf");
+        (await validateCpj.Should().ThrowAsync<ArgumentNullException>())
+            .Which.ParamName.Should().Be("cpj");
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the Codex P2 review on PR #374: when a public `ValidateAsync` overload is called with a null model, `RunValidationAsync` now throws `ArgumentNullException` with the caller-facing parameter name (`eds`, `dcf`, or `cpj`) instead of the generic `model` name.

This keeps async null-check behavior consistent with the synchronous overloads and the documented parameter names.

## Changes

- Pass `paramName` into `RunValidationAsync` from each public `ValidateAsync` overload.
- Add async null-check tests asserting the correct parameter names.

## Test plan

- [x] All `CanOpenModelValidator*` tests (64 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3257-4713-7302-8f1c-61f0ac2b8444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3257-4713-7302-8f1c-61f0ac2b8444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

