### PR TITLE
fix: reject non-finite REAL32/REAL64 values in typed OD conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ parameter ranges.
 
 Typed value conversion covers BOOLEAN, signed and unsigned integers (including the CANopen
 24/40/48/56-bit types), REAL32/REAL64, VISIBLE_STRING, UNICODE_STRING, and OCTET_STRING.
-Numeric ranges are validated when setting values. DOMAIN entries are excluded because DCF
-files reference their payload through `UploadFile`/`DownloadFile` instead of an inline
-value; use those properties directly. The original string overloads
+Numeric ranges are validated when setting values, and REAL32/REAL64 values must be finite:
+`NaN` and values that overflow the target range (for example `double.MaxValue` on a REAL32
+entry) are rejected instead of being written as `Infinity`. DOMAIN entries are excluded
+because DCF files reference their payload through `UploadFile`/`DownloadFile` instead of an
+inline value; use those properties directly. The original string overloads
 remain available when an application needs exact control of the serialized representation.
 
 ### Writing an EDS File

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -26,6 +26,9 @@ public static class CanOpenValueConverter
     /// <remarks>
     /// Integer values may use decimal, hexadecimal (<c>0x</c>), octal notation, or
     /// <c>$NODEID</c> formulas. Empty or whitespace-only integer literals are treated as zero.
+    /// REAL32/REAL64 values must be finite: <c>NaN</c> and literals that saturate to infinity
+    /// (for example <c>3.5e40</c> for REAL32) are rejected because EDS/DCF has no
+    /// interoperable representation for them.
     /// OCTET_STRING values are returned as <see cref="byte"/> arrays when written as
     /// hexadecimal literals. DOMAIN is not supported because DCF files reference its payload
     /// through <c>UploadFile</c>/<c>DownloadFile</c> instead of an inline value.
@@ -45,12 +48,12 @@ public static class CanOpenValueConverter
             0x0005 => (byte)ParseUnsignedInteger(value, 8, nodeId),
             0x0006 => (ushort)ParseUnsignedInteger(value, 16, nodeId),
             0x0007 => (uint)ParseUnsignedInteger(value, 32, nodeId),
-            0x0008 => float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
+            0x0008 => ParseReal32(value),
             0x0009 => value,
             0x000A => ParseByteString(value),
             0x000B => value,
             0x0010 => (int)ParseSignedInteger(value, 24, nodeId),
-            0x0011 => double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture),
+            0x0011 => ParseReal64(value),
             0x0012 => ParseSignedInteger(value, 40, nodeId),
             0x0013 => ParseSignedInteger(value, 48, nodeId),
             0x0014 => ParseSignedInteger(value, 56, nodeId),
@@ -70,6 +73,12 @@ public static class CanOpenValueConverter
     /// <summary>
     /// Formats a .NET value according to its CANopen data type index for storage in an EDS/DCF model.
     /// </summary>
+    /// <remarks>
+    /// REAL32/REAL64 values must be finite. <c>NaN</c> and infinities are rejected, including
+    /// inputs that only become infinite through the narrowing conversion (for example
+    /// <see cref="double.MaxValue"/> for a REAL32 entry), so a value that cannot be represented
+    /// is never persisted as <c>Infinity</c>.
+    /// </remarks>
     public static string Format(object value, ushort dataType)
     {
         EnsureNotNull(value, nameof(value));
@@ -268,13 +277,60 @@ public static class CanOpenValueConverter
     private static string FormatReal32(object value)
     {
         EnsureNumeric(value);
-        return Convert.ToSingle(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+        var converted = Convert.ToSingle(value, CultureInfo.InvariantCulture);
+        EnsureFiniteReal(float.IsNaN(converted), float.IsInfinity(converted), value, 32);
+        return converted.ToString("R", CultureInfo.InvariantCulture);
     }
 
     private static string FormatReal64(object value)
     {
         EnsureNumeric(value);
-        return Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+        var converted = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        EnsureFiniteReal(double.IsNaN(converted), double.IsInfinity(converted), value, 64);
+        return converted.ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Parses a REAL32 literal. <c>float.Parse</c> saturates out-of-range literals such as
+    /// <c>3.5e40</c> to infinity instead of throwing, so the result is validated explicitly.
+    /// </summary>
+    private static float ParseReal32(string value)
+    {
+        var parsed = float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+        EnsureFiniteReal(float.IsNaN(parsed), float.IsInfinity(parsed), value.Trim(), 32);
+        return parsed;
+    }
+
+    /// <summary>
+    /// Parses a REAL64 literal. <c>double.Parse</c> saturates out-of-range literals such as
+    /// <c>3.5e400</c> to infinity instead of throwing, so the result is validated explicitly.
+    /// </summary>
+    private static double ParseReal64(string value)
+    {
+        var parsed = double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+        EnsureFiniteReal(double.IsNaN(parsed), double.IsInfinity(parsed), value.Trim(), 64);
+        return parsed;
+    }
+
+    /// <summary>
+    /// Rejects REAL32/REAL64 values that are not finite. EDS/DCF stores REAL values as plain
+    /// numeric literals, so <c>NaN</c> and infinities have no interoperable representation.
+    /// Infinity is reported as <see cref="OverflowException"/> because it is also what a
+    /// narrowing conversion silently produces when a wider input such as
+    /// <see cref="double.MaxValue"/> exceeds the finite <see cref="float"/> range; without this
+    /// check the value would be persisted as <c>Infinity</c>.
+    /// </summary>
+    private static void EnsureFiniteReal(bool isNaN, bool isInfinity, object value, int bits)
+    {
+        if (isNaN)
+        {
+            throw new FormatException($"'{value}' is not a valid CANopen REAL{bits} value.");
+        }
+
+        if (isInfinity)
+        {
+            throw new OverflowException($"Value '{value}' is outside the finite REAL{bits} range.");
+        }
     }
 
     /// <summary>
@@ -460,7 +516,12 @@ public static class CanOpenValueConverter
     {
         if (value is not byte[] bytes)
         {
-            throw new InvalidCastException("OCTET_STRING and DOMAIN values must be supplied as byte arrays.");
+            // DOMAIN (0x000F) is rejected earlier with NotSupportedException, so OCTET_STRING
+            // is the only data type that reaches this conversion. Do not mention DOMAIN here:
+            // it misleads callers debugging a type mismatch.
+            throw new InvalidCastException(
+                "OCTET_STRING values must be supplied as byte arrays, but a value of type " +
+                $"{value.GetType().Name} was provided.");
         }
 
         const string hexDigits = "0123456789ABCDEF";

--- a/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
+++ b/tests/EdsDcfNet.Tests/Extensions/TypedObjectDictionaryValueTests.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet.Tests.Extensions;
 
+using System.Globalization;
 using EdsDcfNet.Extensions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Utilities;
@@ -885,6 +886,142 @@ public class TypedObjectDictionaryValueTests
         var act = () => dictionary.GetParameterValue<byte>(0x9999);
 
         act.Should().Throw<KeyNotFoundException>().WithMessage("*0x9999*");
+    }
+
+    [Theory]
+    [InlineData(0x0008)] // REAL32
+    [InlineData(0x0011)] // REAL64
+    public void Format_PositiveInfinityForRealType_ThrowsArgumentException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(double.PositiveInfinity, dataType);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<OverflowException>();
+    }
+
+    [Theory]
+    [InlineData(0x0008)]
+    [InlineData(0x0011)]
+    public void Format_NegativeInfinityForRealType_ThrowsArgumentException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(double.NegativeInfinity, dataType);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<OverflowException>();
+    }
+
+    [Theory]
+    [InlineData(0x0008)]
+    [InlineData(0x0011)]
+    public void Format_NaNForRealType_ThrowsArgumentException(ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Format(double.NaN, dataType);
+
+        act.Should().Throw<ArgumentException>().WithInnerException<FormatException>();
+    }
+
+    public static TheoryData<object> Real32OverflowingInputs => new()
+    {
+        double.MaxValue,
+        double.MinValue,
+        3.5e40D,
+        -3.5e40D
+    };
+
+    [Theory]
+    [MemberData(nameof(Real32OverflowingInputs))]
+    public void Format_WiderValueOutsideReal32Range_ThrowsArgumentException(object value)
+    {
+        // Convert.ToSingle saturates to infinity instead of throwing, so the converted
+        // result must be validated explicitly (see PR #393 review feedback).
+        var act = () => CanOpenValueConverter.Format(value, 0x0008);
+
+        act.Should().Throw<ArgumentException>()
+            .WithInnerException<OverflowException>()
+            .WithMessage("*REAL32*");
+    }
+
+    [Fact]
+    public void Format_Real32AtMaxValue_IsAccepted()
+    {
+        CanOpenValueConverter.Format(float.MaxValue, 0x0008)
+            .Should().Be(float.MaxValue.ToString("R", CultureInfo.InvariantCulture));
+        CanOpenValueConverter.Format(float.MinValue, 0x0008)
+            .Should().Be(float.MinValue.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_Real64AtMaxValue_IsAccepted()
+    {
+        CanOpenValueConverter.Format(double.MaxValue, 0x0011)
+            .Should().Be(double.MaxValue.ToString("R", CultureInfo.InvariantCulture));
+        CanOpenValueConverter.Format(double.MinValue, 0x0011)
+            .Should().Be(double.MinValue.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void SetParameterValue_Real32OverflowingValue_DoesNotPersistInfinity()
+    {
+        var dictionary = CreateDictionary();
+        dictionary.Objects[0x2004] = new CanOpenObject
+        {
+            Index = 0x2004,
+            DataType = 0x0008,
+            ParameterValue = "1.5"
+        };
+
+        var act = () => dictionary.SetParameterValue(0x2004, (object)double.MaxValue);
+
+        act.Should().Throw<ArgumentException>();
+        dictionary.Objects[0x2004].ParameterValue.Should().Be("1.5");
+    }
+
+    [Theory]
+    [InlineData("3.5e40", 0x0008)]   // saturates float.Parse to +Infinity
+    [InlineData("-3.5e40", 0x0008)]  // saturates float.Parse to -Infinity
+    [InlineData("3.5e400", 0x0011)]  // saturates double.Parse to +Infinity
+    [InlineData("-3.5e400", 0x0011)]
+    public void Parse_RealLiteralOutsideRange_ThrowsOverflowException(string value, ushort dataType)
+    {
+        // float.Parse/double.Parse saturate to infinity rather than throwing, so a value that
+        // cannot be represented must not silently round-trip as Infinity.
+        var act = () => CanOpenValueConverter.Parse(value, dataType);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Theory]
+    [InlineData("NaN", 0x0008)]
+    [InlineData("NaN", 0x0011)]
+    [InlineData("Infinity", 0x0008)]
+    [InlineData("-Infinity", 0x0011)]
+    public void Parse_NonFiniteRealLiteral_ThrowsFormatOrOverflowException(string value, ushort dataType)
+    {
+        var act = () => CanOpenValueConverter.Parse(value, dataType);
+
+        act.Should().Throw<Exception>().Which.Should().Match(ex => ex is FormatException || ex is OverflowException);
+    }
+
+    [Fact]
+    public void Parse_RealAtMaxValue_RoundTripsThroughFormat()
+    {
+        var real32 = CanOpenValueConverter.Format(float.MaxValue, 0x0008);
+        CanOpenValueConverter.Parse(real32, 0x0008).Should().Be(float.MaxValue);
+
+        var real64 = CanOpenValueConverter.Format(double.MaxValue, 0x0011);
+        CanOpenValueConverter.Parse(real64, 0x0011).Should().Be(double.MaxValue);
+    }
+
+    [Fact]
+    public void Format_NonByteArrayForOctetString_MessageDoesNotMentionDomain()
+    {
+        // DOMAIN is rejected earlier with NotSupportedException, so naming it here would
+        // mislead callers debugging a type mismatch (see PR #393 review feedback).
+        var act = () => CanOpenValueConverter.Format("not bytes", 0x000A);
+
+        var inner = act.Should().Throw<ArgumentException>()
+            .WithInnerException<InvalidCastException>().Which;
+        inner.Message.Should().Contain("OCTET_STRING");
+        inner.Message.Should().Contain("String");
+        inner.Message.Should().NotContain("DOMAIN");
     }
 
     private static ObjectDictionary CreateDictionary()


### PR DESCRIPTION
## Description

Addresses the open review feedback on #393.

**1. REAL32/REAL64 overflow to infinity (Codex P2)**

`Convert.ToSingle` saturates a wider input such as `double.MaxValue` to positive infinity instead of throwing, so `Format`'s `catch (OverflowException)` never fired and `SetParameterValue` happily persisted `Infinity` into the device config.

Verified empirically on net10.0:

| input | before |
|---|---|
| `Convert.ToSingle(double.MaxValue)` | `Infinity` (no throw) |
| `float.Parse("3.5e40")` | `Infinity` (no throw) |
| `double.Parse("3.5e400")` | `Infinity` (no throw) |

The **parse** path had the same flaw, so a file containing `3.5e40` (or an `Infinity` written by the bug) would silently round-trip. Both directions are now validated:

- `NaN` results in `FormatException`
- Infinities result in `OverflowException`

`Format` continues to wrap both into `ArgumentException` like every other unrepresentable value, so the public contract is unchanged for callers.

**2. Misleading DOMAIN mention in `FormatByteString`**

The `InvalidCastException` said "OCTET_STRING and DOMAIN values must be supplied as byte arrays", but DOMAIN (`0x000F`) is rejected earlier with `NotSupportedException` and can never reach that branch. The message now covers only OCTET_STRING and names the offending type.

## Type of change

- [x] Bug fix (`fix:`)

## Public API changes

- [x] **No** public API changes

No signatures change. Behaviour narrows only for values that previously produced a corrupt `Infinity` serialization, which was never a valid EDS/DCF representation.

## Boundary & regression matrix

| Concern | Coverage |
|---|---|
| Numeric boundaries | `Format_Real32AtMaxValue_IsAccepted`, `Format_Real64AtMaxValue_IsAccepted` (`float.MaxValue` / `MinValue` still accepted) |
| Overflow rejection | `Format_WiderValueOutsideReal32Range_ThrowsArgumentException` (`double.MaxValue`, `double.MinValue`, `3.5e40`, `-3.5e40`) |
| Non-finite rejection | `Format_PositiveInfinityForRealType_*`, `Format_NegativeInfinityForRealType_*`, `Format_NaNForRealType_*` for both `0x0008` and `0x0011` |
| Parse path | `Parse_RealLiteralOutsideRange_ThrowsOverflowException`, `Parse_NonFiniteRealLiteral_ThrowsFormatOrOverflowException` |
| Round-trip fidelity | `Parse_RealAtMaxValue_RoundTripsThroughFormat` |
| API contract | `SetParameterValue_Real32OverflowingValue_DoesNotPersistInfinity` (asserts the original value is left untouched) |
| Error message | `Format_NonByteArrayForOctetString_MessageDoesNotMentionDomain` |
| End-to-end write path | `WriteDcf_AfterRejectedReal32Overflow_ContainsNoInfinity` (written DCF keeps the previous value and contains no `Infinity`/`NaN`), `WriteDcf_AfterAcceptedReal32MaxValue_RoundTripsThroughReader` |

Negative control: with the source fix reverted, 20 of the new converter tests fail and `WriteDcf_AfterRejectedReal32Overflow_ContainsNoInfinity` fails, confirming the bug reached the serialized DCF file rather than stopping at the converter boundary. With the fix applied all 1546 pass.

## Testing

- [x] `dotnet test --configuration Release` passes locally (1546/1546)
- [x] `dotnet build --configuration Release` passes locally (0 warnings, both `netstandard2.0` and `net10.0`)
