### PR TITLE
fix(validation): restore sync/async validation parity for external subclasses (#357)

### DIFF
--- a/src/EdsDcfNet/FormatCanOpenOperations.cs
+++ b/src/EdsDcfNet/FormatCanOpenOperations.cs
@@ -315,12 +315,12 @@ public class FormatCanOpenOperations<TModel>
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken)
     {
-        if (!CanOpenWriteGuard.ShouldValidateBeforeWrite(options))
-            return Task.CompletedTask;
-
+        // Immer den Delegate aufrufen (wie in 1.9.x) – dieser entscheidet selbst,
+        // ob validiert wird (z. B. via CanOpenWriteGuard.ShouldValidateBeforeWrite).
         if (_ensureValidForWriteAsync != null)
             return _ensureValidForWriteAsync(model, options, cancellationToken);
 
+        // Fallback: synchronen Delegate asynchron ausführen
         cancellationToken.ThrowIfCancellationRequested();
         _ensureValidForWrite(model, options);
         return Task.CompletedTask;


### PR DESCRIPTION
Fixes #357.

Remove early exit in EnsureValidForWriteAsync to ensure validation delegates are always invoked, matching 1.9.x behavior. External subclasses that pass custom delegates expecting unconditional validation no longer silently skip validation in async write paths.