### PR TITLE
fix: limit XML nesting depth in SecureXmlParser (#395)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,8 +68,9 @@ network), consumers should apply the standard defense-in-depth measures:
 - **Validate file origin** before passing paths or content to the library.
 - **Limit resource usage** (memory, CPU) at the process level when parsing
   files from untrusted sources. The library applies default input-size limits
-  for all formats and an XML nesting-depth limit for XDD/XDC; raise these only
-  for trusted, known-large payloads.
+  for all formats (raise via `CanOpenFileOptions.MaxInputSize` only for
+  trusted, known-large payloads) and a fixed XML nesting-depth cap for
+  XDD/XDC that is not consumer-configurable.
 - **Keep the package up to date** to receive security fixes as soon as they
   are released.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,7 @@ surface is therefore limited to:
 |------|-----------------------------|
 | Malformed input handling | Unbounded memory allocation, infinite loops, or unhandled exceptions when parsing crafted EDS/DCF/CPJ files |
 | Path traversal | Any API that accepts a file path and could be abused to read or write outside the intended directory |
-| Denial of service via parsing | Algorithmic complexity attacks (e.g. quadratic parsing) triggered by crafted files |
+| Denial of service via parsing | Algorithmic complexity attacks (e.g. quadratic parsing, deeply nested XML) triggered by crafted files |
 | Dependency vulnerabilities | Vulnerabilities in NuGet dependencies. The main library has no runtime dependencies shipped to consumers, but does use build-time/dev-only tooling packages (e.g. Microsoft.SourceLink.GitHub). |
 
 The following are **out of scope**:
@@ -67,7 +67,9 @@ network), consumers should apply the standard defense-in-depth measures:
 
 - **Validate file origin** before passing paths or content to the library.
 - **Limit resource usage** (memory, CPU) at the process level when parsing
-  files from untrusted sources.
+  files from untrusted sources. The library applies default input-size limits
+  for all formats and an XML nesting-depth limit for XDD/XDC; raise these only
+  for trusted, known-large payloads.
 - **Keep the package up to date** to receive security fixes as soon as they
   are released.
 

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -51,6 +51,13 @@ for EDS/DCF/CPJ/XDD/XDC via `CanOpenFileOptions`.
 Guideline: keep the default for untrusted inputs and raise limits only as needed for
 trusted, known-large payloads.
 
+### XML Nesting Depth Limits (XDD/XDC)
+
+`SecureXmlParser` additionally caps `XmlReader.Depth` when loading XDD/XDC documents
+(default **64**). Deeply nested but still small well-formed trees can otherwise cause
+high CPU cost under the size limit alone. Typical CiA 311 profiles are far shallower
+(around depth 8). Exceeding the limit fails with `EdsParseException` during parse.
+
 ## 8.2 Culture Independence (InvariantCulture)
 
 CANopen INI/XML files are culture-independent. Numeric values use deterministic formats and must not depend on OS locale.

--- a/src/EdsDcfNet/Parsers/SecureXmlParser.cs
+++ b/src/EdsDcfNet/Parsers/SecureXmlParser.cs
@@ -257,8 +257,8 @@ internal static class SecureXmlParser
         public override ReadState ReadState => _inner.ReadState;
         public override XmlNameTable NameTable => _inner.NameTable;
 
-        public override string GetAttribute(string name) => _inner.GetAttribute(name)!;
-        public override string GetAttribute(string name, string? namespaceURI) => _inner.GetAttribute(name, namespaceURI)!;
+        public override string? GetAttribute(string name) => _inner.GetAttribute(name);
+        public override string? GetAttribute(string name, string? namespaceURI) => _inner.GetAttribute(name, namespaceURI);
         public override string GetAttribute(int i) => _inner.GetAttribute(i);
 
         public override bool MoveToAttribute(string name) => _inner.MoveToAttribute(name);

--- a/src/EdsDcfNet/Parsers/SecureXmlParser.cs
+++ b/src/EdsDcfNet/Parsers/SecureXmlParser.cs
@@ -14,6 +14,13 @@ internal static class SecureXmlParser
 {
     internal const long DefaultMaxInputSize = ReaderDefaults.DefaultMaxInputSize;
 
+    /// <summary>
+    /// Default maximum allowed <see cref="XmlReader.Depth"/> for XDD/XDC parsing.
+    /// Root elements have depth 0. CiA 311 profiles are typically around depth 8;
+    /// 64 blocks deep-nesting DoS payloads while remaining generous for real files.
+    /// </summary>
+    internal const int DefaultMaxDepth = 64;
+
     internal static void EnsureFileWithinSizeLimit(
         string filePath,
         string formatName,
@@ -37,16 +44,27 @@ internal static class SecureXmlParser
         string content,
         string formatName,
         string parseErrorMessage,
-        long maxInputSize = DefaultMaxInputSize)
+        long maxInputSize = DefaultMaxInputSize,
+        int maxDepth = DefaultMaxDepth)
     {
         EnsureContentWithinSizeLimit(content, formatName, maxInputSize);
+        if (maxDepth < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDepth),
+                maxDepth,
+                "Maximum XML nesting depth must be non-negative.");
+        }
 
         try
         {
             var settings = CreateSecureReaderSettings(maxInputSize);
             using var stringReader = new StringReader(content);
-            using var xmlReader = XmlReader.Create(stringReader, settings);
-            return XDocument.Load(xmlReader, LoadOptions.None);
+            using var depthLimitedReader = new DepthLimitingXmlReader(
+                XmlReader.Create(stringReader, settings),
+                maxDepth,
+                formatName);
+            return XDocument.Load(depthLimitedReader, LoadOptions.None);
         }
         catch (XmlException ex)
         {
@@ -207,5 +225,82 @@ internal static class SecureXmlParser
         if (value == null)
             throw new ArgumentNullException(parameterName);
 #endif
+    }
+
+    /// <summary>
+    /// Forwards to an inner <see cref="XmlReader"/> and rejects nodes whose
+    /// <see cref="XmlReader.Depth"/> exceeds a configured maximum.
+    /// </summary>
+    private sealed class DepthLimitingXmlReader : XmlReader
+    {
+        private readonly XmlReader _inner;
+        private readonly int _maxDepth;
+        private readonly string _formatName;
+
+        public DepthLimitingXmlReader(XmlReader inner, int maxDepth, string formatName)
+        {
+            _inner = inner;
+            _maxDepth = maxDepth;
+            _formatName = formatName;
+        }
+
+        public override XmlNodeType NodeType => _inner.NodeType;
+        public override string LocalName => _inner.LocalName;
+        public override string NamespaceURI => _inner.NamespaceURI;
+        public override string Prefix => _inner.Prefix;
+        public override string Value => _inner.Value;
+        public override int Depth => _inner.Depth;
+        public override string BaseURI => _inner.BaseURI;
+        public override bool IsEmptyElement => _inner.IsEmptyElement;
+        public override int AttributeCount => _inner.AttributeCount;
+        public override bool EOF => _inner.EOF;
+        public override ReadState ReadState => _inner.ReadState;
+        public override XmlNameTable NameTable => _inner.NameTable;
+
+        public override string GetAttribute(string name) => _inner.GetAttribute(name)!;
+        public override string GetAttribute(string name, string? namespaceURI) => _inner.GetAttribute(name, namespaceURI)!;
+        public override string GetAttribute(int i) => _inner.GetAttribute(i);
+
+        public override bool MoveToAttribute(string name) => _inner.MoveToAttribute(name);
+        public override bool MoveToAttribute(string name, string? ns) => _inner.MoveToAttribute(name, ns);
+        public override void MoveToAttribute(int i) => _inner.MoveToAttribute(i);
+        public override bool MoveToFirstAttribute() => _inner.MoveToFirstAttribute();
+        public override bool MoveToNextAttribute() => _inner.MoveToNextAttribute();
+        public override bool MoveToElement() => _inner.MoveToElement();
+        public override bool ReadAttributeValue() => _inner.ReadAttributeValue();
+
+        public override string? LookupNamespace(string prefix) => _inner.LookupNamespace(prefix);
+        public override void ResolveEntity() => _inner.ResolveEntity();
+
+        public override bool Read()
+        {
+            if (!_inner.Read())
+                return false;
+
+            EnsureDepthWithinLimit();
+            return true;
+        }
+
+        public override void Close() => _inner.Close();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void EnsureDepthWithinLimit()
+        {
+            if (_inner.Depth <= _maxDepth)
+                return;
+
+            throw new EdsParseException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} content exceeds the maximum XML nesting depth of {1}.",
+                    _formatName,
+                    _maxDepth));
+        }
     }
 }

--- a/tests/EdsDcfNet.Tests/Parsers/SecureXmlParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/SecureXmlParserTests.cs
@@ -124,8 +124,7 @@ public class SecureXmlParserTests
     [Fact]
     public void ParseDocument_InvalidXml_ThrowsEdsParseException()
     {
-        var act = () => Invoke<XDocument>(
-            "ParseDocument",
+        var act = () => InvokeParseDocument(
             "<root><broken></root>",
             "XDD",
             "Failed to parse XDD XML content.",
@@ -133,6 +132,68 @@ public class SecureXmlParserTests
 
         act.Should().Throw<EdsParseException>()
             .WithMessage("*Failed to parse XDD XML content.*");
+    }
+
+    [Fact]
+    public void ParseDocument_ExceedsMaxDepth_ThrowsEdsParseException()
+    {
+        // Depth 0 = <a>, depth 1 = <b>, depth 2 = <c>. With maxDepth 1, <c> must fail.
+        const string nested = "<a><b><c/></b></a>";
+
+        var act = () => InvokeParseDocument(
+            nested,
+            "XDD",
+            "Failed to parse XDD XML content.",
+            1024L,
+            maxDepth: 1);
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*maximum XML nesting depth of 1*");
+    }
+
+    [Fact]
+    public void ParseDocument_AtMaxDepth_Succeeds()
+    {
+        const string nested = "<a><b><c/></b></a>";
+
+        var doc = InvokeParseDocument(
+            nested,
+            "XDD",
+            "Failed to parse XDD XML content.",
+            1024L,
+            maxDepth: 2);
+
+        doc.Root.Should().NotBeNull();
+        doc.Root!.Name.LocalName.Should().Be("a");
+    }
+
+    [Fact]
+    public void ParseDocument_RealisticFlatFixture_Succeeds()
+    {
+        var content = File.ReadAllText("Fixtures/sample_device.xdd");
+
+        var doc = InvokeParseDocument(
+            content,
+            "XDD",
+            "Failed to parse XDD XML content.",
+            10L * 1024 * 1024);
+
+        doc.Root.Should().NotBeNull();
+        doc.Root!.Name.LocalName.Should().Be("ISO15745ProfileContainer");
+    }
+
+    [Fact]
+    public void ParseDocument_NegativeMaxDepth_ThrowsArgumentOutOfRangeException()
+    {
+        var act = () => InvokeParseDocument(
+            "<root/>",
+            "XDD",
+            "Failed to parse XDD XML content.",
+            1024L,
+            maxDepth: -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Where(ex => ex.ParamName == "maxDepth");
     }
 
     [Fact]
@@ -159,11 +220,25 @@ public class SecureXmlParserTests
         }
     }
 
+    private static XDocument InvokeParseDocument(
+        string content,
+        string formatName,
+        string parseErrorMessage,
+        long maxInputSize,
+        int maxDepth = 64)
+    {
+        return Invoke<XDocument>(
+            "ParseDocument",
+            content,
+            formatName,
+            parseErrorMessage,
+            maxInputSize,
+            maxDepth);
+    }
+
     private static T Invoke<T>(string methodName, params object?[] args)
     {
-        var method = SecureXmlParserType.GetMethod(
-            methodName,
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var method = ResolveMethod(methodName, args.Length);
 
         try
         {
@@ -179,9 +254,7 @@ public class SecureXmlParserTests
 
     private static async Task<T> InvokeAsync<T>(string methodName, params object?[] args)
     {
-        var method = SecureXmlParserType.GetMethod(
-            methodName,
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var method = ResolveMethod(methodName, args.Length);
 
         Task<T> task;
         try
@@ -195,6 +268,17 @@ public class SecureXmlParserTests
         }
 
         return await task.ConfigureAwait(false);
+    }
+
+    private static MethodInfo ResolveMethod(string methodName, int argumentCount)
+    {
+        var method = SecureXmlParserType
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .SingleOrDefault(m => m.Name == methodName && m.GetParameters().Length == argumentCount);
+
+        return method
+            ?? throw new InvalidOperationException(
+                $"Internal method {methodName} with {argumentCount} parameter(s) not found.");
     }
 
     private sealed class WriteOnlyStream : MemoryStream

--- a/tests/EdsDcfNet.Tests/Parsers/SecureXmlParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/SecureXmlParserTests.cs
@@ -3,6 +3,7 @@ namespace EdsDcfNet.Tests.Parsers;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Parsers;
@@ -12,6 +13,11 @@ public class SecureXmlParserTests
     private static readonly Type SecureXmlParserType =
         typeof(XddReader).Assembly.GetType("EdsDcfNet.Parsers.SecureXmlParser")
         ?? throw new InvalidOperationException("Internal type EdsDcfNet.Parsers.SecureXmlParser not found.");
+
+    private static readonly Type DepthLimitingXmlReaderType =
+        SecureXmlParserType.GetNestedType("DepthLimitingXmlReader", BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException(
+            "Internal type EdsDcfNet.Parsers.SecureXmlParser+DepthLimitingXmlReader not found.");
 
     [Fact]
     public void ReadContentFromStreamWithLimit_ValidStream_ReturnsContent()
@@ -197,6 +203,64 @@ public class SecureXmlParserTests
     }
 
     [Fact]
+    public void DepthLimitingXmlReader_ForwardingMembers_DelegateToInner()
+    {
+        // XDocument.Load does not exercise every XmlReader abstract member.
+        // Drive the remaining forwarding overrides directly so patch coverage
+        // includes the DepthLimitingXmlReader wrapper surface.
+        const string xml = """
+            <root xmlns:p="urn:eds-dcf-net:test" p:attr="ns-value" id="42">
+              text
+            </root>
+            """;
+
+        using var stringReader = new StringReader(xml);
+        var inner = XmlReader.Create(
+            stringReader,
+            new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            });
+        // DepthLimitingXmlReader owns and disposes the inner reader.
+        using var reader = CreateDepthLimitingXmlReader(inner, maxDepth: 8, formatName: "XDD");
+
+        reader.Read().Should().BeTrue(); // move to <root>
+        reader.NodeType.Should().Be(XmlNodeType.Element);
+
+        reader.Depth.Should().Be(0);
+        _ = reader.BaseURI;
+        reader.AttributeCount.Should().Be(3);
+        reader.NameTable.Should().NotBeNull();
+
+        reader.GetAttribute("id").Should().Be("42");
+        reader.GetAttribute("attr", "urn:eds-dcf-net:test").Should().Be("ns-value");
+        reader.GetAttribute(0).Should().NotBeNullOrEmpty();
+
+        reader.MoveToAttribute("id").Should().BeTrue();
+        reader.Value.Should().Be("42");
+        reader.MoveToElement().Should().BeTrue();
+
+        reader.MoveToAttribute("attr", "urn:eds-dcf-net:test").Should().BeTrue();
+        reader.Value.Should().Be("ns-value");
+        reader.MoveToElement().Should().BeTrue();
+
+        reader.MoveToAttribute(0);
+        reader.ReadAttributeValue().Should().BeTrue();
+        reader.MoveToElement().Should().BeTrue();
+
+        reader.LookupNamespace("p").Should().Be("urn:eds-dcf-net:test");
+
+        var resolveEntity = () => reader.ResolveEntity();
+        resolveEntity.Should().Throw<InvalidOperationException>();
+
+        reader.Close();
+        reader.ReadState.Should().Be(ReadState.Closed);
+
+        InvokeDispose(reader, disposing: false);
+    }
+
+    [Fact]
     public void EnsureFileWithinSizeLimit_TooLarge_ThrowsEdsParseException()
     {
         var tempFile = Path.GetTempFileName();
@@ -234,6 +298,34 @@ public class SecureXmlParserTests
             parseErrorMessage,
             maxInputSize,
             maxDepth);
+    }
+
+    private static XmlReader CreateDepthLimitingXmlReader(
+        XmlReader inner,
+        int maxDepth,
+        string formatName)
+    {
+        var instance = Activator.CreateInstance(
+            DepthLimitingXmlReaderType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [inner, maxDepth, formatName],
+            culture: null);
+
+        return (XmlReader)instance!;
+    }
+
+    private static void InvokeDispose(XmlReader reader, bool disposing)
+    {
+        var dispose = typeof(XmlReader).GetMethod(
+            "Dispose",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(bool)],
+            modifiers: null)
+            ?? throw new InvalidOperationException("XmlReader.Dispose(bool) not found.");
+
+        dispose.Invoke(reader, [disposing]);
     }
 
     private static T Invoke<T>(string methodName, params object?[] args)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #395.

`SecureXmlParser` already hardened XDD/XDC parsing against XXE/DTD and oversized input, but had no nesting-depth limit. Deeply nested yet small well-formed trees can cause high CPU cost under `MaxInputSize`.

This change:

- Caps `XmlReader.Depth` at **64** during `XDocument.Load` via a depth-limiting reader wrapper
- Throws `EdsParseException` when the limit is exceeded (before the full tree is built)
- Keeps the default generous vs typical CiA 311 profiles (~depth 8) while blocking pathological nesting
- Adds regression tests for over-deep XML, at-limit success, and the realistic `sample_device.xdd` fixture
- Documents the limit in `SECURITY.md` and architecture cross-cutting concepts

`CanOpenFileOptions` wiring was deferred: depth is XML-only, and the shared read pipeline currently only forwards `MaxInputSize` through `Func<..., long, ...>` delegates (changing that would be a larger compatibility-sensitive change). The optional configurability called out in the issue can follow as a format-specific options extension if needed.

## Test plan

- [x] `SecureXmlParserTests` covers too-deep → exception, at-limit → OK, fixture → OK
- [x] Full test suite (`dotnet test`) — 1548 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785602844429889?thread_ts=1785602844.429889&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-ed74ba5e-5fc3-5247-ba7a-5640eddf02ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed74ba5e-5fc3-5247-ba7a-5640eddf02ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

