### PR TITLE
Revert "fix(validation): restore synchronous validation exceptions for async writes (#359)"

### DIFF
--- a/src/EdsDcfNet/FormatCanOpenOperations.cs
+++ b/src/EdsDcfNet/FormatCanOpenOperations.cs
@@ -314,12 +314,12 @@ public class FormatCanOpenOperations<TModel>
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken)
     {
-        if (!CanOpenWriteGuard.ShouldValidateBeforeWrite(options))
-            return Task.CompletedTask;
-
+        // Immer den Delegate aufrufen (wie in 1.9.x) – dieser entscheidet selbst,
+        // ob validiert wird (z. B. via CanOpenWriteGuard.ShouldValidateBeforeWrite).
         if (_ensureValidForWriteAsync != null)
             return _ensureValidForWriteAsync(model, options, cancellationToken);
 
+        // Fallback: synchronen Delegate asynchron ausführen
         cancellationToken.ThrowIfCancellationRequested();
         _ensureValidForWrite(model, options);
         return Task.CompletedTask;

--- a/src/EdsDcfNet/FormatCanOpenOperations.cs
+++ b/src/EdsDcfNet/FormatCanOpenOperations.cs
@@ -267,8 +267,7 @@ public class FormatCanOpenOperations<TModel>
 
     /// <summary>
     /// Writes to disk asynchronously. When <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/>
-    /// is enabled, validation runs synchronously before I/O so
-    /// <see cref="ModelValidationException"/> is thrown at the call site.
+    /// is enabled, validation also runs asynchronously and honors <paramref name="cancellationToken"/>. 
     /// </summary>
     /// <exception cref="ModelValidationException">
     /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
@@ -279,12 +278,7 @@ public class FormatCanOpenOperations<TModel>
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
     {
-        // Validierung synchron ausführen (wie in 1.9.x) – Exceptions werden
-        // sofort am Aufrufpunkt geworfen, nicht auf dem Task.
-        // Delegates werden immer aufgerufen (PR #380 Kompatibilität)
-        cancellationToken.ThrowIfCancellationRequested();
-        _ensureValidForWrite(model, options);
-
+        await EnsureValidForWriteAsync(model, options, cancellationToken).ConfigureAwait(false);
         await _writeFileAsync(model, filePath, cancellationToken).ConfigureAwait(false);
     }
 
@@ -299,8 +293,8 @@ public class FormatCanOpenOperations<TModel>
 
     /// <summary>
     /// Writes to a stream asynchronously. The stream is not disposed. When
-    /// <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled, validation runs
-    /// synchronously before I/O so <see cref="ModelValidationException"/> is thrown at the call site.
+    /// <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled, validation also
+    /// runs asynchronously and honors <paramref name="cancellationToken"/>. 
     /// </summary>
     /// <exception cref="ModelValidationException">
     /// Thrown when <see cref="CanOpenWriteOptions.ValidateBeforeWrite"/> is enabled and the model has validation issues.
@@ -311,11 +305,7 @@ public class FormatCanOpenOperations<TModel>
         CanOpenWriteOptions? options,
         CancellationToken cancellationToken = default)
     {
-        // Validierung synchron ausführen (wie in 1.9.x)
-        // Delegates werden immer aufgerufen (PR #380 Kompatibilität)
-        cancellationToken.ThrowIfCancellationRequested();
-        _ensureValidForWrite(model, options);
-
+        await EnsureValidForWriteAsync(model, options, cancellationToken).ConfigureAwait(false);
         await _writeStreamAsync(model, stream, cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/EdsDcfNet.Tests/Integration/FormatCanOpenOperationsAsyncValidationTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/FormatCanOpenOperationsAsyncValidationTests.cs
@@ -101,7 +101,7 @@ public class FormatCanOpenOperationsAsyncValidationTests
     }
 
     [Fact]
-    public async Task AsyncDelegateSubclass_WriteFileAsync_WithValidatedOptions_UsesSyncValidationDespiteAsyncDelegate()
+    public async Task AsyncDelegateSubclass_WriteFileAsync_WithValidatedOptions_UsesInjectedAsyncValidation()
     {
         var tracker = new AsyncValidationTracker();
         var operations = new AsyncDelegateFormatOperations(tracker);
@@ -112,9 +112,8 @@ public class FormatCanOpenOperationsAsyncValidationTests
         {
             await operations.WriteFileAsync(eds, tempFile, CanOpenWriteOptions.Validated);
 
-            tracker.SyncCalled.Should().BeTrue();
-            tracker.AsyncCalled.Should().BeFalse(
-                "async write paths validate synchronously so ModelValidationException is thrown at the call site");
+            tracker.AsyncCalled.Should().BeTrue();
+            tracker.SyncCalled.Should().BeFalse();
         }
         finally
         {
@@ -124,7 +123,7 @@ public class FormatCanOpenOperationsAsyncValidationTests
     }
 
     [Fact]
-    public async Task AsyncDelegateSubclass_WriteStreamAsync_WithValidatedOptions_UsesSyncValidationDespiteAsyncDelegate()
+    public async Task AsyncDelegateSubclass_WriteStreamAsync_WithValidatedOptions_UsesInjectedAsyncValidation()
     {
         var tracker = new AsyncValidationTracker();
         var operations = new AsyncDelegateFormatOperations(tracker);
@@ -133,9 +132,8 @@ public class FormatCanOpenOperationsAsyncValidationTests
 
         await operations.WriteStreamAsync(eds, stream, CanOpenWriteOptions.Validated);
 
-        tracker.SyncCalled.Should().BeTrue();
-        tracker.AsyncCalled.Should().BeFalse(
-            "async write paths validate synchronously so ModelValidationException is thrown at the call site");
+        tracker.AsyncCalled.Should().BeTrue();
+        tracker.SyncCalled.Should().BeFalse();
         stream.Length.Should().BeGreaterThan(0);
     }
 


### PR DESCRIPTION
Reverts dborgards/eds-dcf-net#381