### PR TITLE
feat: typed Object Dictionary value access and OD documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ extensions also provide category queries and access to RPDO/TPDO communication a
 parameter ranges.
 
 Typed value conversion covers BOOLEAN, signed and unsigned integers (including the CANopen
-24/40/48/56-bit types), REAL32/REAL64, VISIBLE_STRING, UNICODE_STRING, OCTET_STRING, and
-DOMAIN. Numeric ranges are validated when setting values. The original string overloads
+24/40/48/56-bit types), REAL32/REAL64, VISIBLE_STRING, UNICODE_STRING, and OCTET_STRING.
+Numeric ranges are validated when setting values. DOMAIN entries are excluded because DCF
+files reference their payload through `UploadFile`/`DownloadFile` instead of an inline
+value; use those properties directly. The original string overloads
 remain available when an application needs exact control of the serialized representation.
 
 ### Writing an EDS File

--- a/README.md
+++ b/README.md
@@ -73,10 +73,15 @@ var deviceType = dictionary.GetObject(0x1000);
 var mappingEntry = dictionary.GetSubObject(0x1A00, 0x01);
 
 Console.WriteLine(deviceType?.ParameterName);
-Console.WriteLine(dictionary.GetParameterValue(0x1A00, 0x01));
 
-// Change a configured value. The writer persists it as ParameterValue.
-if (!dictionary.SetParameterValue(0x1A00, 0x01, "0x60000108"))
+// Read values as object or as a strongly typed value. The .NET type is derived
+// automatically from DataType in the Object Dictionary.
+object? rawDeviceType = dictionary.GetParameterValueAsObject(0x1000); // uint for UNSIGNED32
+uint mapping = dictionary.GetParameterValue<uint>(0x1A00, 0x01);
+
+// Pass a .NET value directly. It is validated against the OD data type and converted
+// to the textual ParameterValue representation persisted by the writer.
+if (!dictionary.SetParameterValue(0x1A00, 0x01, 0x60000108U))
     throw new InvalidOperationException("TPDO mapping entry 0x1A00:01 is missing.");
 
 // Create a manufacturer-specific object programmatically.
@@ -100,6 +105,11 @@ The model distinguishes mandatory, optional, and manufacturer-specific object li
 represents ARRAY and RECORD entries through typed `CanOpenSubObject` instances. Convenience
 extensions also provide category queries and access to RPDO/TPDO communication and mapping
 parameter ranges.
+
+Typed value conversion covers BOOLEAN, signed and unsigned integers (including the CANopen
+24/40/48/56-bit types), REAL32/REAL64, VISIBLE_STRING, UNICODE_STRING, OCTET_STRING, and
+DOMAIN. Numeric ranges are validated when setting values. The original string overloads
+remain available when an application needs exact control of the serialized representation.
 
 ### Writing an EDS File
 
@@ -609,6 +619,7 @@ Rules for adding such an option:
 - ✅ Indexed lookup, creation, and modification of objects and sub-objects
 - ✅ Mandatory, optional, and manufacturer-specific object lists
 - ✅ Default values and DCF/XDC configured parameter values
+- ✅ Automatic conversion between OD data types and .NET values, with range validation
 - ✅ Helpers for RPDO/TPDO communication and mapping parameters
 - ✅ Complete EDS parsing and writing
 - ✅ Complete DCF parsing and writing

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@
 A comprehensive, easy-to-use C# .NET library for CANopen file formats:
 CiA DS 306 (EDS, DCF, CPJ) and CiA 311 (XDD, XDC).
 
+EdsDcfNet exposes the CANopen **Object Dictionary as a fully typed, editable API**.
+Applications can inspect, query, create, and configure objects and sub-objects directly;
+the library is not limited to file conversion or lossless round-trips.
+
 ## Features
 
 ✨ **Simple API** - Intuitive, fluent API style for quick integration
+
+🗂️ **First-Class Object Dictionary API** - Query, create, and modify CANopen objects,
+sub-objects, object lists, data types, access rights, defaults, and configured values
 
 📖 **Read & Write EDS** - Parse and generate Electronic Data Sheets
 
@@ -45,6 +52,54 @@ Console.WriteLine($"Device: {eds.DeviceInfo.ProductName}");
 Console.WriteLine($"Vendor: {eds.DeviceInfo.VendorName}");
 Console.WriteLine($"Product Number: 0x{eds.DeviceInfo.ProductNumber:X}");
 ```
+
+### Working with the CANopen Object Dictionary
+
+Every EDS, DCF, XDD, and XDC model exposes its parsed object dictionary through
+`ObjectDictionary`. It is an application-facing model, not merely parser state: use it
+to inspect device capabilities, find objects and sub-objects by index, evaluate default
+or configured values, update a DCF configuration, or build an object dictionary in code.
+
+```csharp
+using EdsDcfNet;
+using EdsDcfNet.Extensions;
+using EdsDcfNet.Models;
+
+var dcf = CanOpenFile.Dcf.ReadFile("configured_device.dcf");
+var dictionary = dcf.ObjectDictionary;
+
+// Query objects and sub-objects by their CANopen index.
+var deviceType = dictionary.GetObject(0x1000);
+var mappingEntry = dictionary.GetSubObject(0x1A00, 0x01);
+
+Console.WriteLine(deviceType?.ParameterName);
+Console.WriteLine(dictionary.GetParameterValue(0x1A00, 0x01));
+
+// Change a configured value. The writer persists it as ParameterValue.
+if (!dictionary.SetParameterValue(0x1A00, 0x01, "0x60000108"))
+    throw new InvalidOperationException("TPDO mapping entry 0x1A00:01 is missing.");
+
+// Create a manufacturer-specific object programmatically.
+dictionary.ManufacturerObjects.Add(0x2000);
+dictionary.Objects[0x2000] = new CanOpenObject
+{
+    Index = 0x2000,
+    ParameterName = "Application mode",
+    ObjectType = 0x07,       // VAR
+    DataType = 0x0005,       // UNSIGNED8
+    AccessType = AccessType.ReadWrite,
+    DefaultValue = "0",
+    ParameterValue = "1",
+    PdoMapping = true
+};
+
+CanOpenFile.Dcf.WriteFile(dcf, "configured_device_updated.dcf");
+```
+
+The model distinguishes mandatory, optional, and manufacturer-specific object lists and
+represents ARRAY and RECORD entries through typed `CanOpenSubObject` instances. Convenience
+extensions also provide category queries and access to RPDO/TPDO communication and mapping
+parameter ranges.
 
 ### Writing an EDS File
 
@@ -550,6 +605,11 @@ Rules for adding such an option:
 
 ## Supported Features
 
+- ✅ First-class, editable CANopen Object Dictionary model for EDS, DCF, XDD, and XDC
+- ✅ Indexed lookup, creation, and modification of objects and sub-objects
+- ✅ Mandatory, optional, and manufacturer-specific object lists
+- ✅ Default values and DCF/XDC configured parameter values
+- ✅ Helpers for RPDO/TPDO communication and mapping parameters
 - ✅ Complete EDS parsing and writing
 - ✅ Complete DCF parsing and writing
 - ✅ CPJ nodelist project parsing and writing (CiA 306-3 network topologies)

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -87,8 +87,8 @@ public static class ObjectDictionaryExtensions
     public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte? nodeId = null)
     {
         var obj = objDict.GetObject(index);
-        var value = obj?.ParameterValue ?? obj?.DefaultValue;
-        if (IsMissingValue(value, obj?.DataType))
+        var value = ResolveParameterOrDefaultValue(obj?.ParameterValue, obj?.DefaultValue, obj?.DataType);
+        if (value is null)
         {
             return null;
         }
@@ -98,7 +98,7 @@ public static class ObjectDictionaryExtensions
             throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
         }
 
-        return CanOpenValueConverter.Parse(value!, obj.DataType.Value, nodeId);
+        return CanOpenValueConverter.Parse(value, obj.DataType.Value, nodeId);
     }
 
     /// <summary>
@@ -115,8 +115,8 @@ public static class ObjectDictionaryExtensions
     public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId = null)
     {
         var subObj = objDict.GetSubObject(index, subIndex);
-        var value = subObj?.ParameterValue ?? subObj?.DefaultValue;
-        if (IsMissingValue(value, subObj?.DataType))
+        var value = ResolveParameterOrDefaultValue(subObj?.ParameterValue, subObj?.DefaultValue, subObj?.DataType);
+        if (value is null)
         {
             return null;
         }
@@ -129,7 +129,7 @@ public static class ObjectDictionaryExtensions
                 $"Sub-object 0x{index:X4}:{subIndex:X2} does not define a CANopen data type.");
         }
 
-        return CanOpenValueConverter.Parse(value!, subObj.DataType, nodeId);
+        return CanOpenValueConverter.Parse(value, subObj.DataType, nodeId);
     }
 
     /// <summary>
@@ -275,6 +275,26 @@ public static class ObjectDictionaryExtensions
         {
             throw new ArgumentNullException(parameterName);
         }
+    }
+
+    /// <summary>
+    /// Prefers a non-missing configured value, otherwise a non-missing default value.
+    /// Empty/whitespace handling is applied per field so a blank ParameterValue does not
+    /// block fallback to a usable DefaultValue.
+    /// </summary>
+    private static string? ResolveParameterOrDefaultValue(string? parameterValue, string? defaultValue, ushort? dataType)
+    {
+        if (!IsMissingValue(parameterValue, dataType))
+        {
+            return parameterValue;
+        }
+
+        if (!IsMissingValue(defaultValue, dataType))
+        {
+            return defaultValue;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -1,6 +1,7 @@
 namespace EdsDcfNet.Extensions;
 
 using EdsDcfNet.Models;
+using EdsDcfNet.Utilities;
 
 /// <summary>
 /// Extension methods for ObjectDictionary to make it easier to work with CANopen objects.
@@ -74,6 +75,99 @@ public static class ObjectDictionaryExtensions
     }
 
     /// <summary>
+    /// Gets an object's configured or default value converted to the .NET type indicated
+    /// by its CANopen data type.
+    /// </summary>
+    /// <returns>The typed value, or <see langword="null"/> if the object or value does not exist.</returns>
+    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index)
+    {
+        var obj = objDict.GetObject(index);
+        var value = obj?.ParameterValue ?? obj?.DefaultValue;
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (!obj!.DataType.HasValue)
+        {
+            throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
+        }
+
+        return CanOpenValueConverter.Parse(value, obj.DataType.Value);
+    }
+
+    /// <summary>
+    /// Gets a sub-object's configured or default value converted to the .NET type indicated
+    /// by its CANopen data type.
+    /// </summary>
+    /// <returns>The typed value, or <see langword="null"/> if the sub-object or value does not exist.</returns>
+    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte subIndex)
+    {
+        var subObj = objDict.GetSubObject(index, subIndex);
+        var value = subObj?.ParameterValue ?? subObj?.DefaultValue;
+        return value == null ? null : CanOpenValueConverter.Parse(value, subObj!.DataType);
+    }
+
+    /// <summary>
+    /// Gets an object's configured or default value as <typeparamref name="T"/>.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">The object or its configured/default value does not exist.</exception>
+    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index)
+    {
+        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index), index, null);
+    }
+
+    /// <summary>
+    /// Gets a sub-object's configured or default value as <typeparamref name="T"/>.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">The sub-object or its configured/default value does not exist.</exception>
+    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte subIndex)
+    {
+        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, subIndex), index, subIndex);
+    }
+
+    /// <summary>
+    /// Converts and sets an object's parameter value according to its CANopen data type.
+    /// </summary>
+    /// <returns><c>true</c> if the object was found and the value was set.</returns>
+    public static bool SetParameterValue(this ObjectDictionary objDict, ushort index, object value)
+    {
+        EnsureNotNull(value, nameof(value));
+
+        var obj = objDict.GetObject(index);
+        if (obj == null)
+        {
+            return false;
+        }
+
+        if (!obj.DataType.HasValue)
+        {
+            throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
+        }
+
+        obj.ParameterValue = CanOpenValueConverter.Format(value, obj.DataType.Value);
+        return true;
+    }
+
+    /// <summary>
+    /// Converts and sets a sub-object's parameter value according to its CANopen data type.
+    /// </summary>
+    /// <returns><c>true</c> if the sub-object was found and the value was set.</returns>
+    public static bool SetParameterValue(this ObjectDictionary objDict, ushort index, byte subIndex, object value)
+    {
+        EnsureNotNull(value, nameof(value));
+
+        var subObj = objDict.GetSubObject(index, subIndex);
+        if (subObj == null)
+        {
+            return false;
+        }
+
+        subObj.ParameterValue = CanOpenValueConverter.Format(value, subObj.DataType);
+        return true;
+    }
+
+    /// <summary>
     /// Gets all objects of a specific type (mandatory, optional, or manufacturer).
     /// </summary>
     public static IEnumerable<CanOpenObject> GetObjectsByType(this ObjectDictionary objDict, ObjectCategory category)
@@ -113,6 +207,31 @@ public static class ObjectDictionaryExtensions
         return objDict.Objects.Values
             .Where(obj => obj.Index >= startIndex && obj.Index <= endIndex)
             .OrderBy(obj => obj.Index);
+    }
+
+    private static T CastParameterValue<T>(object? value, ushort index, byte? subIndex)
+    {
+        var address = subIndex.HasValue ? $"0x{index:X4}:{subIndex.Value:X2}" : $"0x{index:X4}";
+        if (value == null)
+        {
+            throw new KeyNotFoundException($"Object Dictionary value {address} does not exist.");
+        }
+
+        if (value is T typedValue)
+        {
+            return typedValue;
+        }
+
+        throw new InvalidCastException(
+            $"Object Dictionary value {address} has .NET type {value.GetType().Name}, not {typeof(T).Name}.");
+    }
+
+    private static void EnsureNotNull(object? value, string parameterName)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
     }
 }
 

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -294,7 +294,9 @@ public static class ObjectDictionaryExtensions
     /// Decides whether a resolved textual value should be treated as "no value".
     /// Parsed models store a missing DefaultValue as an empty string, so empty is always
     /// missing. Whitespace-only is missing too, except for string data types where
-    /// whitespace is representable content that the writers persist.
+    /// whitespace is representable content that the writers persist, and except when
+    /// <paramref name="dataType"/> is null or the parser sentinel 0 — then any
+    /// non-empty text must stay present so typed APIs can reject the untyped object.
     /// </summary>
     private static bool IsMissingValue(string? value, ushort? dataType)
     {
@@ -303,8 +305,10 @@ public static class ObjectDictionaryExtensions
             return true;
         }
 
-        var isStringType = dataType is 0x0009 or 0x000B; // VISIBLE_STRING, UNICODE_STRING
-        return !isStringType && string.IsNullOrWhiteSpace(value);
+        // VISIBLE_STRING / UNICODE_STRING keep whitespace; unknown/sentinel DataType
+        // must also keep it so GetParameterValueAsObject can throw rather than return null.
+        var preserveWhitespace = dataType is null or 0 or 0x0009 or 0x000B;
+        return !preserveWhitespace && string.IsNullOrWhiteSpace(value);
     }
 }
 

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -198,6 +198,14 @@ public static class ObjectDictionaryExtensions
             return false;
         }
 
+        // Sub-objects store a missing DataType as 0 (see ParseSubObject default), unlike
+        // top-level objects which leave DataType null when the field is omitted.
+        if (subObj.DataType == 0)
+        {
+            throw new InvalidOperationException(
+                $"Sub-object 0x{index:X4}:{subIndex:X2} does not define a CANopen data type.");
+        }
+
         subObj.ParameterValue = CanOpenValueConverter.Format(value, subObj.DataType);
         return true;
     }

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -93,7 +93,9 @@ public static class ObjectDictionaryExtensions
             return null;
         }
 
-        if (!obj!.DataType.HasValue)
+        // Explicit DataType=0 from EDS parsing is HasValue but not a real CANopen type
+        // (same sentinel sub-objects use when the field is omitted).
+        if (obj!.DataType is null or 0)
         {
             throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
         }
@@ -175,7 +177,9 @@ public static class ObjectDictionaryExtensions
             return false;
         }
 
-        if (!obj.DataType.HasValue)
+        // Explicit DataType=0 from EDS parsing is HasValue but not a real CANopen type
+        // (same sentinel sub-objects use when the field is omitted).
+        if (obj.DataType is null or 0)
         {
             throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
         }

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -88,7 +88,9 @@ public static class ObjectDictionaryExtensions
     {
         var obj = objDict.GetObject(index);
         var value = obj?.ParameterValue ?? obj?.DefaultValue;
-        if (value == null)
+        // Parsed models store a missing DefaultValue as an empty string, so treat
+        // empty/whitespace like "no value" instead of forwarding it to the converter.
+        if (string.IsNullOrWhiteSpace(value))
         {
             return null;
         }
@@ -98,7 +100,7 @@ public static class ObjectDictionaryExtensions
             throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
         }
 
-        return CanOpenValueConverter.Parse(value, obj.DataType.Value, nodeId);
+        return CanOpenValueConverter.Parse(value!, obj.DataType.Value, nodeId);
     }
 
     /// <summary>
@@ -116,7 +118,9 @@ public static class ObjectDictionaryExtensions
     {
         var subObj = objDict.GetSubObject(index, subIndex);
         var value = subObj?.ParameterValue ?? subObj?.DefaultValue;
-        if (value == null)
+        // Parsed models store a missing DefaultValue as an empty string, so treat
+        // empty/whitespace like "no value" instead of forwarding it to the converter.
+        if (string.IsNullOrWhiteSpace(value))
         {
             return null;
         }
@@ -129,7 +133,7 @@ public static class ObjectDictionaryExtensions
                 $"Sub-object 0x{index:X4}:{subIndex:X2} does not define a CANopen data type.");
         }
 
-        return CanOpenValueConverter.Parse(value, subObj.DataType, nodeId);
+        return CanOpenValueConverter.Parse(value!, subObj.DataType, nodeId);
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -78,8 +78,13 @@ public static class ObjectDictionaryExtensions
     /// Gets an object's configured or default value converted to the .NET type indicated
     /// by its CANopen data type.
     /// </summary>
+    /// <param name="objDict">The object dictionary.</param>
+    /// <param name="index">Object index.</param>
+    /// <param name="nodeId">
+    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
+    /// </param>
     /// <returns>The typed value, or <see langword="null"/> if the object or value does not exist.</returns>
-    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index)
+    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte? nodeId = null)
     {
         var obj = objDict.GetObject(index);
         var value = obj?.ParameterValue ?? obj?.DefaultValue;
@@ -93,37 +98,67 @@ public static class ObjectDictionaryExtensions
             throw new InvalidOperationException($"Object 0x{index:X4} does not define a CANopen data type.");
         }
 
-        return CanOpenValueConverter.Parse(value, obj.DataType.Value);
+        return CanOpenValueConverter.Parse(value, obj.DataType.Value, nodeId);
     }
 
     /// <summary>
     /// Gets a sub-object's configured or default value converted to the .NET type indicated
     /// by its CANopen data type.
     /// </summary>
+    /// <param name="objDict">The object dictionary.</param>
+    /// <param name="index">Object index.</param>
+    /// <param name="subIndex">Sub-object sub-index.</param>
+    /// <param name="nodeId">
+    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
+    /// </param>
     /// <returns>The typed value, or <see langword="null"/> if the sub-object or value does not exist.</returns>
-    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte subIndex)
+    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId = null)
     {
         var subObj = objDict.GetSubObject(index, subIndex);
         var value = subObj?.ParameterValue ?? subObj?.DefaultValue;
-        return value == null ? null : CanOpenValueConverter.Parse(value, subObj!.DataType);
+        if (value == null)
+        {
+            return null;
+        }
+
+        // Sub-objects store a missing DataType as 0 (see ParseSubObject default), unlike
+        // top-level objects which leave DataType null when the field is omitted.
+        if (subObj!.DataType == 0)
+        {
+            throw new InvalidOperationException(
+                $"Sub-object 0x{index:X4}:{subIndex:X2} does not define a CANopen data type.");
+        }
+
+        return CanOpenValueConverter.Parse(value, subObj.DataType, nodeId);
     }
 
     /// <summary>
     /// Gets an object's configured or default value as <typeparamref name="T"/>.
     /// </summary>
+    /// <param name="objDict">The object dictionary.</param>
+    /// <param name="index">Object index.</param>
+    /// <param name="nodeId">
+    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
+    /// </param>
     /// <exception cref="KeyNotFoundException">The object or its configured/default value does not exist.</exception>
-    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index)
+    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte? nodeId = null)
     {
-        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index), index, null);
+        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, nodeId), index, null);
     }
 
     /// <summary>
     /// Gets a sub-object's configured or default value as <typeparamref name="T"/>.
     /// </summary>
+    /// <param name="objDict">The object dictionary.</param>
+    /// <param name="index">Object index.</param>
+    /// <param name="subIndex">Sub-object sub-index.</param>
+    /// <param name="nodeId">
+    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
+    /// </param>
     /// <exception cref="KeyNotFoundException">The sub-object or its configured/default value does not exist.</exception>
-    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte subIndex)
+    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId = null)
     {
-        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, subIndex), index, subIndex);
+        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, subIndex, nodeId), index, subIndex);
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -88,9 +88,7 @@ public static class ObjectDictionaryExtensions
     {
         var obj = objDict.GetObject(index);
         var value = obj?.ParameterValue ?? obj?.DefaultValue;
-        // Parsed models store a missing DefaultValue as an empty string, so treat
-        // empty/whitespace like "no value" instead of forwarding it to the converter.
-        if (string.IsNullOrWhiteSpace(value))
+        if (IsMissingValue(value, obj?.DataType))
         {
             return null;
         }
@@ -118,9 +116,7 @@ public static class ObjectDictionaryExtensions
     {
         var subObj = objDict.GetSubObject(index, subIndex);
         var value = subObj?.ParameterValue ?? subObj?.DefaultValue;
-        // Parsed models store a missing DefaultValue as an empty string, so treat
-        // empty/whitespace like "no value" instead of forwarding it to the converter.
-        if (string.IsNullOrWhiteSpace(value))
+        if (IsMissingValue(value, subObj?.DataType))
         {
             return null;
         }
@@ -279,6 +275,23 @@ public static class ObjectDictionaryExtensions
         {
             throw new ArgumentNullException(parameterName);
         }
+    }
+
+    /// <summary>
+    /// Decides whether a resolved textual value should be treated as "no value".
+    /// Parsed models store a missing DefaultValue as an empty string, so empty is always
+    /// missing. Whitespace-only is missing too, except for string data types where
+    /// whitespace is representable content that the writers persist.
+    /// </summary>
+    private static bool IsMissingValue(string? value, ushort? dataType)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return true;
+        }
+
+        var isStringType = dataType is 0x0009 or 0x000B; // VISIBLE_STRING, UNICODE_STRING
+        return !isStringType && string.IsNullOrWhiteSpace(value);
     }
 }
 

--- a/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
+++ b/src/EdsDcfNet/Extensions/ObjectDictionaryExtensions.cs
@@ -80,12 +80,22 @@ public static class ObjectDictionaryExtensions
     /// </summary>
     /// <param name="objDict">The object dictionary.</param>
     /// <param name="index">Object index.</param>
+    /// <param name="subIndex">
+    /// Optional sub-object sub-index. Omit (or pass <see langword="null"/>) for the
+    /// object-level value. The second positional argument is always the sub-index;
+    /// pass <paramref name="nodeId"/> by name for object-level reads.
+    /// </param>
     /// <param name="nodeId">
     /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
     /// </param>
-    /// <returns>The typed value, or <see langword="null"/> if the object or value does not exist.</returns>
-    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte? nodeId = null)
+    /// <returns>The typed value, or <see langword="null"/> if the object/sub-object or value does not exist.</returns>
+    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte? subIndex = null, byte? nodeId = null)
     {
+        if (subIndex.HasValue)
+        {
+            return GetSubObjectParameterValueAsObject(objDict, index, subIndex.Value, nodeId);
+        }
+
         var obj = objDict.GetObject(index);
         var value = ResolveParameterOrDefaultValue(obj?.ParameterValue, obj?.DefaultValue, obj?.DataType);
         if (value is null)
@@ -103,18 +113,7 @@ public static class ObjectDictionaryExtensions
         return CanOpenValueConverter.Parse(value, obj.DataType.Value, nodeId);
     }
 
-    /// <summary>
-    /// Gets a sub-object's configured or default value converted to the .NET type indicated
-    /// by its CANopen data type.
-    /// </summary>
-    /// <param name="objDict">The object dictionary.</param>
-    /// <param name="index">Object index.</param>
-    /// <param name="subIndex">Sub-object sub-index.</param>
-    /// <param name="nodeId">
-    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
-    /// </param>
-    /// <returns>The typed value, or <see langword="null"/> if the sub-object or value does not exist.</returns>
-    public static object? GetParameterValueAsObject(this ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId = null)
+    private static object? GetSubObjectParameterValueAsObject(ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId)
     {
         var subObj = objDict.GetSubObject(index, subIndex);
         var value = ResolveParameterOrDefaultValue(subObj?.ParameterValue, subObj?.DefaultValue, subObj?.DataType);
@@ -135,30 +134,20 @@ public static class ObjectDictionaryExtensions
     }
 
     /// <summary>
-    /// Gets an object's configured or default value as <typeparamref name="T"/>.
+    /// Gets an object's or sub-object's configured or default value as <typeparamref name="T"/>.
     /// </summary>
     /// <param name="objDict">The object dictionary.</param>
     /// <param name="index">Object index.</param>
+    /// <param name="subIndex">
+    /// Optional sub-object sub-index. Omit (or pass <see langword="null"/>) for the
+    /// object-level value. The second positional argument is always the sub-index;
+    /// pass <paramref name="nodeId"/> by name for object-level reads.
+    /// </param>
     /// <param name="nodeId">
     /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
     /// </param>
-    /// <exception cref="KeyNotFoundException">The object or its configured/default value does not exist.</exception>
-    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte? nodeId = null)
-    {
-        return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, nodeId), index, null);
-    }
-
-    /// <summary>
-    /// Gets a sub-object's configured or default value as <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="objDict">The object dictionary.</param>
-    /// <param name="index">Object index.</param>
-    /// <param name="subIndex">Sub-object sub-index.</param>
-    /// <param name="nodeId">
-    /// Optional node ID used to evaluate <c>$NODEID</c> formulas in the configured or default value.
-    /// </param>
-    /// <exception cref="KeyNotFoundException">The sub-object or its configured/default value does not exist.</exception>
-    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte subIndex, byte? nodeId = null)
+    /// <exception cref="KeyNotFoundException">The object/sub-object or its configured/default value does not exist.</exception>
+    public static T GetParameterValue<T>(this ObjectDictionary objDict, ushort index, byte? subIndex = null, byte? nodeId = null)
     {
         return CastParameterValue<T>(objDict.GetParameterValueAsObject(index, subIndex, nodeId), index, subIndex);
     }

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -245,6 +245,16 @@ public static class CanOpenValueConverter
             throw new InvalidCastException(
                 $"Value '{value}' is a floating-point number and cannot be stored in an integer CANopen data type without loss.");
         }
+
+        // Only genuine integral numeric types are allowed. bool, char, strings, and other
+        // convertible types must be rejected: BOOLEAN is a separate CANopen data type, so
+        // e.g. SetParameterValue(index, true) must not silently write 1 to an UNSIGNED8.
+        if (value is not (sbyte or byte or short or ushort or int or uint or long or ulong))
+        {
+            throw new InvalidCastException(
+                $"Value of type {value.GetType().Name} cannot be stored in an integer CANopen data type. " +
+                "Provide an integral numeric value.");
+        }
     }
 
     private static void ValidateSignedRange(long value, int bits)

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -131,6 +131,8 @@ public static class CanOpenValueConverter
         }
 
         // Accept numeric 0/1 only; any other number is outside the CANopen BOOLEAN value range.
+        // Fractional inputs must be rejected before conversion so 0.25 does not round to 0.
+        EnsureIntegral(value);
         var numeric = Convert.ToInt64(value, CultureInfo.InvariantCulture);
         return numeric switch
         {

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -110,12 +110,16 @@ public static class CanOpenValueConverter
     private static bool ParseBoolean(string value)
     {
         var normalized = value.Trim();
-        if (normalized == "1" || normalized.Equals("true", StringComparison.OrdinalIgnoreCase))
+        if (normalized == "1"
+            || normalized.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("yes", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        if (normalized == "0" || normalized.Equals("false", StringComparison.OrdinalIgnoreCase))
+        if (normalized == "0"
+            || normalized.Equals("false", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("no", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -85,12 +85,12 @@ public static class CanOpenValueConverter
                 0x0005 => FormatUnsigned(value, 8),
                 0x0006 => FormatUnsigned(value, 16),
                 0x0007 => FormatUnsigned(value, 32),
-                0x0008 => Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+                0x0008 => FormatReal32(value),
                 0x0009 or 0x000B => value as string
                     ?? throw new InvalidCastException("VISIBLE_STRING and UNICODE_STRING values must be supplied as strings."),
                 0x000A => FormatByteString(value),
                 0x0010 => FormatSigned(value, 24),
-                0x0011 => Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+                0x0011 => FormatReal64(value),
                 0x0012 => FormatSigned(value, 40),
                 0x0013 => FormatSigned(value, 48),
                 0x0014 => FormatSigned(value, 56),
@@ -262,6 +262,34 @@ public static class CanOpenValueConverter
             throw new InvalidCastException(
                 $"Value of type {value.GetType().Name} cannot be stored in an integer CANopen data type. " +
                 "Provide an integral numeric value.");
+        }
+    }
+
+    private static string FormatReal32(object value)
+    {
+        EnsureNumeric(value);
+        return Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatReal64(object value)
+    {
+        EnsureNumeric(value);
+        return Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Ensures a value destined for a REAL32/REAL64 entry is a genuine numeric type.
+    /// bool, char, strings, and other <see cref="IConvertible"/> inputs must be rejected:
+    /// BOOLEAN is a separate CANopen data type, so e.g. SetParameterValue(index, true)
+    /// must not silently write 1 to a REAL32 object.
+    /// </summary>
+    private static void EnsureNumeric(object value)
+    {
+        if (value is not (sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal))
+        {
+            throw new InvalidCastException(
+                $"Value of type {value.GetType().Name} cannot be stored in a REAL CANopen data type. " +
+                "Provide a numeric value.");
         }
     }
 

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -13,42 +13,47 @@ public static class CanOpenValueConverter
     /// </summary>
     /// <param name="value">The textual EDS/DCF value.</param>
     /// <param name="dataType">The CANopen data type index.</param>
+    /// <param name="nodeId">
+    /// Optional node ID used to evaluate <c>$NODEID</c> formulas such as <c>$NODEID+0x200</c>.
+    /// Required when <paramref name="value"/> contains a <c>$NODEID</c> expression.
+    /// </param>
     /// <returns>The value represented by the corresponding .NET type.</returns>
     /// <remarks>
-    /// Integer values may use decimal, hexadecimal (<c>0x</c>), or octal notation.
+    /// Integer values may use decimal, hexadecimal (<c>0x</c>), octal notation, or
+    /// <c>$NODEID</c> formulas. Empty or whitespace-only integer literals are treated as zero.
     /// OCTET_STRING and DOMAIN values are returned as <see cref="byte"/> arrays when written
     /// as hexadecimal literals. TIME_OF_DAY and TIME_DIFFERENCE currently remain unsupported
     /// because their file representation does not provide a universally interoperable mapping.
     /// </remarks>
-    public static object Parse(string value, ushort dataType)
+    public static object Parse(string value, ushort dataType, byte? nodeId = null)
     {
         EnsureNotNull(value, nameof(value));
 
         return dataType switch
         {
             0x0001 => ParseBoolean(value),
-            0x0002 => (sbyte)ParseSignedInteger(value, 8),
-            0x0003 => (short)ParseSignedInteger(value, 16),
-            0x0004 => (int)ParseSignedInteger(value, 32),
-            0x0005 => (byte)ParseUnsignedInteger(value, 8),
-            0x0006 => (ushort)ParseUnsignedInteger(value, 16),
-            0x0007 => (uint)ParseUnsignedInteger(value, 32),
+            0x0002 => (sbyte)ParseSignedInteger(value, 8, nodeId),
+            0x0003 => (short)ParseSignedInteger(value, 16, nodeId),
+            0x0004 => (int)ParseSignedInteger(value, 32, nodeId),
+            0x0005 => (byte)ParseUnsignedInteger(value, 8, nodeId),
+            0x0006 => (ushort)ParseUnsignedInteger(value, 16, nodeId),
+            0x0007 => (uint)ParseUnsignedInteger(value, 32, nodeId),
             0x0008 => float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
             0x0009 => value,
             0x000A => ParseByteString(value),
             0x000B => value,
             0x000F => ParseByteString(value),
-            0x0010 => (int)ParseSignedInteger(value, 24),
+            0x0010 => (int)ParseSignedInteger(value, 24, nodeId),
             0x0011 => double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
-            0x0012 => ParseSignedInteger(value, 40),
-            0x0013 => ParseSignedInteger(value, 48),
-            0x0014 => ParseSignedInteger(value, 56),
-            0x0015 => ParseSignedInteger(value, 64),
-            0x0016 => (uint)ParseUnsignedInteger(value, 24),
-            0x0018 => ParseUnsignedInteger(value, 40),
-            0x0019 => ParseUnsignedInteger(value, 48),
-            0x001A => ParseUnsignedInteger(value, 56),
-            0x001B => ParseUnsignedInteger(value, 64),
+            0x0012 => ParseSignedInteger(value, 40, nodeId),
+            0x0013 => ParseSignedInteger(value, 48, nodeId),
+            0x0014 => ParseSignedInteger(value, 56, nodeId),
+            0x0015 => ParseSignedInteger(value, 64, nodeId),
+            0x0016 => (uint)ParseUnsignedInteger(value, 24, nodeId),
+            0x0018 => ParseUnsignedInteger(value, 40, nodeId),
+            0x0019 => ParseUnsignedInteger(value, 48, nodeId),
+            0x001A => ParseUnsignedInteger(value, 56, nodeId),
+            0x001B => ParseUnsignedInteger(value, 64, nodeId),
             0x000C or 0x000D => throw new NotSupportedException(
                 $"CANopen data type 0x{dataType:X4} does not have a universally interoperable EDS/DCF to .NET mapping."),
             _ => throw new NotSupportedException($"CANopen data type 0x{dataType:X4} is not supported for typed value conversion.")
@@ -117,10 +122,22 @@ public static class CanOpenValueConverter
         throw new FormatException($"'{value}' is not a valid CANopen BOOLEAN value.");
     }
 
-    private static long ParseSignedInteger(string value, int bits)
+    private static long ParseSignedInteger(string value, int bits, byte? nodeId)
     {
         var trimmed = value.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return 0;
+        }
+
         long result;
+        if (trimmed.StartsWith("$NODEID", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ValueConverter.ParseInteger(trimmed, nodeId);
+            ValidateSignedRange(result, bits);
+            return result;
+        }
+
         if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
             var raw = ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
@@ -151,11 +168,20 @@ public static class CanOpenValueConverter
         return result;
     }
 
-    private static ulong ParseUnsignedInteger(string value, int bits)
+    private static ulong ParseUnsignedInteger(string value, int bits, byte? nodeId)
     {
         var trimmed = value.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return 0;
+        }
+
         ulong result;
-        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        if (trimmed.StartsWith("$NODEID", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ValueConverter.ParseInteger(trimmed, nodeId);
+        }
+        else if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
             result = ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
         }

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -1,0 +1,285 @@
+namespace EdsDcfNet.Utilities;
+
+using System.Globalization;
+
+/// <summary>
+/// Converts CANopen Object Dictionary values between their EDS/DCF string representation
+/// and the corresponding .NET type defined by the CANopen data type index.
+/// </summary>
+public static class CanOpenValueConverter
+{
+    /// <summary>
+    /// Parses an Object Dictionary value according to its CANopen data type index.
+    /// </summary>
+    /// <param name="value">The textual EDS/DCF value.</param>
+    /// <param name="dataType">The CANopen data type index.</param>
+    /// <returns>The value represented by the corresponding .NET type.</returns>
+    /// <remarks>
+    /// Integer values may use decimal, hexadecimal (<c>0x</c>), or octal notation.
+    /// OCTET_STRING and DOMAIN values are returned as <see cref="byte"/> arrays when written
+    /// as hexadecimal literals. TIME_OF_DAY and TIME_DIFFERENCE currently remain unsupported
+    /// because their file representation does not provide a universally interoperable mapping.
+    /// </remarks>
+    public static object Parse(string value, ushort dataType)
+    {
+        EnsureNotNull(value, nameof(value));
+
+        return dataType switch
+        {
+            0x0001 => ParseBoolean(value),
+            0x0002 => (sbyte)ParseSignedInteger(value, 8),
+            0x0003 => (short)ParseSignedInteger(value, 16),
+            0x0004 => (int)ParseSignedInteger(value, 32),
+            0x0005 => (byte)ParseUnsignedInteger(value, 8),
+            0x0006 => (ushort)ParseUnsignedInteger(value, 16),
+            0x0007 => (uint)ParseUnsignedInteger(value, 32),
+            0x0008 => float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
+            0x0009 => value,
+            0x000A => ParseByteString(value),
+            0x000B => value,
+            0x000F => ParseByteString(value),
+            0x0010 => (int)ParseSignedInteger(value, 24),
+            0x0011 => double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
+            0x0012 => ParseSignedInteger(value, 40),
+            0x0013 => ParseSignedInteger(value, 48),
+            0x0014 => ParseSignedInteger(value, 56),
+            0x0015 => ParseSignedInteger(value, 64),
+            0x0016 => (uint)ParseUnsignedInteger(value, 24),
+            0x0018 => ParseUnsignedInteger(value, 40),
+            0x0019 => ParseUnsignedInteger(value, 48),
+            0x001A => ParseUnsignedInteger(value, 56),
+            0x001B => ParseUnsignedInteger(value, 64),
+            0x000C or 0x000D => throw new NotSupportedException(
+                $"CANopen data type 0x{dataType:X4} does not have a universally interoperable EDS/DCF to .NET mapping."),
+            _ => throw new NotSupportedException($"CANopen data type 0x{dataType:X4} is not supported for typed value conversion.")
+        };
+    }
+
+    /// <summary>
+    /// Formats a .NET value according to its CANopen data type index for storage in an EDS/DCF model.
+    /// </summary>
+    public static string Format(object value, ushort dataType)
+    {
+        EnsureNotNull(value, nameof(value));
+
+        try
+        {
+            return dataType switch
+            {
+                0x0001 => Convert.ToBoolean(value, CultureInfo.InvariantCulture) ? "1" : "0",
+                0x0002 => FormatSigned(value, 8),
+                0x0003 => FormatSigned(value, 16),
+                0x0004 => FormatSigned(value, 32),
+                0x0005 => FormatUnsigned(value, 8),
+                0x0006 => FormatUnsigned(value, 16),
+                0x0007 => FormatUnsigned(value, 32),
+                0x0008 => Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+                0x0009 or 0x000B => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
+                0x000A or 0x000F => FormatByteString(value),
+                0x0010 => FormatSigned(value, 24),
+                0x0011 => Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+                0x0012 => FormatSigned(value, 40),
+                0x0013 => FormatSigned(value, 48),
+                0x0014 => FormatSigned(value, 56),
+                0x0015 => FormatSigned(value, 64),
+                0x0016 => FormatUnsigned(value, 24),
+                0x0018 => FormatUnsigned(value, 40),
+                0x0019 => FormatUnsigned(value, 48),
+                0x001A => FormatUnsigned(value, 56),
+                0x001B => FormatUnsigned(value, 64),
+                0x000C or 0x000D => throw new NotSupportedException(
+                    $"CANopen data type 0x{dataType:X4} does not have a universally interoperable EDS/DCF to .NET mapping."),
+                _ => throw new NotSupportedException($"CANopen data type 0x{dataType:X4} is not supported for typed value conversion.")
+            };
+        }
+        catch (Exception ex) when (ex is FormatException || ex is InvalidCastException || ex is OverflowException)
+        {
+            throw new ArgumentException(
+                $"Value '{value}' cannot be represented by CANopen data type 0x{dataType:X4}.",
+                nameof(value),
+                ex);
+        }
+    }
+
+    private static bool ParseBoolean(string value)
+    {
+        var normalized = value.Trim();
+        if (normalized == "1" || normalized.Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (normalized == "0" || normalized.Equals("false", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        throw new FormatException($"'{value}' is not a valid CANopen BOOLEAN value.");
+    }
+
+    private static long ParseSignedInteger(string value, int bits)
+    {
+        var trimmed = value.Trim();
+        long result;
+        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            var raw = ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+            ValidateUnsignedRange(raw, bits);
+            if (bits < 64 && (raw & (1UL << (bits - 1))) != 0)
+            {
+                result = (long)(raw - (1UL << bits));
+            }
+            else
+            {
+                result = unchecked((long)raw);
+            }
+        }
+        else if (IsOctal(trimmed))
+        {
+            var raw = Convert.ToUInt64(trimmed, 8);
+            ValidateUnsignedRange(raw, bits);
+            result = bits < 64 && (raw & (1UL << (bits - 1))) != 0
+                ? (long)(raw - (1UL << bits))
+                : unchecked((long)raw);
+        }
+        else
+        {
+            result = long.Parse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            ValidateSignedRange(result, bits);
+        }
+
+        return result;
+    }
+
+    private static ulong ParseUnsignedInteger(string value, int bits)
+    {
+        var trimmed = value.Trim();
+        ulong result;
+        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+        }
+        else if (IsOctal(trimmed))
+        {
+            result = Convert.ToUInt64(trimmed, 8);
+        }
+        else
+        {
+            result = ulong.Parse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture);
+        }
+
+        ValidateUnsignedRange(result, bits);
+        return result;
+    }
+
+    private static string FormatSigned(object value, int bits)
+    {
+        var converted = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+        ValidateSignedRange(converted, bits);
+        return converted.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatUnsigned(object value, int bits)
+    {
+        var converted = Convert.ToUInt64(value, CultureInfo.InvariantCulture);
+        ValidateUnsignedRange(converted, bits);
+        return converted.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static void ValidateSignedRange(long value, int bits)
+    {
+        if (bits == 64)
+        {
+            return;
+        }
+
+        var minimum = -(1L << (bits - 1));
+        var maximum = (1L << (bits - 1)) - 1;
+        if (value < minimum || value > maximum)
+        {
+            throw new OverflowException($"Value {value} is outside the signed {bits}-bit range.");
+        }
+    }
+
+    private static void ValidateUnsignedRange(ulong value, int bits)
+    {
+        if (bits < 64 && value >= (1UL << bits))
+        {
+            throw new OverflowException($"Value {value} is outside the unsigned {bits}-bit range.");
+        }
+    }
+
+    private static bool IsOctal(string value) =>
+        value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]);
+
+    private static byte[] ParseByteString(string value)
+    {
+        var normalized = value.Trim();
+        if (normalized.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[2..];
+        }
+
+        normalized = normalized.Replace(" ", string.Empty).Replace("-", string.Empty);
+        if (normalized.Length % 2 != 0)
+        {
+            throw new FormatException("A CANopen byte string must contain an even number of hexadecimal digits.");
+        }
+
+        var result = new byte[normalized.Length / 2];
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = (byte)((ParseHexDigit(normalized[i * 2]) << 4) | ParseHexDigit(normalized[(i * 2) + 1]));
+        }
+
+        return result;
+    }
+
+    private static string FormatByteString(object value)
+    {
+        if (value is not byte[] bytes)
+        {
+            throw new InvalidCastException("OCTET_STRING and DOMAIN values must be supplied as byte arrays.");
+        }
+
+        const string hexDigits = "0123456789ABCDEF";
+        var chars = new char[(bytes.Length * 2) + 2];
+        chars[0] = '0';
+        chars[1] = 'x';
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            chars[(i * 2) + 2] = hexDigits[bytes[i] >> 4];
+            chars[(i * 2) + 3] = hexDigits[bytes[i] & 0x0F];
+        }
+
+        return new string(chars);
+    }
+
+    private static int ParseHexDigit(char value)
+    {
+        if (value >= '0' && value <= '9')
+        {
+            return value - '0';
+        }
+
+        if (value >= 'A' && value <= 'F')
+        {
+            return value - 'A' + 10;
+        }
+
+        if (value >= 'a' && value <= 'f')
+        {
+            return value - 'a' + 10;
+        }
+
+        throw new FormatException($"'{value}' is not a hexadecimal digit.");
+    }
+
+    private static void EnsureNotNull(object? value, string parameterName)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
+    }
+}

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -71,7 +71,7 @@ public static class CanOpenValueConverter
         {
             return dataType switch
             {
-                0x0001 => Convert.ToBoolean(value, CultureInfo.InvariantCulture) ? "1" : "0",
+                0x0001 => FormatBoolean(value),
                 0x0002 => FormatSigned(value, 8),
                 0x0003 => FormatSigned(value, 16),
                 0x0004 => FormatSigned(value, 32),
@@ -79,7 +79,8 @@ public static class CanOpenValueConverter
                 0x0006 => FormatUnsigned(value, 16),
                 0x0007 => FormatUnsigned(value, 32),
                 0x0008 => Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
-                0x0009 or 0x000B => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
+                0x0009 or 0x000B => value as string
+                    ?? throw new InvalidCastException("VISIBLE_STRING and UNICODE_STRING values must be supplied as strings."),
                 0x000A or 0x000F => FormatByteString(value),
                 0x0010 => FormatSigned(value, 24),
                 0x0011 => Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
@@ -120,6 +121,23 @@ public static class CanOpenValueConverter
         }
 
         throw new FormatException($"'{value}' is not a valid CANopen BOOLEAN value.");
+    }
+
+    private static string FormatBoolean(object value)
+    {
+        if (value is bool boolean)
+        {
+            return boolean ? "1" : "0";
+        }
+
+        // Accept numeric 0/1 only; any other number is outside the CANopen BOOLEAN value range.
+        var numeric = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+        return numeric switch
+        {
+            0 => "0",
+            1 => "1",
+            _ => throw new OverflowException($"Value {numeric} is outside the CANopen BOOLEAN value range (0 or 1).")
+        };
     }
 
     private static long ParseSignedInteger(string value, int bits, byte? nodeId)
@@ -200,6 +218,7 @@ public static class CanOpenValueConverter
 
     private static string FormatSigned(object value, int bits)
     {
+        EnsureIntegral(value);
         var converted = Convert.ToInt64(value, CultureInfo.InvariantCulture);
         ValidateSignedRange(converted, bits);
         return converted.ToString(CultureInfo.InvariantCulture);
@@ -207,9 +226,19 @@ public static class CanOpenValueConverter
 
     private static string FormatUnsigned(object value, int bits)
     {
+        EnsureIntegral(value);
         var converted = Convert.ToUInt64(value, CultureInfo.InvariantCulture);
         ValidateUnsignedRange(converted, bits);
         return converted.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static void EnsureIntegral(object value)
+    {
+        if (value is float or double or decimal)
+        {
+            throw new InvalidCastException(
+                $"Value '{value}' is a floating-point number and cannot be stored in an integer CANopen data type without loss.");
+        }
     }
 
     private static void ValidateSignedRange(long value, int bits)

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -203,19 +203,19 @@ public static class CanOpenValueConverter
         ulong result;
         if (trimmed.StartsWith("$NODEID", StringComparison.OrdinalIgnoreCase))
         {
-            result = ValueConverter.ParseInteger(trimmed, nodeId);
+            result = EvaluateUnsignedNodeIdFormula(trimmed, nodeId);
         }
         else if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
-            result = ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+            result = ParseUnsignedLiteral(trimmed);
         }
         else if (IsOctal(trimmed))
         {
-            result = Convert.ToUInt64(trimmed, 8);
+            result = ParseUnsignedLiteral(trimmed);
         }
         else
         {
-            result = ulong.Parse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            result = ParseUnsignedLiteral(trimmed);
         }
 
         ValidateUnsignedRange(result, bits);
@@ -274,11 +274,31 @@ public static class CanOpenValueConverter
         value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]);
 
     /// <summary>
-    /// Evaluates a <c>$NODEID</c> formula in signed arithmetic so subtraction can yield
-    /// negative values for signed target types (e.g. <c>$NODEID-2</c> with node ID 1 is -1).
-    /// The unsigned evaluator in <see cref="ValueConverter.ParseInteger"/> would underflow.
+    /// Parses an unsigned integer literal (decimal, hexadecimal, or octal) into a
+    /// <see cref="ulong"/> so 40/48/56/64-bit values are preserved.
     /// </summary>
-    private static long EvaluateSignedNodeIdFormula(string formula, byte? nodeId)
+    private static ulong ParseUnsignedLiteral(string trimmed)
+    {
+        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return ulong.Parse(trimmed[2..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+        }
+
+        if (IsOctal(trimmed))
+        {
+            return Convert.ToUInt64(trimmed, 8);
+        }
+
+        return ulong.Parse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Splits a <c>$NODEID</c> formula into its operator and unsigned operand. The operand is
+    /// parsed as <see cref="ulong"/> so 40/48/56/64-bit offsets are preserved, and malformed
+    /// input consistently surfaces as <see cref="FormatException"/> like other literals in
+    /// this converter.
+    /// </summary>
+    private static (char? Operator, ulong Operand) SplitNodeIdFormula(string formula, byte? nodeId)
     {
         if (!nodeId.HasValue)
         {
@@ -290,7 +310,7 @@ public static class CanOpenValueConverter
         var suffix = formula[token.Length..].Trim();
         if (suffix.Length == 0)
         {
-            return nodeId.Value;
+            return (null, 0);
         }
 
         if (suffix[0] is '+' or '-')
@@ -302,13 +322,52 @@ public static class CanOpenValueConverter
                     $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
             }
 
-            // Reuse the existing unsigned literal parser for the operand, then combine in signed math.
-            var right = (long)ValueConverter.ParseInteger(rightSide);
-            return suffix[0] == '+' ? nodeId.Value + right : nodeId.Value - right;
+            return (suffix[0], ParseUnsignedLiteral(rightSide));
         }
 
         throw new FormatException(
             $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
+    }
+
+    /// <summary>
+    /// Evaluates a <c>$NODEID</c> formula in signed 64-bit arithmetic so subtraction can yield
+    /// negative values for signed target types (e.g. <c>$NODEID-2</c> with node ID 1 is -1).
+    /// </summary>
+    private static long EvaluateSignedNodeIdFormula(string formula, byte? nodeId)
+    {
+        var (op, operand) = SplitNodeIdFormula(formula, nodeId);
+        if (op is null)
+        {
+            return nodeId!.Value;
+        }
+
+        if (operand > long.MaxValue)
+        {
+            throw new OverflowException($"$NODEID formula '{formula}' has an operand outside the signed 64-bit range.");
+        }
+
+        // Fold the sign into the operand so a single checked addition covers both cases.
+        // Only addition can overflow: the node ID is at most 255 and the negated operand
+        // is at least -long.MaxValue, so subtraction stays within the signed 64-bit range.
+        var signedOperand = op.Value == '+' ? (long)operand : -(long)operand;
+        return checked(nodeId!.Value + signedOperand);
+    }
+
+    /// <summary>
+    /// Evaluates a <c>$NODEID</c> formula in unsigned 64-bit arithmetic so 40/48/56/64-bit
+    /// offsets are preserved. Subtraction below zero raises <see cref="OverflowException"/>.
+    /// </summary>
+    private static ulong EvaluateUnsignedNodeIdFormula(string formula, byte? nodeId)
+    {
+        var (op, operand) = SplitNodeIdFormula(formula, nodeId);
+        return op switch
+        {
+            null => nodeId!.Value,
+            '+' => checked(nodeId!.Value + operand),
+            _ => nodeId!.Value >= operand
+                ? nodeId!.Value - operand
+                : throw new OverflowException($"$NODEID formula '{formula}' underflows the unsigned value range.")
+        };
     }
 
     private static byte[] ParseByteString(string value)

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -157,7 +157,7 @@ public static class CanOpenValueConverter
         long result;
         if (trimmed.StartsWith("$NODEID", StringComparison.OrdinalIgnoreCase))
         {
-            result = ValueConverter.ParseInteger(trimmed, nodeId);
+            result = EvaluateSignedNodeIdFormula(trimmed, nodeId);
             ValidateSignedRange(result, bits);
             return result;
         }
@@ -272,6 +272,44 @@ public static class CanOpenValueConverter
 
     private static bool IsOctal(string value) =>
         value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]);
+
+    /// <summary>
+    /// Evaluates a <c>$NODEID</c> formula in signed arithmetic so subtraction can yield
+    /// negative values for signed target types (e.g. <c>$NODEID-2</c> with node ID 1 is -1).
+    /// The unsigned evaluator in <see cref="ValueConverter.ParseInteger"/> would underflow.
+    /// </summary>
+    private static long EvaluateSignedNodeIdFormula(string formula, byte? nodeId)
+    {
+        if (!nodeId.HasValue)
+        {
+            throw new NotSupportedException(
+                $"Cannot evaluate $NODEID formula '{formula}' without a node ID context.");
+        }
+
+        const string token = "$NODEID";
+        var suffix = formula[token.Length..].Trim();
+        if (suffix.Length == 0)
+        {
+            return nodeId.Value;
+        }
+
+        if (suffix[0] is '+' or '-')
+        {
+            var rightSide = suffix[1..].Trim();
+            if (rightSide.Length == 0 || rightSide.Contains('+') || rightSide.Contains('-'))
+            {
+                throw new FormatException(
+                    $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
+            }
+
+            // Reuse the existing unsigned literal parser for the operand, then combine in signed math.
+            var right = (long)ValueConverter.ParseInteger(rightSide);
+            return suffix[0] == '+' ? nodeId.Value + right : nodeId.Value - right;
+        }
+
+        throw new FormatException(
+            $"Unsupported $NODEID formula '{formula}'. Expected '$NODEID', '$NODEID+<number>' or '$NODEID-<number>'.");
+    }
 
     private static byte[] ParseByteString(string value)
     {

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -8,6 +8,11 @@ using System.Globalization;
 /// </summary>
 public static class CanOpenValueConverter
 {
+    private const string DomainNotSupportedMessage =
+        "CANopen data type 0x000F (DOMAIN) is not supported for typed value conversion. " +
+        "DCF DOMAIN payloads are referenced through CanOpenObject.UploadFile and " +
+        "CanOpenObject.DownloadFile rather than an inline ParameterValue; access those " +
+        "properties directly.";
     /// <summary>
     /// Parses an Object Dictionary value according to its CANopen data type index.
     /// </summary>
@@ -21,8 +26,10 @@ public static class CanOpenValueConverter
     /// <remarks>
     /// Integer values may use decimal, hexadecimal (<c>0x</c>), octal notation, or
     /// <c>$NODEID</c> formulas. Empty or whitespace-only integer literals are treated as zero.
-    /// OCTET_STRING and DOMAIN values are returned as <see cref="byte"/> arrays when written
-    /// as hexadecimal literals. TIME_OF_DAY and TIME_DIFFERENCE currently remain unsupported
+    /// OCTET_STRING values are returned as <see cref="byte"/> arrays when written as
+    /// hexadecimal literals. DOMAIN is not supported because DCF files reference its payload
+    /// through <c>UploadFile</c>/<c>DownloadFile</c> instead of an inline value.
+    /// TIME_OF_DAY and TIME_DIFFERENCE currently remain unsupported
     /// because their file representation does not provide a universally interoperable mapping.
     /// </remarks>
     public static object Parse(string value, ushort dataType, byte? nodeId = null)
@@ -42,7 +49,6 @@ public static class CanOpenValueConverter
             0x0009 => value,
             0x000A => ParseByteString(value),
             0x000B => value,
-            0x000F => ParseByteString(value),
             0x0010 => (int)ParseSignedInteger(value, 24, nodeId),
             0x0011 => double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
             0x0012 => ParseSignedInteger(value, 40, nodeId),
@@ -56,6 +62,7 @@ public static class CanOpenValueConverter
             0x001B => ParseUnsignedInteger(value, 64, nodeId),
             0x000C or 0x000D => throw new NotSupportedException(
                 $"CANopen data type 0x{dataType:X4} does not have a universally interoperable EDS/DCF to .NET mapping."),
+            0x000F => throw new NotSupportedException(DomainNotSupportedMessage),
             _ => throw new NotSupportedException($"CANopen data type 0x{dataType:X4} is not supported for typed value conversion.")
         };
     }
@@ -81,7 +88,7 @@ public static class CanOpenValueConverter
                 0x0008 => Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
                 0x0009 or 0x000B => value as string
                     ?? throw new InvalidCastException("VISIBLE_STRING and UNICODE_STRING values must be supplied as strings."),
-                0x000A or 0x000F => FormatByteString(value),
+                0x000A => FormatByteString(value),
                 0x0010 => FormatSigned(value, 24),
                 0x0011 => Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
                 0x0012 => FormatSigned(value, 40),
@@ -95,6 +102,7 @@ public static class CanOpenValueConverter
                 0x001B => FormatUnsigned(value, 64),
                 0x000C or 0x000D => throw new NotSupportedException(
                     $"CANopen data type 0x{dataType:X4} does not have a universally interoperable EDS/DCF to .NET mapping."),
+                0x000F => throw new NotSupportedException(DomainNotSupportedMessage),
                 _ => throw new NotSupportedException($"CANopen data type 0x{dataType:X4} is not supported for typed value conversion.")
             };
         }
@@ -346,21 +354,38 @@ public static class CanOpenValueConverter
     private static long EvaluateSignedNodeIdFormula(string formula, byte? nodeId)
     {
         var (op, operand) = SplitNodeIdFormula(formula, nodeId);
+        long baseValue = nodeId!.Value;
         if (op is null)
         {
-            return nodeId!.Value;
+            return baseValue;
         }
 
-        if (operand > long.MaxValue)
+        if (op.Value == '+')
         {
-            throw new OverflowException($"$NODEID formula '{formula}' has an operand outside the signed 64-bit range.");
+            if (operand > (ulong)(long.MaxValue - baseValue))
+            {
+                throw new OverflowException($"$NODEID formula '{formula}' overflows the signed 64-bit range.");
+            }
+
+            return baseValue + (long)operand;
         }
 
-        // Fold the sign into the operand so a single checked addition covers both cases.
-        // Only addition can overflow: the node ID is at most 255 and the negated operand
-        // is at least -long.MaxValue, so subtraction stays within the signed 64-bit range.
-        var signedOperand = op.Value == '+' ? (long)operand : -(long)operand;
-        return checked(nodeId!.Value + signedOperand);
+        if (operand <= (ulong)baseValue)
+        {
+            return baseValue - (long)operand;
+        }
+
+        // The result is negative. Evaluate its magnitude in unsigned space so operands above
+        // long.MaxValue still produce valid results, e.g. $NODEID-0x8000000000000000 with node
+        // ID 1 is -9223372036854775807, which fits in a signed 64-bit value.
+        const ulong maximumNegativeMagnitude = (ulong)long.MaxValue + 1;
+        var magnitude = operand - (ulong)baseValue;
+        if (magnitude > maximumNegativeMagnitude)
+        {
+            throw new OverflowException($"$NODEID formula '{formula}' underflows the signed 64-bit range.");
+        }
+
+        return magnitude == maximumNegativeMagnitude ? long.MinValue : -(long)magnitude;
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -12,8 +12,12 @@ public class TypedObjectDictionaryValueTests
     {
         { "1", 0x0001, true },
         { "true", 0x0001, true },
+        { "yes", 0x0001, true },
+        { "YES", 0x0001, true },
         { "0", 0x0001, false },
         { "false", 0x0001, false },
+        { "no", 0x0001, false },
+        { "No", 0x0001, false },
         { "0xFF", 0x0002, (sbyte)-1 },
         { "017", 0x0002, (sbyte)15 },
         { "0377", 0x0002, (sbyte)-1 },
@@ -473,6 +477,21 @@ public class TypedObjectDictionaryValueTests
 
         dictionary.GetParameterValueAsObject(0x2000).Should().BeNull();
         dictionary.GetParameterValueAsObject(0x1018, 1).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetParameterValueAsObject_BlankParameterValue_FallsBackToDefault(string blankParameter)
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2000].ParameterValue = blankParameter;
+        dictionary.Objects[0x2000].DefaultValue = "10";
+        dictionary.Objects[0x1018].SubObjects[1].ParameterValue = blankParameter;
+        dictionary.Objects[0x1018].SubObjects[1].DefaultValue = "20";
+
+        dictionary.GetParameterValueAsObject(0x2000).Should().Be((byte)10);
+        dictionary.GetParameterValueAsObject(0x1018, 1).Should().Be(20U);
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -66,7 +66,7 @@ public class TypedObjectDictionaryValueTests
     [Fact]
     public void Parse_ByteStringWithSeparators_IgnoresSpacesAndDashes()
     {
-        CanOpenValueConverter.Parse("01 02-fe", 0x000F)
+        CanOpenValueConverter.Parse("01 02-fe", 0x000A)
             .Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0xFE });
     }
 
@@ -178,7 +178,7 @@ public class TypedObjectDictionaryValueTests
     {
         CanOpenValueConverter.Format(true, 0x0001).Should().Be("1");
         CanOpenValueConverter.Format(1.5F, 0x0008).Should().Be("1.5");
-        CanOpenValueConverter.Format(new byte[] { 0x01, 0xAB }, 0x000F).Should().Be("0x01AB");
+        CanOpenValueConverter.Format(new byte[] { 0x01, 0xAB }, 0x000A).Should().Be("0x01AB");
     }
 
     [Fact]
@@ -545,9 +545,49 @@ public class TypedObjectDictionaryValueTests
     [Fact]
     public void Parse_SignedNodeIdOperandOutsideSigned64Range_ThrowsOverflowException()
     {
-        var act = () => CanOpenValueConverter.Parse("$NODEID-0xFFFFFFFFFFFFFFFF", 0x0015, nodeId: 1);
+        // long.MinValue magnitude is 2^63; one more than that underflows.
+        var act = () => CanOpenValueConverter.Parse("$NODEID-0x8000000000000001", 0x0015, nodeId: 0);
 
         act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdSubtractionWithOperandAboveInt64Max_ReturnsNegativeResult()
+    {
+        // 1 - 0x8000000000000000 == -9223372036854775807, which fits in INTEGER64.
+        CanOpenValueConverter.Parse("$NODEID-0x8000000000000000", 0x0015, nodeId: 1)
+            .Should().Be(-9223372036854775807L);
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdSubtractionReachingInt64Min_ReturnsMinValue()
+    {
+        CanOpenValueConverter.Parse("$NODEID-0x8000000000000000", 0x0015, nodeId: 0)
+            .Should().Be(long.MinValue);
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdSubtractionStayingPositive_ReturnsDifference()
+    {
+        CanOpenValueConverter.Parse("$NODEID-2", 0x0003, nodeId: 10).Should().Be((short)8);
+    }
+
+    [Theory]
+    [InlineData(0x000F)]
+    public void Parse_DomainDataType_ThrowsNotSupportedException(ushort dataType)
+    {
+        // DCF DOMAIN payloads live in UploadFile/DownloadFile, not in ParameterValue.
+        var act = () => CanOpenValueConverter.Parse("0x01AB", dataType);
+
+        act.Should().Throw<NotSupportedException>().WithMessage("*DOMAIN*");
+    }
+
+    [Fact]
+    public void Format_DomainDataType_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Format(new byte[] { 0x01, 0xAB }, 0x000F);
+
+        act.Should().Throw<NotSupportedException>().WithMessage("*DOMAIN*");
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -513,6 +513,58 @@ public class TypedObjectDictionaryValueTests
     }
 
     [Fact]
+    public void GetParameterValue_ParsedDcfWithoutConfiguredValue_FallsBackToDefault()
+    {
+        // End-to-end: DcfReader stores an absent ParameterValue INI key as an empty
+        // string, which must not mask the DefaultValue for typed reads.
+        const string dcfContent = """
+            [FileInfo]
+            FileName=test.dcf
+            FileVersion=1
+            FileRevision=0
+            EDSVersion=4.0
+
+            [DeviceInfo]
+            VendorName=Test
+            VendorNumber=0x1
+            ProductName=Test Device
+            ProductNumber=0x1
+            RevisionNumber=0x1
+            OrderCode=T-1
+            BaudRate_500=1
+            SimpleBootUpSlave=1
+            Granularity=8
+            NrOfRXPDO=0
+            NrOfTXPDO=0
+            LSS_Supported=0
+
+            [DeviceComissioning]
+            NodeID=2
+            NodeName=TestNode
+            Baudrate=500
+            NetNumber=1
+            NetworkName=net
+            LSS_SerialNumber=0
+
+            [MandatoryObjects]
+            SupportedObjects=1
+            1=0x1000
+
+            [1000]
+            ParameterName=Device Type
+            ObjectType=0x7
+            DataType=0x0007
+            AccessType=ro
+            DefaultValue=0x00000191
+            PDOMapping=0
+            """;
+
+        var dcf = CanOpenFile.Dcf.ReadString(dcfContent);
+
+        dcf.ObjectDictionary.GetParameterValue<uint>(0x1000).Should().Be(0x191U);
+    }
+
+    [Fact]
     public void GetParameterValueAsObject_WhitespaceOnlyStringValue_IsPreserved()
     {
         var dictionary = CreateDictionary();

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -411,12 +411,21 @@ public class TypedObjectDictionaryValueTests
         CanOpenValueConverter.Format(value, 0x0001).Should().Be(expected);
     }
 
-    [Theory]
-    [InlineData(0x0003)] // INTEGER16
-    [InlineData(0x0007)] // UNSIGNED32
-    public void Format_FractionalValueForIntegerType_ThrowsArgumentException(ushort dataType)
+    public static TheoryData<object, ushort> FractionalValues => new()
     {
-        var act = () => CanOpenValueConverter.Format(1.5, dataType);
+        { 1.5D, 0x0003 },  // double -> INTEGER16
+        { 1.5F, 0x0003 },  // float -> INTEGER16
+        { 1.5M, 0x0003 },  // decimal -> INTEGER16
+        { 1.5D, 0x0007 },  // double -> UNSIGNED32
+        { 1.5F, 0x0007 },  // float -> UNSIGNED32
+        { 1.5M, 0x0007 }   // decimal -> UNSIGNED32
+    };
+
+    [Theory]
+    [MemberData(nameof(FractionalValues))]
+    public void Format_FractionalValueForIntegerType_ThrowsArgumentException(object value, ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(value, dataType);
 
         act.Should().Throw<ArgumentException>().WithMessage($"*0x{dataType:X4}*");
     }

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -429,6 +429,19 @@ public class TypedObjectDictionaryValueTests
         act.Should().Throw<InvalidOperationException>().WithMessage("*0x1018:03*");
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetParameterValueAsObject_EmptyDefault_TreatedAsMissingValue(string emptyDefault)
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2000].DefaultValue = emptyDefault;
+        dictionary.Objects[0x1018].SubObjects[1].DefaultValue = emptyDefault;
+
+        dictionary.GetParameterValueAsObject(0x2000).Should().BeNull();
+        dictionary.GetParameterValueAsObject(0x1018, 1).Should().BeNull();
+    }
+
     [Fact]
     public void SetParameterValue_NullLiteral_StillBindsToStringOverload()
     {

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -411,6 +411,17 @@ public class TypedObjectDictionaryValueTests
         CanOpenValueConverter.Format(value, 0x0001).Should().Be(expected);
     }
 
+    public static TheoryData<object> FractionalBooleanValues => new() { 0.25D, 1.4F, 0.5M };
+
+    [Theory]
+    [MemberData(nameof(FractionalBooleanValues))]
+    public void Format_FractionalNumericBoolean_ThrowsArgumentException(object value)
+    {
+        var act = () => CanOpenValueConverter.Format(value, 0x0001);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*0x0001*");
+    }
+
     public static TheoryData<object, ushort> FractionalValues => new()
     {
         { 1.5D, 0x0003 },  // double -> INTEGER16
@@ -462,6 +473,42 @@ public class TypedObjectDictionaryValueTests
 
         dictionary.GetParameterValueAsObject(0x2000).Should().BeNull();
         dictionary.GetParameterValueAsObject(0x1018, 1).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetParameterValueAsObject_WhitespaceOnlyStringValue_IsPreserved()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2001] = new CanOpenObject
+        {
+            Index = 0x2001,
+            DataType = 0x0009, // VISIBLE_STRING
+            ParameterValue = "   "
+        };
+        dictionary.Objects[0x1018].SubObjects[4] = new CanOpenSubObject
+        {
+            SubIndex = 4,
+            DataType = 0x000B, // UNICODE_STRING
+            DefaultValue = "  "
+        };
+
+        dictionary.GetParameterValueAsObject(0x2001).Should().Be("   ");
+        dictionary.GetParameterValue<string>(0x2001).Should().Be("   ");
+        dictionary.GetParameterValueAsObject(0x1018, 4).Should().Be("  ");
+    }
+
+    [Fact]
+    public void GetParameterValueAsObject_EmptyStringTypeValue_TreatedAsMissing()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2001] = new CanOpenObject
+        {
+            Index = 0x2001,
+            DataType = 0x0009, // VISIBLE_STRING
+            DefaultValue = ""  // parser default for a missing value
+        };
+
+        dictionary.GetParameterValueAsObject(0x2001).Should().BeNull();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -456,6 +456,86 @@ public class TypedObjectDictionaryValueTests
     }
 
     [Fact]
+    public void Parse_NodeIdFormulaWithLargeOffset_SupportsWideUnsignedTypes()
+    {
+        // Offsets beyond the 32-bit range must survive for UNSIGNED40..UNSIGNED64.
+        CanOpenValueConverter.Parse("$NODEID+0x100000000", 0x001B, nodeId: 2).Should().Be(0x100000002UL);
+        CanOpenValueConverter.Parse("$NODEID+0xFF00000000", 0x0018, nodeId: 1).Should().Be(0xFF00000001UL);
+    }
+
+    [Fact]
+    public void Parse_NodeIdFormulaWithLargeOffset_SupportsWideSignedTypes()
+    {
+        CanOpenValueConverter.Parse("$NODEID+0x100000000", 0x0015, nodeId: 2).Should().Be(0x100000002L);
+        CanOpenValueConverter.Parse("$NODEID-0x100000000", 0x0015, nodeId: 1).Should().Be(-0xFFFFFFFFL);
+    }
+
+    [Fact]
+    public void Parse_UnsignedNodeIdSubtractionBelowZero_ThrowsOverflowException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID-2", 0x0005, nodeId: 1);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void Parse_UnsignedNodeIdSubtractionWithinRange_ReturnsDifference()
+    {
+        CanOpenValueConverter.Parse("$NODEID-2", 0x0005, nodeId: 10).Should().Be((byte)8);
+    }
+
+    [Fact]
+    public void Parse_UnsignedNodeIdFormulaWithoutNodeId_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID+1", 0x0007);
+
+        act.Should().Throw<NotSupportedException>().WithMessage("*node ID*");
+    }
+
+    [Fact]
+    public void Parse_BareNodeIdTokenForUnsignedType_ReturnsNodeId()
+    {
+        CanOpenValueConverter.Parse("$NODEID", 0x0007, nodeId: 9).Should().Be(9U);
+    }
+
+    [Theory]
+    [InlineData("$NODEID-")]
+    [InlineData("$NODEID/2")]
+    [InlineData("$NODEID+abc")]
+    [InlineData("$NODEID+1-1")]
+    public void Parse_MalformedUnsignedNodeIdFormula_ThrowsFormatException(string formula)
+    {
+        // The typed converter must consistently throw FormatException, never EdsParseException.
+        var act = () => CanOpenValueConverter.Parse(formula, 0x0007, nodeId: 1);
+
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdOperandOutsideSigned64Range_ThrowsOverflowException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID-0xFFFFFFFFFFFFFFFF", 0x0015, nodeId: 1);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdAdditionOverflowingInt64_ThrowsOverflowException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID+0x7FFFFFFFFFFFFFFF", 0x0015, nodeId: 1);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void Parse_UnsignedNodeIdAdditionOverflowingUInt64_ThrowsOverflowException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID+0xFFFFFFFFFFFFFFFF", 0x001B, nodeId: 1);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
     public void GetParameterValue_NodeIdPassedByName_ReadsObjectLevelValue()
     {
         var dictionary = CreateDictionary();

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -590,6 +590,63 @@ public class TypedObjectDictionaryValueTests
         act.Should().Throw<NotSupportedException>().WithMessage("*DOMAIN*");
     }
 
+    [Theory]
+    [InlineData(0x0008)] // REAL32
+    [InlineData(0x0011)] // REAL64
+    public void Format_BooleanForRealType_ThrowsInvalidCastException(ushort dataType)
+    {
+        // BOOLEAN is a separate CANopen data type; true must not silently become 1.
+        var act = () => CanOpenValueConverter.Format(true, dataType);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>().WithMessage("*numeric*");
+    }
+
+    [Theory]
+    [InlineData(0x0008)]
+    [InlineData(0x0011)]
+    public void Format_CharForRealType_ThrowsInvalidCastException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format('1', dataType);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>().WithMessage("*numeric*");
+    }
+
+    public static TheoryData<object> NumericRealInputs => new()
+    {
+        (sbyte)1,
+        (byte)2,
+        (short)3,
+        (ushort)4,
+        5,
+        6U,
+        7L,
+        8UL,
+        9.5F,
+        10.5D,
+        11.5M
+    };
+
+    [Theory]
+    [MemberData(nameof(NumericRealInputs))]
+    public void Format_NumericValuesForRealType_AreAccepted(object value)
+    {
+        var act = () => CanOpenValueConverter.Format(value, 0x0008);
+
+        act.Should().NotThrow();
+        CanOpenValueConverter.Format(value, 0x0011).Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void SetParameterValue_BooleanForRealObject_ThrowsInvalidCastException()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2003] = new CanOpenObject { Index = 0x2003, DataType = 0x0008 };
+
+        var act = () => dictionary.SetParameterValue(0x2003, (object)true);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>();
+    }
+
     [Fact]
     public void Parse_SignedNodeIdAdditionOverflowingInt64_ThrowsOverflowException()
     {

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -1,0 +1,195 @@
+namespace EdsDcfNet.Tests.Extensions;
+
+using EdsDcfNet.Extensions;
+using EdsDcfNet.Models;
+using EdsDcfNet.Utilities;
+using FluentAssertions;
+using Xunit;
+
+public class TypedObjectDictionaryValueTests
+{
+    public static TheoryData<string, ushort, object> TypedValues => new()
+    {
+        { "1", 0x0001, true },
+        { "0xFF", 0x0002, (sbyte)-1 },
+        { "-1234", 0x0003, (short)-1234 },
+        { "0xFFFFFFFF", 0x0004, -1 },
+        { "255", 0x0005, (byte)255 },
+        { "0x1234", 0x0006, (ushort)0x1234 },
+        { "0x12345678", 0x0007, 0x12345678U },
+        { "1.25", 0x0008, 1.25F },
+        { "Device name", 0x0009, "Device name" },
+        { "Grüße", 0x000B, "Grüße" },
+        { "-8388608", 0x0010, -8388608 },
+        { "1.25", 0x0011, 1.25D },
+        { "-549755813888", 0x0012, -549755813888L },
+        { "9223372036854775807", 0x0015, long.MaxValue },
+        { "16777215", 0x0016, 16777215U },
+        { "18446744073709551615", 0x001B, ulong.MaxValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(TypedValues))]
+    public void Parse_SupportedDataType_ReturnsExpectedDotNetType(string value, ushort dataType, object expected)
+    {
+        var result = CanOpenValueConverter.Parse(value, dataType);
+
+        result.Should().Be(expected);
+        result.GetType().Should().Be(expected.GetType());
+    }
+
+    [Fact]
+    public void Parse_OctetString_ReturnsByteArray()
+    {
+        CanOpenValueConverter.Parse("0x0102FE", 0x000A)
+            .Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0xFE });
+    }
+
+    [Fact]
+    public void Format_UsesInvariantAndCanonicalRepresentations()
+    {
+        CanOpenValueConverter.Format(true, 0x0001).Should().Be("1");
+        CanOpenValueConverter.Format(1.5F, 0x0008).Should().Be("1.5");
+        CanOpenValueConverter.Format(new byte[] { 0x01, 0xAB }, 0x000F).Should().Be("0x01AB");
+    }
+
+    [Fact]
+    public void Format_ValueOutsideDataTypeRange_ThrowsArgumentException()
+    {
+        var act = () => CanOpenValueConverter.Format(256, 0x0005);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*0x0005*");
+    }
+
+    [Fact]
+    public void Parse_UnsupportedDataType_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Parse("1", 0x0020);
+
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*0x0020*");
+    }
+
+    [Fact]
+    public void GetParameterValueAsObject_UsesConfiguredValueBeforeDefaultAndDataType()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2000].ParameterValue = "0x2A";
+
+        var result = dictionary.GetParameterValueAsObject(0x2000);
+
+        result.Should().BeOfType<byte>().Which.Should().Be(42);
+    }
+
+    [Fact]
+    public void GetParameterValue_Generic_ReturnsStronglyTypedValue()
+    {
+        var dictionary = CreateDictionary();
+
+        dictionary.GetParameterValue<uint>(0x1018, 1).Should().Be(0x100U);
+    }
+
+    [Fact]
+    public void GetParameterValue_GenericWithWrongType_ThrowsHelpfulException()
+    {
+        var dictionary = CreateDictionary();
+
+        var act = () => dictionary.GetParameterValue<int>(0x2000);
+
+        act.Should().Throw<InvalidCastException>()
+            .WithMessage("*0x2000*Byte*Int32*");
+    }
+
+    [Fact]
+    public void SetParameterValue_Object_FormatsAccordingToObjectDataType()
+    {
+        var dictionary = CreateDictionary();
+
+        dictionary.SetParameterValue(0x2000, (object)(byte)42).Should().BeTrue();
+
+        dictionary.Objects[0x2000].ParameterValue.Should().Be("42");
+        dictionary.GetParameterValue<byte>(0x2000).Should().Be(42);
+    }
+
+    [Fact]
+    public void SetParameterValue_ObjectForSubObject_UsesSubObjectDataType()
+    {
+        var dictionary = CreateDictionary();
+
+        dictionary.SetParameterValue(0x1018, 1, (object)0x12345678U).Should().BeTrue();
+
+        dictionary.Objects[0x1018].SubObjects[1].ParameterValue.Should().Be("305419896");
+    }
+
+    [Fact]
+    public void SetParameterValue_StringOverload_RemainsLosslessAndBackwardCompatible()
+    {
+        var dictionary = CreateDictionary();
+
+        dictionary.SetParameterValue(0x2000, "0x2A").Should().BeTrue();
+
+        dictionary.Objects[0x2000].ParameterValue.Should().Be("0x2A");
+    }
+
+    [Fact]
+    public void TypedAccess_ObjectWithoutDataType_ThrowsInvalidOperationException()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x3000] = new CanOpenObject
+        {
+            Index = 0x3000,
+            DefaultValue = "1"
+        };
+
+        var get = () => dictionary.GetParameterValueAsObject(0x3000);
+        var set = () => dictionary.SetParameterValue(0x3000, (object)1);
+
+        get.Should().Throw<InvalidOperationException>().WithMessage("*0x3000*");
+        set.Should().Throw<InvalidOperationException>().WithMessage("*0x3000*");
+    }
+
+    [Fact]
+    public void TypedAccess_MissingObjectOrValue_ReturnsNullOrFalse()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x3000] = new CanOpenObject { Index = 0x3000, DataType = 0x0005 };
+
+        dictionary.GetParameterValueAsObject(0x9999).Should().BeNull();
+        dictionary.GetParameterValueAsObject(0x3000).Should().BeNull();
+        dictionary.SetParameterValue(0x9999, (object)1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetParameterValue_GenericMissingValue_ThrowsKeyNotFoundException()
+    {
+        var dictionary = CreateDictionary();
+
+        var act = () => dictionary.GetParameterValue<byte>(0x9999);
+
+        act.Should().Throw<KeyNotFoundException>().WithMessage("*0x9999*");
+    }
+
+    private static ObjectDictionary CreateDictionary()
+    {
+        var dictionary = new ObjectDictionary();
+        dictionary.Objects[0x2000] = new CanOpenObject
+        {
+            Index = 0x2000,
+            DataType = 0x0005,
+            DefaultValue = "10"
+        };
+        dictionary.Objects[0x1018] = new CanOpenObject
+        {
+            Index = 0x1018,
+            ObjectType = 0x09
+        };
+        dictionary.Objects[0x1018].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            DataType = 0x0007,
+            DefaultValue = "0x100"
+        };
+        return dictionary;
+    }
+}

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -150,6 +150,77 @@ public class TypedObjectDictionaryValueTests
     }
 
     [Fact]
+    public void TypedAccess_SubObjectWithoutDataType_ThrowsInvalidOperationException()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x1400] = new CanOpenObject
+        {
+            Index = 0x1400,
+            ObjectType = 0x09
+        };
+        dictionary.Objects[0x1400].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            DataType = 0,
+            DefaultValue = "$NODEID+0x200"
+        };
+
+        var act = () => dictionary.GetParameterValueAsObject(0x1400, 1);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*0x1400:01*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_EmptyOrWhitespaceInteger_ReturnsZero(string value)
+    {
+        CanOpenValueConverter.Parse(value, 0x0004).Should().Be(0);
+        CanOpenValueConverter.Parse(value, 0x0007).Should().Be(0U);
+        CanOpenValueConverter.Parse(value, 0x0005).Should().Be((byte)0);
+    }
+
+    [Fact]
+    public void Parse_NodeIdFormula_EvaluatesWithProvidedNodeId()
+    {
+        CanOpenValueConverter.Parse("$NODEID+0x200", 0x0007, nodeId: 5)
+            .Should().Be(517U);
+        CanOpenValueConverter.Parse("$NODEID", 0x0005, nodeId: 7)
+            .Should().Be((byte)7);
+    }
+
+    [Fact]
+    public void Parse_NodeIdFormulaWithoutNodeId_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID+0x200", 0x0007);
+
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*Cannot evaluate $NODEID formula*");
+    }
+
+    [Fact]
+    public void GetParameterValue_SubObjectNodeIdFormula_EvaluatesWithNodeId()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x1400] = new CanOpenObject
+        {
+            Index = 0x1400,
+            ObjectType = 0x09
+        };
+        dictionary.Objects[0x1400].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            DataType = 0x0007,
+            DefaultValue = "$NODEID+0x200"
+        };
+
+        dictionary.GetParameterValueAsObject(0x1400, 1, nodeId: 5).Should().Be(517U);
+        dictionary.GetParameterValue<uint>(0x1400, 1, nodeId: 5).Should().Be(517U);
+        dictionary.GetParameterValue(0x1400, 1).Should().Be("$NODEID+0x200");
+    }
+
+    [Fact]
     public void TypedAccess_MissingObjectOrValue_ReturnsNullOrFalse()
     {
         var dictionary = CreateDictionary();

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -34,6 +34,7 @@ public class TypedObjectDictionaryValueTests
         { "0xFFFFFFFFFFFFFF", 0x0014, -1L },
         { "9223372036854775807", 0x0015, long.MaxValue },
         { "0xFFFFFFFFFFFFFFFF", 0x0015, -1L },
+        { "0777", 0x0015, 511L },
         { "16777215", 0x0016, 16777215U },
         { "0xFFFFFFFFFF", 0x0018, 1099511627775UL },
         { "281474976710655", 0x0019, 281474976710655UL },
@@ -68,6 +69,8 @@ public class TypedObjectDictionaryValueTests
     [Theory]
     [InlineData("0x123", 0x000A)]  // odd digit count
     [InlineData("0xZZ", 0x000A)]   // invalid hex digit
+    [InlineData("0x!!", 0x000A)]   // character below '0'
+    [InlineData("0x::", 0x000A)]   // character between '9' and 'A'
     [InlineData("maybe", 0x0001)]  // invalid boolean token
     public void Parse_MalformedValue_ThrowsFormatException(string value, ushort dataType)
     {
@@ -80,6 +83,7 @@ public class TypedObjectDictionaryValueTests
     [InlineData("256", 0x0005)]           // unsigned decimal overflow
     [InlineData("0x1FF", 0x0005)]         // unsigned hex overflow
     [InlineData("128", 0x0002)]           // signed decimal overflow
+    [InlineData("-129", 0x0002)]          // signed decimal underflow
     [InlineData("0x1000000", 0x0010)]     // signed hex overflow (24-bit)
     public void Parse_ValueOutsideRange_ThrowsOverflowException(string value, ushort dataType)
     {
@@ -208,6 +212,15 @@ public class TypedObjectDictionaryValueTests
         var dictionary = CreateDictionary();
 
         dictionary.GetParameterValue<uint>(0x1018, 1).Should().Be(0x100U);
+    }
+
+    [Fact]
+    public void GetParameterValueAsObject_SubObjectConfiguredValue_TakesPrecedenceOverDefault()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x1018].SubObjects[1].ParameterValue = "0x200";
+
+        dictionary.GetParameterValueAsObject(0x1018, 1).Should().Be(0x200U);
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -484,6 +484,37 @@ public class TypedObjectDictionaryValueTests
         CanOpenValueConverter.Parse("$NODEID-2", 0x0005, nodeId: 10).Should().Be((byte)8);
     }
 
+    [Theory]
+    [InlineData(0x0005)] // UNSIGNED8
+    [InlineData(0x0004)] // INTEGER16
+    public void Format_BooleanForIntegerType_ThrowsInvalidCastException(ushort dataType)
+    {
+        // BOOLEAN is a separate CANopen data type; true must not silently become 1.
+        var act = () => CanOpenValueConverter.Format(true, dataType);
+
+        act.Should().Throw<InvalidCastException>().WithMessage("*integral*");
+    }
+
+    [Theory]
+    [InlineData(0x0005)]
+    [InlineData(0x0003)]
+    public void Format_CharForIntegerType_ThrowsInvalidCastException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format('1', dataType);
+
+        act.Should().Throw<InvalidCastException>().WithMessage("*integral*");
+    }
+
+    [Fact]
+    public void SetParameterValue_BooleanForUnsignedObject_ThrowsInvalidCastException()
+    {
+        var dictionary = CreateDictionary();
+
+        var act = () => dictionary.SetParameterValue(0x2000, (object)true);
+
+        act.Should().Throw<InvalidCastException>();
+    }
+
     [Fact]
     public void Parse_UnsignedNodeIdFormulaWithoutNodeId_ThrowsNotSupportedException()
     {

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -415,6 +415,62 @@ public class TypedObjectDictionaryValueTests
         CanOpenValueConverter.Parse("$NODEID+0x100", 0x0004, nodeId: 2).Should().Be(0x102);
     }
 
+    [Fact]
+    public void Parse_NodeIdSubtractionForSignedType_YieldsNegativeValue()
+    {
+        CanOpenValueConverter.Parse("$NODEID-2", 0x0002, nodeId: 1).Should().Be((sbyte)-1);
+        CanOpenValueConverter.Parse("$NODEID-0x10", 0x0004, nodeId: 2).Should().Be(-14);
+    }
+
+    [Fact]
+    public void Parse_NodeIdSubtractionOutsideSignedRange_ThrowsOverflowException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID-200", 0x0002, nodeId: 1);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void Parse_SignedNodeIdFormulaWithoutNodeId_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Parse("$NODEID+1", 0x0004);
+
+        act.Should().Throw<NotSupportedException>().WithMessage("*node ID*");
+    }
+
+    [Theory]
+    [InlineData("$NODEID+")]
+    [InlineData("$NODEID*2")]
+    [InlineData("$NODEID+1+1")]
+    public void Parse_MalformedSignedNodeIdFormula_ThrowsFormatException(string formula)
+    {
+        var act = () => CanOpenValueConverter.Parse(formula, 0x0004, nodeId: 1);
+
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Parse_BareNodeIdTokenForSignedType_ReturnsNodeId()
+    {
+        CanOpenValueConverter.Parse("$NODEID", 0x0004, nodeId: 5).Should().Be(5);
+    }
+
+    [Fact]
+    public void GetParameterValue_NodeIdPassedByName_ReadsObjectLevelValue()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2002] = new CanOpenObject
+        {
+            Index = 0x2002,
+            DataType = 0x0007,
+            DefaultValue = "$NODEID+0x200"
+        };
+
+        // The second positional argument is always the sub-index, so nodeId must be named.
+        dictionary.GetParameterValue<uint>(0x2002, nodeId: 5).Should().Be(0x205U);
+        dictionary.GetParameterValueAsObject(0x2002, nodeId: 5).Should().Be(0x205U);
+    }
+
     [Theory]
     [InlineData(2)]
     [InlineData(-1)]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -380,6 +380,68 @@ public class TypedObjectDictionaryValueTests
         CanOpenValueConverter.Parse("$NODEID+0x100", 0x0004, nodeId: 2).Should().Be(0x102);
     }
 
+    [Theory]
+    [InlineData(2)]
+    [InlineData(-1)]
+    public void Format_NumericBooleanOutsideRange_ThrowsArgumentException(int value)
+    {
+        var act = () => CanOpenValueConverter.Format(value, 0x0001);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*0x0001*");
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    public void Format_NumericBooleanZeroOrOne_IsAccepted(int value, string expected)
+    {
+        CanOpenValueConverter.Format(value, 0x0001).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0x0003)] // INTEGER16
+    [InlineData(0x0007)] // UNSIGNED32
+    public void Format_FractionalValueForIntegerType_ThrowsArgumentException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(1.5, dataType);
+
+        act.Should().Throw<ArgumentException>().WithMessage($"*0x{dataType:X4}*");
+    }
+
+    [Theory]
+    [InlineData(0x0009)] // VISIBLE_STRING
+    [InlineData(0x000B)] // UNICODE_STRING
+    public void Format_NonStringForStringType_ThrowsArgumentException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(new byte[] { 0x01 }, dataType);
+
+        act.Should().Throw<ArgumentException>().WithMessage($"*0x{dataType:X4}*");
+    }
+
+    [Fact]
+    public void SetParameterValue_SubObjectWithoutDataType_ThrowsInvalidOperationException()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x1018].SubObjects[3] = new CanOpenSubObject { SubIndex = 3, DataType = 0 };
+
+        var act = () => dictionary.SetParameterValue(0x1018, 3, (object)1U);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*0x1018:03*");
+    }
+
+    [Fact]
+    public void SetParameterValue_NullLiteral_StillBindsToStringOverload()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2000].ParameterValue = "10";
+
+        // Overload resolution must keep preferring the string overload for null literals,
+        // preserving source compatibility with pre-typed-API callers.
+        dictionary.SetParameterValue(0x2000, null!).Should().BeTrue();
+
+        dictionary.Objects[0x2000].ParameterValue.Should().BeNull();
+    }
+
     [Fact]
     public void GetParameterValue_GenericMissingValue_ThrowsKeyNotFoundException()
     {

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -492,7 +492,7 @@ public class TypedObjectDictionaryValueTests
         // BOOLEAN is a separate CANopen data type; true must not silently become 1.
         var act = () => CanOpenValueConverter.Format(true, dataType);
 
-        act.Should().Throw<InvalidCastException>().WithMessage("*integral*");
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>().WithMessage("*integral*");
     }
 
     [Theory]
@@ -502,7 +502,7 @@ public class TypedObjectDictionaryValueTests
     {
         var act = () => CanOpenValueConverter.Format('1', dataType);
 
-        act.Should().Throw<InvalidCastException>().WithMessage("*integral*");
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>().WithMessage("*integral*");
     }
 
     [Fact]
@@ -512,7 +512,7 @@ public class TypedObjectDictionaryValueTests
 
         var act = () => dictionary.SetParameterValue(0x2000, (object)true);
 
-        act.Should().Throw<InvalidCastException>();
+        act.Should().Throw<ArgumentException>().WithInnerException<InvalidCastException>();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -287,6 +287,24 @@ public class TypedObjectDictionaryValueTests
     }
 
     [Fact]
+    public void TypedAccess_ObjectWithDataTypeZero_ThrowsInvalidOperationException()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x3001] = new CanOpenObject
+        {
+            Index = 0x3001,
+            DataType = 0, // parser sentinel for an omitted DataType field
+            DefaultValue = "1"
+        };
+
+        var get = () => dictionary.GetParameterValueAsObject(0x3001);
+        var set = () => dictionary.SetParameterValue(0x3001, (object)1);
+
+        get.Should().Throw<InvalidOperationException>().WithMessage("*0x3001*");
+        set.Should().Throw<InvalidOperationException>().WithMessage("*0x3001*");
+    }
+
+    [Fact]
     public void TypedAccess_SubObjectWithoutDataType_ThrowsInvalidOperationException()
     {
         var dictionary = CreateDictionary();

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -11,20 +11,33 @@ public class TypedObjectDictionaryValueTests
     public static TheoryData<string, ushort, object> TypedValues => new()
     {
         { "1", 0x0001, true },
+        { "true", 0x0001, true },
+        { "0", 0x0001, false },
+        { "false", 0x0001, false },
         { "0xFF", 0x0002, (sbyte)-1 },
+        { "017", 0x0002, (sbyte)15 },
+        { "0377", 0x0002, (sbyte)-1 },
         { "-1234", 0x0003, (short)-1234 },
         { "0xFFFFFFFF", 0x0004, -1 },
         { "255", 0x0005, (byte)255 },
+        { "0377", 0x0005, (byte)255 },
         { "0x1234", 0x0006, (ushort)0x1234 },
         { "0x12345678", 0x0007, 0x12345678U },
         { "1.25", 0x0008, 1.25F },
         { "Device name", 0x0009, "Device name" },
         { "Grüße", 0x000B, "Grüße" },
+        { "0xFF00FF", 0x0010, -65281 },
         { "-8388608", 0x0010, -8388608 },
         { "1.25", 0x0011, 1.25D },
         { "-549755813888", 0x0012, -549755813888L },
+        { "0xFFFFFFFFFFFF", 0x0013, -1L },
+        { "0xFFFFFFFFFFFFFF", 0x0014, -1L },
         { "9223372036854775807", 0x0015, long.MaxValue },
+        { "0xFFFFFFFFFFFFFFFF", 0x0015, -1L },
         { "16777215", 0x0016, 16777215U },
+        { "0xFFFFFFFFFF", 0x0018, 1099511627775UL },
+        { "281474976710655", 0x0019, 281474976710655UL },
+        { "0x1AB", 0x001A, 427UL },
         { "18446744073709551615", 0x001B, ulong.MaxValue }
     };
 
@@ -43,6 +56,113 @@ public class TypedObjectDictionaryValueTests
     {
         CanOpenValueConverter.Parse("0x0102FE", 0x000A)
             .Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0xFE });
+    }
+
+    [Fact]
+    public void Parse_ByteStringWithSeparators_IgnoresSpacesAndDashes()
+    {
+        CanOpenValueConverter.Parse("01 02-fe", 0x000F)
+            .Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0xFE });
+    }
+
+    [Theory]
+    [InlineData("0x123", 0x000A)]  // odd digit count
+    [InlineData("0xZZ", 0x000A)]   // invalid hex digit
+    [InlineData("maybe", 0x0001)]  // invalid boolean token
+    public void Parse_MalformedValue_ThrowsFormatException(string value, ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Parse(value, dataType);
+
+        act.Should().Throw<FormatException>();
+    }
+
+    [Theory]
+    [InlineData("256", 0x0005)]           // unsigned decimal overflow
+    [InlineData("0x1FF", 0x0005)]         // unsigned hex overflow
+    [InlineData("128", 0x0002)]           // signed decimal overflow
+    [InlineData("0x1000000", 0x0010)]     // signed hex overflow (24-bit)
+    public void Parse_ValueOutsideRange_ThrowsOverflowException(string value, ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Parse(value, dataType);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Theory]
+    [InlineData(0x000C)] // TIME_OF_DAY
+    [InlineData(0x000D)] // TIME_DIFFERENCE
+    public void ParseAndFormat_TimeTypes_ThrowNotSupportedException(ushort dataType)
+    {
+        var parse = () => CanOpenValueConverter.Parse("1", dataType);
+        var format = () => CanOpenValueConverter.Format(1, dataType);
+
+        parse.Should().Throw<NotSupportedException>().WithMessage($"*0x{dataType:X4}*");
+        format.Should().Throw<NotSupportedException>().WithMessage($"*0x{dataType:X4}*");
+    }
+
+    [Fact]
+    public void ParseAndFormat_NullValue_ThrowArgumentNullException()
+    {
+        var parse = () => CanOpenValueConverter.Parse(null!, 0x0005);
+        var format = () => CanOpenValueConverter.Format(null!, 0x0005);
+
+        parse.Should().Throw<ArgumentNullException>();
+        format.Should().Throw<ArgumentNullException>();
+    }
+
+    public static TheoryData<object, ushort, string> FormattedValues => new()
+    {
+        { false, 0x0001, "0" },
+        { (sbyte)-5, 0x0002, "-5" },
+        { (short)-1234, 0x0003, "-1234" },
+        { -70000, 0x0004, "-70000" },
+        { (byte)7, 0x0005, "7" },
+        { (ushort)512, 0x0006, "512" },
+        { 0x12345678U, 0x0007, "305419896" },
+        { "Device", 0x0009, "Device" },
+        { "Grüße", 0x000B, "Grüße" },
+        { -8388608, 0x0010, "-8388608" },
+        { 2.5D, 0x0011, "2.5" },
+        { -549755813888L, 0x0012, "-549755813888" },
+        { -140737488355328L, 0x0013, "-140737488355328" },
+        { -36028797018963968L, 0x0014, "-36028797018963968" },
+        { long.MinValue, 0x0015, "-9223372036854775808" },
+        { 16777215U, 0x0016, "16777215" },
+        { 1099511627775UL, 0x0018, "1099511627775" },
+        { 281474976710655UL, 0x0019, "281474976710655" },
+        { 72057594037927935UL, 0x001A, "72057594037927935" },
+        { ulong.MaxValue, 0x001B, "18446744073709551615" }
+    };
+
+    [Theory]
+    [MemberData(nameof(FormattedValues))]
+    public void Format_SupportedDataType_ProducesCanonicalString(object value, ushort dataType, string expected)
+    {
+        CanOpenValueConverter.Format(value, dataType).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Format_SignedValueOutsideRange_ThrowsArgumentException()
+    {
+        var act = () => CanOpenValueConverter.Format(128, 0x0002);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*0x0002*");
+    }
+
+    [Fact]
+    public void Format_NonByteArrayForOctetString_ThrowsArgumentException()
+    {
+        var act = () => CanOpenValueConverter.Format("not bytes", 0x000A);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*0x000A*");
+    }
+
+    [Fact]
+    public void Format_UnsupportedDataType_ThrowsNotSupportedException()
+    {
+        var act = () => CanOpenValueConverter.Format(1, 0x0020);
+
+        act.Should().Throw<NotSupportedException>().WithMessage("*0x0020*");
     }
 
     [Fact]
@@ -229,6 +349,35 @@ public class TypedObjectDictionaryValueTests
         dictionary.GetParameterValueAsObject(0x9999).Should().BeNull();
         dictionary.GetParameterValueAsObject(0x3000).Should().BeNull();
         dictionary.SetParameterValue(0x9999, (object)1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TypedAccess_MissingSubObjectOrValue_ReturnsNullOrFalse()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x1018].SubObjects[2] = new CanOpenSubObject { SubIndex = 2, DataType = 0x0005 };
+
+        dictionary.GetParameterValueAsObject(0x1018, 99).Should().BeNull();
+        dictionary.GetParameterValueAsObject(0x1018, 2).Should().BeNull();
+        dictionary.SetParameterValue(0x1018, 99, (object)1U).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetParameterValue_NullTypedValue_ThrowsArgumentNullException()
+    {
+        var dictionary = CreateDictionary();
+
+        var forObject = () => dictionary.SetParameterValue(0x2000, (object)null!);
+        var forSubObject = () => dictionary.SetParameterValue(0x1018, 1, (object)null!);
+
+        forObject.Should().Throw<ArgumentNullException>();
+        forSubObject.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Parse_NodeIdFormulaForSignedType_EvaluatesWithNodeId()
+    {
+        CanOpenValueConverter.Parse("$NODEID+0x100", 0x0004, nodeId: 2).Should().Be(0x102);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This PR makes the CANopen Object Dictionary a first-class, application-friendly part of the library, both in the documentation and in the API.

### Documentation (README)

- Highlight the fully typed, editable Object Dictionary model in the intro and feature list, so the project is not perceived as a round-trip-only tool
- Add a dedicated "Working with the CANopen Object Dictionary" quick-start section with a practical example (querying, modifying, and creating objects)
- Extend the Supported Features list with OD-related capabilities

### Typed value access (new API)

Previously, `GetParameterValue` / `SetParameterValue` only worked with raw strings, forcing callers to parse and format values themselves. This PR adds typed overloads that derive the .NET type automatically from the object's `DataType`:

- `GetParameterValueAsObject(index[, subIndex])` returns the configured or default value converted to the matching .NET type
- `GetParameterValue<T>(index[, subIndex])` returns a strongly typed value with a helpful `InvalidCastException` / `KeyNotFoundException` on mismatch or missing values
- `SetParameterValue(index[, subIndex], object value)` validates the value against the CANopen data type (including range checks) and stores the canonical textual representation
- New `CanOpenValueConverter` handles the mapping: BOOLEAN, signed/unsigned integers including the 24/40/48/56-bit CANopen types, REAL32/REAL64, VISIBLE_STRING, UNICODE_STRING, OCTET_STRING, and DOMAIN
- TIME_OF_DAY / TIME_DIFFERENCE intentionally throw `NotSupportedException` because their file representation has no universally interoperable mapping

### Backward compatibility

- The existing string-based overloads are unchanged and remain the lossless, exact-representation path
- No existing signatures were modified; all additions are new overloads or new types

## Testing

- 29 new tests covering type mapping for all supported data types, hex/decimal/octal parsing, range validation, default vs. configured value precedence, sub-object access, and error cases
- Full test suite passes: 1384 tests, 0 failures
- Both target frameworks (netstandard2.0, net10.0) build clean with analyzers enabled