### PR TITLE
fix: enforce MaxInputSize while reading file-based inputs (TOCTOU)

### DIFF
--- a/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
+++ b/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
@@ -64,7 +64,7 @@ internal sealed class ByteLimitingStream : Stream
     public override void Flush() => _inner.Flush();
 
     public override int Read(byte[] buffer, int offset, int count)
-        => CountBytes(_inner.Read(buffer, offset, count));
+        => CountBytes(_inner.Read(buffer, offset, LimitCount(count)));
 
     public override async Task<int> ReadAsync(
         byte[] buffer,
@@ -72,6 +72,7 @@ internal sealed class ByteLimitingStream : Stream
         int count,
         CancellationToken cancellationToken)
     {
+        count = LimitCount(count);
 #if NET10_0_OR_GREATER
         var bytesRead = await _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
 #else
@@ -85,6 +86,10 @@ internal sealed class ByteLimitingStream : Stream
         Memory<byte> buffer,
         CancellationToken cancellationToken = default)
     {
+        var limitedLength = LimitCount(buffer.Length);
+        if (limitedLength < buffer.Length)
+            buffer = buffer.Slice(0, limitedLength);
+
         var bytesRead = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         return CountBytes(bytesRead);
     }
@@ -102,6 +107,22 @@ internal sealed class ByteLimitingStream : Stream
             _inner.Dispose();
 
         base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Caps the requested read size so at most one byte past <see cref="_maxBytes"/>
+    /// can be transferred in a single operation (needed to detect overflow).
+    /// </summary>
+    private int LimitCount(int count)
+    {
+        var remainingIncludingProbe = _maxBytes - _totalBytesRead + 1;
+        if (remainingIncludingProbe <= 0)
+            throw new EdsParseException(_exceededMessage);
+
+        if (count > remainingIncludingProbe)
+            return remainingIncludingProbe > int.MaxValue ? int.MaxValue : (int)remainingIncludingProbe;
+
+        return count;
     }
 
     private int CountBytes(int bytesRead)

--- a/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
+++ b/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
@@ -1,0 +1,123 @@
+namespace EdsDcfNet.Parsers;
+
+using EdsDcfNet.Exceptions;
+
+/// <summary>
+/// Forwards reads to an inner stream and aborts once more than a configured
+/// number of bytes has been read.
+/// </summary>
+/// <remarks>
+/// File-based readers document their limit in bytes, while the decoding readers
+/// count characters. Multibyte encodings decode to fewer characters than bytes,
+/// so the byte limit has to be enforced on the raw stream to stay effective when
+/// a file grows after its length was checked.
+/// </remarks>
+internal sealed class ByteLimitingStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly long _maxBytes;
+    private readonly string _exceededMessage;
+    private long _totalBytesRead;
+
+    internal ByteLimitingStream(Stream inner, long maxBytes, string exceededMessage)
+    {
+        _inner = inner;
+        _maxBytes = maxBytes;
+        _exceededMessage = exceededMessage;
+    }
+
+    /// <summary>
+    /// Opens a file for sequential reading with the given byte limit applied.
+    /// </summary>
+    internal static ByteLimitingStream OpenFile(
+        string filePath,
+        long maxBytes,
+        string exceededMessage,
+        bool useAsync)
+    {
+        var options = useAsync
+            ? FileOptions.Asynchronous | FileOptions.SequentialScan
+            : FileOptions.SequentialScan;
+
+        var fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: options);
+
+        try
+        {
+            return new ByteLimitingStream(fileStream, maxBytes, exceededMessage);
+        }
+        catch
+        {
+            fileStream.Dispose();
+            throw;
+        }
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => _inner.Flush();
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => CountBytes(_inner.Read(buffer, offset, count));
+
+    public override async Task<int> ReadAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+#if NET10_0_OR_GREATER
+        var bytesRead = await _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+#else
+        var bytesRead = await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+#endif
+        return CountBytes(bytesRead);
+    }
+
+#if NET10_0_OR_GREATER
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        var bytesRead = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return CountBytes(bytesRead);
+    }
+#endif
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            _inner.Dispose();
+
+        base.Dispose(disposing);
+    }
+
+    private int CountBytes(int bytesRead)
+    {
+        _totalBytesRead += bytesRead;
+        if (_totalBytesRead > _maxBytes)
+            throw new EdsParseException(_exceededMessage);
+
+        return bytesRead;
+    }
+}

--- a/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
+++ b/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
@@ -64,7 +64,7 @@ internal sealed class ByteLimitingStream : Stream
     public override void Flush() => _inner.Flush();
 
     public override int Read(byte[] buffer, int offset, int count)
-        => CountBytes(_inner.Read(buffer, offset, LimitCount(count)));
+        => CountBytes(_inner.Read(buffer, offset, AllowedCount(count)));
 
     public override async Task<int> ReadAsync(
         byte[] buffer,
@@ -72,11 +72,11 @@ internal sealed class ByteLimitingStream : Stream
         int count,
         CancellationToken cancellationToken)
     {
-        count = LimitCount(count);
+        var allowedCount = AllowedCount(count);
 #if NET10_0_OR_GREATER
-        var bytesRead = await _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+        var bytesRead = await _inner.ReadAsync(buffer.AsMemory(offset, allowedCount), cancellationToken).ConfigureAwait(false);
 #else
-        var bytesRead = await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        var bytesRead = await _inner.ReadAsync(buffer, offset, allowedCount, cancellationToken).ConfigureAwait(false);
 #endif
         return CountBytes(bytesRead);
     }
@@ -86,11 +86,8 @@ internal sealed class ByteLimitingStream : Stream
         Memory<byte> buffer,
         CancellationToken cancellationToken = default)
     {
-        var limitedLength = LimitCount(buffer.Length);
-        if (limitedLength < buffer.Length)
-            buffer = buffer.Slice(0, limitedLength);
-
-        var bytesRead = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        var allowed = buffer[..AllowedCount(buffer.Length)];
+        var bytesRead = await _inner.ReadAsync(allowed, cancellationToken).ConfigureAwait(false);
         return CountBytes(bytesRead);
     }
 #endif
@@ -110,19 +107,14 @@ internal sealed class ByteLimitingStream : Stream
     }
 
     /// <summary>
-    /// Caps the requested read size so at most one byte past <see cref="_maxBytes"/>
-    /// can be transferred in a single operation (needed to detect overflow).
+    /// Caps a requested read at one byte past the remaining budget, so an
+    /// oversized input is still detected without buffering a whole block beyond
+    /// the limit.
     /// </summary>
-    private int LimitCount(int count)
+    private int AllowedCount(int count)
     {
-        var remainingIncludingProbe = _maxBytes - _totalBytesRead + 1;
-        if (remainingIncludingProbe <= 0)
-            throw new EdsParseException(_exceededMessage);
-
-        if (count > remainingIncludingProbe)
-            return remainingIncludingProbe > int.MaxValue ? int.MaxValue : (int)remainingIncludingProbe;
-
-        return count;
+        var allowed = _maxBytes - _totalBytesRead + 1;
+        return allowed < count ? (int)allowed : count;
     }
 
     private int CountBytes(int bytesRead)

--- a/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
+++ b/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
@@ -47,15 +47,7 @@ internal sealed class ByteLimitingStream : Stream
             bufferSize: 4096,
             options: options);
 
-        try
-        {
-            return new ByteLimitingStream(fileStream, maxBytes, exceededMessage);
-        }
-        catch
-        {
-            fileStream.Dispose();
-            throw;
-        }
+        return new ByteLimitingStream(fileStream, maxBytes, exceededMessage);
     }
 
     public override bool CanRead => _inner.CanRead;

--- a/src/EdsDcfNet/Parsers/IniParser.cs
+++ b/src/EdsDcfNet/Parsers/IniParser.cs
@@ -51,7 +51,18 @@ public static class IniParser
                     "File '{0}' is too large ({1:N0} bytes). Maximum supported size is {2:N0} bytes.",
                     filePath, fileInfo.Length, maxInputSize));
 
-        return ParseLines(File.ReadLines(filePath));
+        // Stream through ParseReader so MaxInputSize is enforced while reading
+        // (guards TOCTOU if the file grows after the FileInfo.Length check).
+        using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: FileOptions.SequentialScan);
+        using var reader = new StreamReader(stream);
+
+        return ParseReader(reader, maxInputSize);
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Parsers/IniParser.cs
+++ b/src/EdsDcfNet/Parsers/IniParser.cs
@@ -53,13 +53,7 @@ public static class IniParser
 
         // Stream through ParseReader so MaxInputSize is enforced while reading
         // (guards TOCTOU if the file grows after the FileInfo.Length check).
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.SequentialScan);
+        using var stream = OpenFileWithByteLimit(filePath, maxInputSize, useAsync: false);
         using var reader = new StreamReader(stream);
 
         return ParseReader(reader, maxInputSize);
@@ -92,16 +86,24 @@ public static class IniParser
                     "File '{0}' is too large ({1:N0} bytes). Maximum supported size is {2:N0} bytes.",
                     filePath, fileInfo.Length, maxInputSize));
 
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var stream = OpenFileWithByteLimit(filePath, maxInputSize, useAsync: true);
         using var reader = new StreamReader(stream);
 
         return await ParseReaderAsync(reader, maxInputSize, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ByteLimitingStream OpenFileWithByteLimit(
+        string filePath,
+        long maxInputSize,
+        bool useAsync)
+    {
+        var message = string.Format(
+            CultureInfo.InvariantCulture,
+            "File '{0}' is too large. Maximum supported size is {1:N0} bytes.",
+            filePath,
+            maxInputSize);
+
+        return ByteLimitingStream.OpenFile(filePath, maxInputSize, message, useAsync);
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Parsers/SecureXmlParser.cs
+++ b/src/EdsDcfNet/Parsers/SecureXmlParser.cs
@@ -40,6 +40,27 @@ internal static class SecureXmlParser
         }
     }
 
+    /// <summary>
+    /// Opens a file for sequential reading with <paramref name="maxInputSize"/>
+    /// enforced in bytes while reading, so the limit still holds if the file grew
+    /// after <see cref="EnsureFileWithinSizeLimit"/> inspected its length.
+    /// </summary>
+    internal static Stream OpenFileWithSizeLimit(
+        string filePath,
+        string formatName,
+        long maxInputSize,
+        bool useAsync)
+    {
+        var message = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} file '{1}' is too large. Maximum supported size is {2:N0} bytes.",
+            formatName,
+            filePath,
+            maxInputSize);
+
+        return ByteLimitingStream.OpenFile(filePath, maxInputSize, message, useAsync);
+    }
+
     internal static XDocument ParseDocument(
         string content,
         string formatName,

--- a/src/EdsDcfNet/Parsers/XdcReader.cs
+++ b/src/EdsDcfNet/Parsers/XdcReader.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
+using EdsDcfNet.Utilities;
 
 /// <summary>
 /// Reader for CiA 311 XDC (XML Device Configuration) files.

--- a/src/EdsDcfNet/Parsers/XdcReader.cs
+++ b/src/EdsDcfNet/Parsers/XdcReader.cs
@@ -30,13 +30,7 @@ public class XdcReader : IFileReader<DeviceConfigurationFile>
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDC", maxInputSize);
         // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
         // if the file grows after the FileInfo.Length pre-check).
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.SequentialScan);
+        using var stream = SecureXmlParser.OpenFileWithSizeLimit(filePath, "XDC", maxInputSize, useAsync: false);
         var content = SecureXmlParser.ReadContentFromStreamWithLimit(stream, "XDC", maxInputSize);
         return ReadString(content, maxInputSize);
     }
@@ -89,13 +83,7 @@ public class XdcReader : IFileReader<DeviceConfigurationFile>
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDC", maxInputSize);
         // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
         // if the file grows after the FileInfo.Length pre-check).
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var stream = SecureXmlParser.OpenFileWithSizeLimit(filePath, "XDC", maxInputSize, useAsync: true);
         var content = await SecureXmlParser.ReadContentFromStreamWithLimitAsync(
             stream,
             "XDC",

--- a/src/EdsDcfNet/Parsers/XdcReader.cs
+++ b/src/EdsDcfNet/Parsers/XdcReader.cs
@@ -1,11 +1,9 @@
 namespace EdsDcfNet.Parsers;
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Xml.Linq;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
-using EdsDcfNet.Utilities;
 
 /// <summary>
 /// Reader for CiA 311 XDC (XML Device Configuration) files.
@@ -29,7 +27,16 @@ public class XdcReader : IFileReader<DeviceConfigurationFile>
             throw new FileNotFoundException($"XDC file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDC", maxInputSize);
-        var content = File.ReadAllText(filePath);
+        // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
+        // if the file grows after the FileInfo.Length pre-check).
+        using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: FileOptions.SequentialScan);
+        var content = SecureXmlParser.ReadContentFromStreamWithLimit(stream, "XDC", maxInputSize);
         return ReadString(content, maxInputSize);
     }
 
@@ -79,10 +86,20 @@ public class XdcReader : IFileReader<DeviceConfigurationFile>
             throw new FileNotFoundException($"XDC file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDC", maxInputSize);
-        var content = await TextFileIo.ReadAllTextAsync(
+        // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
+        // if the file grows after the FileInfo.Length pre-check).
+        using var stream = new FileStream(
             filePath,
-            Encoding.UTF8,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var content = await SecureXmlParser.ReadContentFromStreamWithLimitAsync(
+            stream,
+            "XDC",
+            maxInputSize,
+            cancellationToken).ConfigureAwait(false);
         return ReadString(content, maxInputSize);
     }
 

--- a/src/EdsDcfNet/Parsers/XddReader.cs
+++ b/src/EdsDcfNet/Parsers/XddReader.cs
@@ -1,11 +1,9 @@
 namespace EdsDcfNet.Parsers;
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Xml.Linq;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
-using EdsDcfNet.Utilities;
 
 /// <summary>
 /// Reader for CiA 311 XDD (XML Device Description) files.
@@ -28,7 +26,16 @@ public class XddReader : IFileReader<ElectronicDataSheet>
             throw new FileNotFoundException($"XDD file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDD", maxInputSize);
-        var content = File.ReadAllText(filePath);
+        // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
+        // if the file grows after the FileInfo.Length pre-check).
+        using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: FileOptions.SequentialScan);
+        var content = SecureXmlParser.ReadContentFromStreamWithLimit(stream, "XDD", maxInputSize);
         return ReadString(content, maxInputSize);
     }
 
@@ -78,10 +85,20 @@ public class XddReader : IFileReader<ElectronicDataSheet>
             throw new FileNotFoundException($"XDD file not found: {filePath}", filePath);
 
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDD", maxInputSize);
-        var content = await TextFileIo.ReadAllTextAsync(
+        // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
+        // if the file grows after the FileInfo.Length pre-check).
+        using var stream = new FileStream(
             filePath,
-            Encoding.UTF8,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var content = await SecureXmlParser.ReadContentFromStreamWithLimitAsync(
+            stream,
+            "XDD",
+            maxInputSize,
+            cancellationToken).ConfigureAwait(false);
         return ReadString(content, maxInputSize);
     }
 

--- a/src/EdsDcfNet/Parsers/XddReader.cs
+++ b/src/EdsDcfNet/Parsers/XddReader.cs
@@ -28,13 +28,7 @@ public class XddReader : IFileReader<ElectronicDataSheet>
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDD", maxInputSize);
         // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
         // if the file grows after the FileInfo.Length pre-check).
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.SequentialScan);
+        using var stream = SecureXmlParser.OpenFileWithSizeLimit(filePath, "XDD", maxInputSize, useAsync: false);
         var content = SecureXmlParser.ReadContentFromStreamWithLimit(stream, "XDD", maxInputSize);
         return ReadString(content, maxInputSize);
     }
@@ -87,13 +81,7 @@ public class XddReader : IFileReader<ElectronicDataSheet>
         SecureXmlParser.EnsureFileWithinSizeLimit(filePath, "XDD", maxInputSize);
         // Bounded stream read enforces MaxInputSize while loading (guards TOCTOU
         // if the file grows after the FileInfo.Length pre-check).
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 4096,
-            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var stream = SecureXmlParser.OpenFileWithSizeLimit(filePath, "XDD", maxInputSize, useAsync: true);
         var content = await SecureXmlParser.ReadContentFromStreamWithLimitAsync(
             stream,
             "XDD",

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -135,6 +135,45 @@ public class ByteLimitingStreamTests
     }
 
     [Fact]
+    public void Read_OverLimit_ReadsAtMostOneByteBeyondTheLimit()
+    {
+        var inner = new CountingStream(new byte[1024]);
+        using var stream = Create(inner, maxBytes: 8);
+        var buffer = new byte[1024];
+
+        var act = () => stream.Read(buffer, 0, buffer.Length);
+
+        act.Should().Throw<EdsParseException>();
+        inner.TotalBytesServed.Should().Be(9);
+    }
+
+    [Fact]
+    public async Task ReadAsync_OverLimit_ReadsAtMostOneByteBeyondTheLimit()
+    {
+        var inner = new CountingStream(new byte[1024]);
+        using var stream = Create(inner, maxBytes: 8);
+        var buffer = new byte[1024];
+
+        var act = () => stream.ReadAsync(buffer, 0, buffer.Length);
+
+        await act.Should().ThrowAsync<EdsParseException>();
+        inner.TotalBytesServed.Should().Be(9);
+    }
+
+    [Fact]
+    public async Task ReadAsync_MemoryOverload_OverLimit_ReadsAtMostOneByteBeyondTheLimit()
+    {
+        var inner = new CountingStream(new byte[1024]);
+        using var stream = Create(inner, maxBytes: 8);
+        var buffer = new byte[1024];
+
+        var act = async () => await stream.ReadAsync(buffer.AsMemory());
+
+        await act.Should().ThrowAsync<EdsParseException>();
+        inner.TotalBytesServed.Should().Be(9);
+    }
+
+    [Fact]
     public void UnsupportedMembers_ThrowNotSupportedException()
     {
         using var stream = Create(new MemoryStream([1, 2, 3]), maxBytes: 8);
@@ -166,6 +205,30 @@ public class ByteLimitingStreamTests
             binder: null,
             args: [inner, maxBytes, ExceededMessage],
             culture: null)!;
+
+    private sealed class CountingStream : MemoryStream
+    {
+        public CountingStream(byte[] buffer)
+            : base(buffer)
+        {
+        }
+
+        public long TotalBytesServed { get; private set; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var bytesRead = base.Read(buffer, offset, count);
+            TotalBytesServed += bytesRead;
+            return bytesRead;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var bytesRead = base.Read(buffer);
+            TotalBytesServed += bytesRead;
+            return bytesRead;
+        }
+    }
 
     private static Stream OpenFile(string filePath, long maxBytes)
     {

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -1,0 +1,186 @@
+namespace EdsDcfNet.Tests.Parsers;
+
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using EdsDcfNet.Exceptions;
+using EdsDcfNet.Parsers;
+
+public class ByteLimitingStreamTests
+{
+    private const string ExceededMessage = "File 'test.eds' is too large. Maximum supported size is 8 bytes.";
+
+    private static readonly Type ByteLimitingStreamType =
+        typeof(XddReader).Assembly.GetType("EdsDcfNet.Parsers.ByteLimitingStream")
+        ?? throw new InvalidOperationException("Internal type EdsDcfNet.Parsers.ByteLimitingStream not found.");
+
+    [Fact]
+    public void Read_ContentAtExactByteLimit_ReadsFully()
+    {
+        var data = Encoding.UTF8.GetBytes("12345678");
+        using var stream = Create(new MemoryStream(data), maxBytes: data.Length);
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        reader.ReadToEnd().Should().Be("12345678");
+    }
+
+    [Fact]
+    public void Read_ContentOneOverByteLimit_ThrowsEdsParseException()
+    {
+        var data = Encoding.UTF8.GetBytes("123456789");
+        using var stream = Create(new MemoryStream(data), maxBytes: data.Length - 1);
+
+        var act = () =>
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        };
+
+        act.Should().Throw<EdsParseException>().WithMessage(ExceededMessage);
+    }
+
+    [Fact]
+    public void Read_MultibyteContentUnderCharacterLimitButOverByteLimit_ThrowsEdsParseException()
+    {
+        // Four characters that encode to eight UTF-8 bytes: a character-based
+        // limit would accept this content, the byte limit must not.
+        var data = Encoding.UTF8.GetBytes("äöüß");
+        using var stream = Create(new MemoryStream(data), maxBytes: 4);
+
+        var act = () =>
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        };
+
+        act.Should().Throw<EdsParseException>().WithMessage(ExceededMessage);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ContentOverByteLimit_ThrowsEdsParseException()
+    {
+        var data = Encoding.UTF8.GetBytes("123456789");
+        using var stream = Create(new MemoryStream(data), maxBytes: data.Length - 1);
+        var buffer = new byte[data.Length];
+
+        var act = () => stream.ReadAsync(buffer, 0, buffer.Length);
+
+        await act.Should().ThrowAsync<EdsParseException>().WithMessage(ExceededMessage);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ContentWithinByteLimit_ReadsContent()
+    {
+        var data = Encoding.UTF8.GetBytes("12345678");
+        using var stream = Create(new MemoryStream(data), maxBytes: data.Length);
+        var buffer = new byte[data.Length];
+
+        var bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
+
+        bytesRead.Should().Be(data.Length);
+        Encoding.UTF8.GetString(buffer).Should().Be("12345678");
+    }
+
+    [Fact]
+    public void OpenFile_FileGrownBeyondLimitAfterOpen_ThrowsEdsParseException()
+    {
+        // Simulates the TOCTOU window: the reader opens the file after its length
+        // was checked, so the byte limit has to be enforced while reading.
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, new string('x', 64));
+
+            using var stream = OpenFile(tempFile, maxBytes: 8);
+
+            var act = () =>
+            {
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                return reader.ReadToEnd();
+            };
+
+            act.Should().Throw<EdsParseException>().WithMessage(ExceededMessage);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void OpenFile_DisposingWrapper_ReleasesUnderlyingFile()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, "[Section1]");
+
+            using (var stream = OpenFile(tempFile, maxBytes: 1024))
+            {
+                stream.CanRead.Should().BeTrue();
+            }
+
+            // The wrapper owns the FileStream; deleting proves the handle is gone.
+            File.Delete(tempFile);
+            File.Exists(tempFile).Should().BeFalse();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void UnsupportedMembers_ThrowNotSupportedException()
+    {
+        using var stream = Create(new MemoryStream([1, 2, 3]), maxBytes: 8);
+
+        stream.CanSeek.Should().BeFalse();
+        stream.CanWrite.Should().BeFalse();
+
+        var length = () => stream.Length;
+        var position = () => stream.Position;
+        var setPosition = () => stream.Position = 0;
+        var seek = () => stream.Seek(0, SeekOrigin.Begin);
+        var setLength = () => stream.SetLength(1);
+        var write = () => stream.Write([1], 0, 1);
+
+        length.Should().Throw<NotSupportedException>();
+        position.Should().Throw<NotSupportedException>();
+        setPosition.Should().Throw<NotSupportedException>();
+        seek.Should().Throw<NotSupportedException>();
+        setLength.Should().Throw<NotSupportedException>();
+        write.Should().Throw<NotSupportedException>();
+
+        stream.Flush();
+    }
+
+    private static Stream Create(Stream inner, long maxBytes)
+        => (Stream)Activator.CreateInstance(
+            ByteLimitingStreamType,
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [inner, maxBytes, ExceededMessage],
+            culture: null)!;
+
+    private static Stream OpenFile(string filePath, long maxBytes)
+    {
+        var method = ByteLimitingStreamType
+            .GetMethod("OpenFile", BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Internal method ByteLimitingStream.OpenFile not found.");
+
+        try
+        {
+            return (Stream)method.Invoke(null, [filePath, maxBytes, ExceededMessage, false])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+}

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -174,6 +174,19 @@ public class ByteLimitingStreamTests
     }
 
     [Fact]
+    public void Dispose_WithoutDisposingManagedState_LeavesInnerStreamOpen()
+    {
+        var inner = new CountingStream(new byte[8]);
+        var stream = Create(inner, maxBytes: 8);
+
+        InvokeDispose(stream, disposing: false);
+        inner.CanRead.Should().BeTrue();
+
+        stream.Dispose();
+        inner.CanRead.Should().BeFalse();
+    }
+
+    [Fact]
     public void UnsupportedMembers_ThrowNotSupportedException()
     {
         using var stream = Create(new MemoryStream([1, 2, 3]), maxBytes: 8);
@@ -205,6 +218,20 @@ public class ByteLimitingStreamTests
             binder: null,
             args: [inner, maxBytes, ExceededMessage],
             culture: null)!;
+
+    private static void InvokeDispose(Stream stream, bool disposing)
+    {
+        var method = ByteLimitingStreamType
+            .GetMethod(
+                "Dispose",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: [typeof(bool)],
+                modifiers: null)
+            ?? throw new InvalidOperationException("ByteLimitingStream.Dispose(bool) not found.");
+
+        method.Invoke(stream, [disposing]);
+    }
 
     private sealed class CountingStream : MemoryStream
     {

--- a/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
@@ -457,7 +457,9 @@ DataType=0x0005
             File.WriteAllText(tempFile, content);
 
             // Act
-            var result = IniParser.ParseFile(tempFile, maxInputSize: content.Length);
+            var result = IniParser.ParseFile(
+                tempFile,
+                maxInputSize: System.Text.Encoding.UTF8.GetByteCount(content));
 
             // Assert
             result.Should().ContainKey("Section1");
@@ -479,7 +481,9 @@ DataType=0x0005
         {
             File.WriteAllText(tempFile, content);
 
-            var act = () => IniParser.ParseFile(tempFile, maxInputSize: content.Length - 1);
+            var act = () => IniParser.ParseFile(
+                tempFile,
+                maxInputSize: System.Text.Encoding.UTF8.GetByteCount(content) - 1);
 
             act.Should().Throw<EdsParseException>()
                 .WithMessage("*too large*");
@@ -554,7 +558,9 @@ DataType=0x0005
         {
             await File.WriteAllTextAsync(tempFile, content);
 
-            var result = await IniParser.ParseFileAsync(tempFile, maxInputSize: content.Length);
+            var result = await IniParser.ParseFileAsync(
+                tempFile,
+                maxInputSize: System.Text.Encoding.UTF8.GetByteCount(content));
 
             result.Should().ContainKey("Section1");
             result["Section1"]["Key1"].Should().Be("Value1");
@@ -575,7 +581,9 @@ DataType=0x0005
         {
             await File.WriteAllTextAsync(tempFile, content);
 
-            var act = () => IniParser.ParseFileAsync(tempFile, maxInputSize: content.Length - 1);
+            var act = () => IniParser.ParseFileAsync(
+                tempFile,
+                maxInputSize: System.Text.Encoding.UTF8.GetByteCount(content) - 1);
 
             await act.Should().ThrowAsync<EdsParseException>()
                 .WithMessage("*too large*");

--- a/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/IniParserTests.cs
@@ -445,6 +445,52 @@ DataType=0x0005
     }
 
     [Fact]
+    public void ParseFile_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        // Arrange — ASCII content so byte length == character count; FileInfo
+        // pre-check passes and ParseReader enforces the limit while streaming.
+        const string content = "[Section1]\nKey1=Value1\n";
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, content);
+
+            // Act
+            var result = IniParser.ParseFile(tempFile, maxInputSize: content.Length);
+
+            // Assert
+            result.Should().ContainKey("Section1");
+            result["Section1"]["Key1"].Should().Be("Value1");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ParseFile_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        const string content = "[Section1]\nKey1=Value1\n";
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, content);
+
+            var act = () => IniParser.ParseFile(tempFile, maxInputSize: content.Length - 1);
+
+            act.Should().Throw<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public async Task ParseFileAsync_ValidFile_ParsesCorrectly()
     {
         // Arrange
@@ -489,6 +535,48 @@ DataType=0x0005
             var act = () => IniParser.ParseFileAsync(tempFile, maxInputSize: 10);
 
             // Assert
+            await act.Should().ThrowAsync<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        const string content = "[Section1]\nKey1=Value1\n";
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, content);
+
+            var result = await IniParser.ParseFileAsync(tempFile, maxInputSize: content.Length);
+
+            result.Should().ContainKey("Section1");
+            result["Section1"]["Key1"].Should().Be("Value1");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        const string content = "[Section1]\nKey1=Value1\n";
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, content);
+
+            var act = () => IniParser.ParseFileAsync(tempFile, maxInputSize: content.Length - 1);
+
             await act.Should().ThrowAsync<EdsParseException>()
                 .WithMessage("*too large*");
         }

--- a/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
@@ -312,7 +312,7 @@ public class XdcReaderTests
         {
             File.WriteAllText(tempFile, MinimalXdc);
 
-            var result = _reader.ReadFile(tempFile, maxInputSize: MinimalXdc.Length);
+            var result = _reader.ReadFile(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdc));
 
             result.FileInfo.FileName.Should().Be("test.xdc");
         }
@@ -332,7 +332,7 @@ public class XdcReaderTests
         {
             File.WriteAllText(tempFile, MinimalXdc);
 
-            var act = () => _reader.ReadFile(tempFile, maxInputSize: MinimalXdc.Length - 1);
+            var act = () => _reader.ReadFile(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdc) - 1);
 
             act.Should().Throw<EdsParseException>()
                 .WithMessage("*too large*");
@@ -353,7 +353,7 @@ public class XdcReaderTests
         {
             await File.WriteAllTextAsync(tempFile, MinimalXdc);
 
-            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdc.Length);
+            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdc));
 
             result.FileInfo.FileName.Should().Be("test.xdc");
         }
@@ -373,7 +373,7 @@ public class XdcReaderTests
         {
             await File.WriteAllTextAsync(tempFile, MinimalXdc);
 
-            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdc.Length - 1);
+            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdc) - 1);
 
             await act.Should().ThrowAsync<EdsParseException>()
                 .WithMessage("*too large*");

--- a/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XdcReaderTests.cs
@@ -302,6 +302,90 @@ public class XdcReaderTests
     }
 
     [Fact]
+    public void ReadFile_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        // Arrange — FileInfo pre-check passes at exact size; bounded stream read
+        // enforces the character limit while loading.
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, MinimalXdc);
+
+            var result = _reader.ReadFile(tempFile, maxInputSize: MinimalXdc.Length);
+
+            result.FileInfo.FileName.Should().Be("test.xdc");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadFile_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, MinimalXdc);
+
+            var act = () => _reader.ReadFile(tempFile, maxInputSize: MinimalXdc.Length - 1);
+
+            act.Should().Throw<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, MinimalXdc);
+
+            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdc.Length);
+
+            result.FileInfo.FileName.Should().Be("test.xdc");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, MinimalXdc);
+
+            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdc.Length - 1);
+
+            await act.Should().ThrowAsync<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void ReadStream_ContentExceedsCustomMaximumSize_ThrowsEdsParseException()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(MinimalXdc));

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -273,7 +273,7 @@ public class XddReaderTests
         {
             File.WriteAllText(tempFile, MinimalXdd);
 
-            var result = _reader.ReadFile(tempFile, maxInputSize: MinimalXdd.Length);
+            var result = _reader.ReadFile(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdd));
 
             result.FileInfo.FileName.Should().Be("test.xdd");
         }
@@ -293,7 +293,7 @@ public class XddReaderTests
         {
             File.WriteAllText(tempFile, MinimalXdd);
 
-            var act = () => _reader.ReadFile(tempFile, maxInputSize: MinimalXdd.Length - 1);
+            var act = () => _reader.ReadFile(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdd) - 1);
 
             act.Should().Throw<EdsParseException>()
                 .WithMessage("*too large*");
@@ -314,7 +314,7 @@ public class XddReaderTests
         {
             await File.WriteAllTextAsync(tempFile, MinimalXdd);
 
-            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdd.Length);
+            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdd));
 
             result.FileInfo.FileName.Should().Be("test.xdd");
         }
@@ -334,7 +334,7 @@ public class XddReaderTests
         {
             await File.WriteAllTextAsync(tempFile, MinimalXdd);
 
-            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdd.Length - 1);
+            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: Encoding.UTF8.GetByteCount(MinimalXdd) - 1);
 
             await act.Should().ThrowAsync<EdsParseException>()
                 .WithMessage("*too large*");

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -263,6 +263,90 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void ReadFile_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        // Arrange — FileInfo pre-check passes at exact size; bounded stream read
+        // enforces the character limit while loading.
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, MinimalXdd);
+
+            var result = _reader.ReadFile(tempFile, maxInputSize: MinimalXdd.Length);
+
+            result.FileInfo.FileName.Should().Be("test.xdd");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadFile_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(tempFile, MinimalXdd);
+
+            var act = () => _reader.ReadFile(tempFile, maxInputSize: MinimalXdd.Length - 1);
+
+            act.Should().Throw<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_ContentAtExactMaxInputSize_ParsesSuccessfully()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, MinimalXdd);
+
+            var result = await _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdd.Length);
+
+            result.FileInfo.FileName.Should().Be("test.xdd");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_ContentOneOverMaxInputSize_ThrowsEdsParseException()
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, MinimalXdd);
+
+            var act = () => _reader.ReadFileAsync(tempFile, maxInputSize: MinimalXdd.Length - 1);
+
+            await act.Should().ThrowAsync<EdsParseException>()
+                .WithMessage("*too large*");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void ReadStream_ContentExceedsCustomMaximumSize_ThrowsEdsParseException()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(MinimalXdd));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #401.

File-based read paths validated size via `FileInfo.Length` then read unboundedly (`File.ReadLines` / `File.ReadAllText` / `TextFileIo.ReadAllTextAsync`). If the file grew between check and read, more memory could be allocated than `MaxInputSize` allows.

This routes the affected overloads through the existing bounded readers (same pattern as the async/stream paths), keeping the `FileInfo.Length` fast-fail:

- `IniParser.ParseFile` → `FileStream` + character-counting `ParseReader`
- `XddReader.ReadFile` / `ReadFileAsync` → `FileStream` + `SecureXmlParser.ReadContentFromStreamWithLimit(Async)`
- `XdcReader.ReadFile` / `ReadFileAsync` → same

Because the bounded readers count decoded characters while the file overloads document a byte limit, the opened `FileStream` is additionally wrapped in a new internal `ByteLimitingStream` that aborts once `MaxInputSize` bytes have been read (raised in review). Each read is clamped to one byte past the remaining allowance, so an oversized file is detected without buffering a full block beyond the limit. The async INI path gets the same treatment.

### Boundary & regression matrix

| Dimension | Cases covered | Test / reason skipped |
|---|---|---|
| Empty / missing input | existing FileNotFound tests | n/a for this change |
| Numeric / size boundaries | content exactly at and one over `MaxInputSize` per file overload; byte limit at, one over, multibyte under the character limit, and at most one byte over-read per call | `*_ContentAtExactMaxInputSize_*`, `*_ContentOneOverMaxInputSize_*`, `ByteLimitingStreamTests` |
| Round-trip fidelity | n/a | read-path hardening only |
| Validation modes | n/a | not write-path |
| Representative fixtures | minimal INI / MinimalXdd / MinimalXdc temp files | added |
| API contract assertions | no public signature changes | internal read path only |

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — Public API compatibility checklist completed

## Testing

- [x] `dotnet test --configuration Release` passes locally (1572 tests)
- [x] `dotnet build --configuration Release` passes locally

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785785101824639?thread_ts=1785785101.824639&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-d0158538-8b7f-5f53-bf66-a4b15b6a3ed9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0158538-8b7f-5f53-bf66-a4b15b6a3ed9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

