### PR TITLE
ci: verify semantic-release commit before relaying status (#402)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,11 @@ jobs:
   # HEAD is that new release commit — which is the SHA that actually needs the required
   # checks. If the branch HEAD equals head_sha, semantic-release did not publish a
   # release this run and there is nothing to relay.
+  #
+  # HEAD ≠ trigger SHA alone is not enough: another commit can land on the branch in
+  # the race window between the release push and this job resolving refs. Verify the
+  # resolved HEAD is actually the semantic-release commit (message, committer, and
+  # first parent == trigger SHA) before posting required checks.
   relay-release-status:
     if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
@@ -197,10 +202,34 @@ jobs:
         if [[ "$current_sha" == "$trigger_sha" ]]; then
           echo "Branch HEAD unchanged — semantic-release did not publish a release. Nothing to relay."
           echo "release_sha=" >> "$GITHUB_OUTPUT"
-        else
-          echo "Release commit detected: ${current_sha} (trigger was ${trigger_sha})"
-          echo "release_sha=${current_sha}" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
+
+        commit_json=$(gh api "repos/${{ github.repository }}/commits/${current_sha}")
+        message=$(jq -r '.commit.message' <<< "$commit_json")
+        committer=$(jq -r '.commit.committer.name' <<< "$commit_json")
+        parent_sha=$(jq -r '.parents[0].sha // empty' <<< "$commit_json")
+
+        if [[ "$message" != "chore(release):"* ]]; then
+          echo "HEAD ${current_sha} is not a chore(release) commit; nothing to relay."
+          echo "release_sha=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$committer" != "semantic-release-bot" ]]; then
+          echo "HEAD ${current_sha} committer is '${committer}', expected semantic-release-bot; nothing to relay."
+          echo "release_sha=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$parent_sha" != "$trigger_sha" ]]; then
+          echo "HEAD ${current_sha} parent is ${parent_sha}, expected trigger ${trigger_sha}; nothing to relay."
+          echo "release_sha=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "Release commit verified: ${current_sha} (trigger was ${trigger_sha})"
+        echo "release_sha=${current_sha}" >> "$GITHUB_OUTPUT"
 
     - name: Post build check run for release commit
       if: steps.resolve_sha.outputs.release_sha != ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #402.

The `relay-release-status` job in `.github/workflows/build.yml` previously treated any branch HEAD that differed from the Semantic Release trigger SHA as the release commit. If another commit landed on `develop`/`main` in that race window, it could receive a green required `build` check and `codecov/patch` status without having been built or tested.

This change verifies the resolved HEAD before posting those statuses:

- commit message starts with `chore(release):`
- committer is `semantic-release-bot`
- first parent SHA equals the workflow trigger SHA

If any check fails, the job exits without relaying.

## Type of change

- [x] CI / build (`ci:` / `build:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [ ] `dotnet test --configuration Release` passes locally
- [ ] `dotnet build --configuration Release` passes locally (required when public API or XML docs changed)

Workflow-only change; validated by inspecting recent release commits (`semantic-release-bot` / `chore(release): …`) and confirming the parent→trigger topology matches what the new guards assert.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785847776575899?thread_ts=1785847776.575899&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-ee819e22-9c09-5b03-941a-d1f3f0437332?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee819e22-9c09-5b03-941a-d1f3f0437332&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

