### PR TITLE
fix(deps): update vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@semantic-release/github": "^12.0.8",
         "@semantic-release/release-notes-generator": "^14.1.1",
         "conventional-changelog-conventionalcommits": "^9.3.1",
-        "semantic-release": "^25.0.7"
+        "semantic-release": "^25.0.8"
       },
       "engines": {
         "node": "^22.14.0 || >=24.10.0"
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.4.tgz",
-      "integrity": "sha512-z5Fn9ftK1QQgFxMSuOd3DtYbTl4hWI2trCEvZcEJMQJy1/OBR0WHcxqzfVun455FSkHML8KgvPxJEa9MtZIBsg==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -655,7 +655,7 @@
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^8.0.0",
+        "normalize-url": "^9.0.0",
         "npm": "^11.6.2",
         "rc": "^1.2.8",
         "read-pkg": "^10.0.0",
@@ -2385,9 +2385,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2729,22 +2729,22 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+      "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.19.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+      "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2823,8 +2823,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.1",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -2848,11 +2848,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.12",
+        "libnpmexec": "^10.3.2",
+        "libnpmfund": "^7.0.26",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.12",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -2868,7 +2868,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -2877,11 +2877,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -2953,7 +2953,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3001,7 +3001,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3346,7 +3346,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3720,12 +3720,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3739,13 +3739,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3762,12 +3762,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.26",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3787,12 +3787,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4161,13 +4161,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4372,7 +4372,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4497,7 +4497,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4593,7 +4593,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5119,9 +5119,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.7",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.7.tgz",
-      "integrity": "sha512-fFiUD7LNFI0TOGkc49WDHUX4GYKrOMDKct5ReSB1EJCZiPsPdbIPIJGys1xb2ILpK1v9JMsRkjJQgTRpbr7DgQ==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "@semantic-release/github": "^12.0.8",
     "@semantic-release/release-notes-generator": "^14.1.1",
     "conventional-changelog-conventionalcommits": "^9.3.1",
-    "semantic-release": "^25.0.7"
+    "semantic-release": "^25.0.8"
   }
 }


### PR DESCRIPTION
## Summary

- update `semantic-release` to 25.0.8 and refresh its release-tool dependency chain
- update `js-yaml` to 4.3.1, `tar` to 7.5.19, `brace-expansion` to 5.0.7, and nested `undici` to 6.27.0
- resolve all six Dependabot alerts currently open on `main` (#22, #27, #29, #31, #33, #36)

GitHub has two additional recent alerts in `auto_dismissed` state for newer `tar`/`brace-expansion` advisories. They affect bundled development-only dependencies inside npm 11 and are not counted as open alerts.

## Validation

- `npm ci --ignore-scripts`
- exact installed versions checked with `npm ls js-yaml tar brace-expansion undici npm --all`
- `dotnet restore EdsDcfNet.sln`
- `dotnet test EdsDcfNet.sln --configuration Release --no-restore` (1,355 passed)
- semantic-release CLI smoke-tested with Node 22.22.0
- `git diff --check`