### PR TITLE
chore(deps): bump semantic-release to 25.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@semantic-release/github": "^12.0.8",
         "@semantic-release/release-notes-generator": "^14.1.1",
         "conventional-changelog-conventionalcommits": "^9.3.1",
-        "semantic-release": "^25.0.5"
+        "semantic-release": "^25.0.7"
       },
       "engines": {
         "node": "^22.14.0 || >=24.10.0"
@@ -5119,9 +5119,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.5.tgz",
-      "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.7.tgz",
+      "integrity": "sha512-fFiUD7LNFI0TOGkc49WDHUX4GYKrOMDKct5ReSB1EJCZiPsPdbIPIJGys1xb2ILpK1v9JMsRkjJQgTRpbr7DgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "@semantic-release/github": "^12.0.8",
     "@semantic-release/release-notes-generator": "^14.1.1",
     "conventional-changelog-conventionalcommits": "^9.3.1",
-    "semantic-release": "^25.0.5"
+    "semantic-release": "^25.0.7"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Bumps `semantic-release` from `^25.0.5` to `^25.0.7` (current latest) and refreshes `package-lock.json`.

`25.0.6` / `25.0.7` include security-related fixes in semantic-release itself:
- **25.0.6**: ensure encoded secrets get masked
- **25.0.7**: argument injection via `repositoryUrl` in `package.json` ([#4245](https://github.com/semantic-release/semantic-release/issues/4245))

Note: remote branch `develop` is not present, so this PR targets `main`.

## Type of change

- [x] Other (`chore:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [x] Lockfile resolves `semantic-release@25.0.7`
- [ ] `dotnet test --configuration Release` passes locally (N/A — Node release tooling only)
- [ ] `dotnet build --configuration Release` passes locally (N/A)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4804cc99-1ffd-4660-a959-75772a11d43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4804cc99-1ffd-4660-a959-75772a11d43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

