### PR TITLE
fix(npm-cli-stub): self-shim detection when install path has spaces

### DIFF
--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -4,6 +4,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
+/** Set while spawning the forwarded command so a re-entry fails fast. */
+const STUB_ACTIVE_ENV = "EDS_NPM_STUB_ACTIVE";
+
 function realpathOrNull(candidate) {
   try {
     return fs.realpathSync(candidate);
@@ -50,6 +53,66 @@ function candidateNames(command) {
   return [...exts.map((ext) => command + ext), command];
 }
 
+/**
+ * Extract .js path references from expanded shim text.
+ * Quoted paths and paths that start with the shim directory may contain spaces
+ * (common when the Windows user profile or checkout path has whitespace).
+ */
+function extractJsRefs(expanded, dir) {
+  const refs = [];
+  const seen = new Set();
+  const add = (ref) => {
+    if (!ref || seen.has(ref)) {
+      return;
+    }
+    seen.add(ref);
+    refs.push(ref);
+  };
+
+  // Quoted segments: "…npm.js" / '…npm.js'
+  const quotedRe = /(["'])([^"'<>|\r\n]*?\.js)\1/gi;
+  let match;
+  while ((match = quotedRe.exec(expanded)) !== null) {
+    add(match[2]);
+  }
+
+  // Unquoted refs anchored on the expanded shim directory (may contain spaces).
+  let from = 0;
+  while (from < expanded.length) {
+    const idx = expanded.indexOf(dir, from);
+    if (idx === -1) {
+      break;
+    }
+    const jsIdx = expanded.indexOf(".js", idx + dir.length);
+    if (jsIdx === -1) {
+      from = idx + 1;
+      continue;
+    }
+    const after = expanded[jsIdx + 3];
+    if (after && /[A-Za-z0-9_]/.test(after)) {
+      // e.g. ".json" — keep scanning
+      from = idx + 1;
+      continue;
+    }
+    const candidate = expanded.slice(idx, jsIdx + 3);
+    // Stop at shell/path delimiters that cannot appear in a file path ref.
+    if (/[\r\n"'<>|]/.test(candidate.slice(dir.length))) {
+      from = idx + 1;
+      continue;
+    }
+    add(candidate);
+    from = jsIdx + 3;
+  }
+
+  // Fallback: unquoted refs without whitespace (relative paths, no dir prefix).
+  const plain = expanded.match(/[^\s"'<>|]+\.js\b/g) || [];
+  for (const ref of plain) {
+    add(ref);
+  }
+
+  return refs;
+}
+
 // Windows cmd-shim / Git Bash wrappers are separate files (not symlinks) that
 // invoke node with a path to our bin script. Their realpath differs from the
 // .js entry, so detect them by resolving .js references in the shim text.
@@ -76,7 +139,7 @@ function shimTargetsSelf(candidatePath, selfRealpaths) {
     .replace(/%~dp0/gi, dir)
     .replace(/%dp0%/gi, dir)
     .replace(/\$basedir/g, dir);
-  const refs = expanded.match(/[^\s"'<>|]+\.js\b/g) || [];
+  const refs = extractJsRefs(expanded, dir);
   for (const ref of refs) {
     const resolved = realpathOrNull(path.resolve(dir, ref.replace(/\\/g, "/")));
     if (resolved && selfRealpaths.has(resolved)) {
@@ -112,6 +175,15 @@ function findExternalCommand(command, selfRealpaths) {
 }
 
 function forward(command, entryScriptPath = process.argv[1]) {
+  if (process.env[STUB_ACTIVE_ENV]) {
+    console.error(
+      `eds-npm-cli-stub: refused to re-enter while forwarding ${command} ` +
+        `(${STUB_ACTIVE_ENV} is set). Self-shim detection likely failed; ` +
+        `check that the install path is handled correctly.`
+    );
+    process.exit(1);
+  }
+
   const selfRealpaths = collectSelfRealpaths(entryScriptPath);
   const target = findExternalCommand(command, selfRealpaths);
 
@@ -124,9 +196,10 @@ function forward(command, entryScriptPath = process.argv[1]) {
   const shell =
     process.platform === "win32" && /\.(?:cmd|bat)$/i.test(target);
 
+  const env = { ...process.env, [STUB_ACTIVE_ENV]: "1" };
   const result = spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
-    env: process.env,
+    env,
     shell,
   });
 
@@ -138,4 +211,11 @@ function forward(command, entryScriptPath = process.argv[1]) {
   process.exit(result.status == null ? 1 : result.status);
 }
 
-module.exports = { forward };
+module.exports = {
+  forward,
+  extractJsRefs,
+  shimTargetsSelf,
+  collectSelfRealpaths,
+  findExternalCommand,
+  STUB_ACTIVE_ENV,
+};

--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -4,9 +4,6 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
-/** Set while spawning the forwarded command so a re-entry fails fast. */
-const STUB_ACTIVE_ENV = "EDS_NPM_STUB_ACTIVE";
-
 function realpathOrNull(candidate) {
   try {
     return fs.realpathSync(candidate);
@@ -175,15 +172,6 @@ function findExternalCommand(command, selfRealpaths) {
 }
 
 function forward(command, entryScriptPath = process.argv[1]) {
-  if (process.env[STUB_ACTIVE_ENV]) {
-    console.error(
-      `eds-npm-cli-stub: refused to re-enter while forwarding ${command} ` +
-        `(${STUB_ACTIVE_ENV} is set). Self-shim detection likely failed; ` +
-        `check that the install path is handled correctly.`
-    );
-    process.exit(1);
-  }
-
   const selfRealpaths = collectSelfRealpaths(entryScriptPath);
   const target = findExternalCommand(command, selfRealpaths);
 
@@ -196,10 +184,9 @@ function forward(command, entryScriptPath = process.argv[1]) {
   const shell =
     process.platform === "win32" && /\.(?:cmd|bat)$/i.test(target);
 
-  const env = { ...process.env, [STUB_ACTIVE_ENV]: "1" };
   const result = spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
-    env,
+    env: process.env,
     shell,
   });
 
@@ -217,5 +204,4 @@ module.exports = {
   shimTargetsSelf,
   collectSelfRealpaths,
   findExternalCommand,
-  STUB_ACTIVE_ENV,
 };

--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -4,6 +4,13 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
+/**
+ * Marker set on the forwarded child so an immediate self-shim re-entry fails
+ * fast. Nested npm/npx from lifecycle scripts inherit it too, so the guard
+ * must ignore those (see isImmediateReentry).
+ */
+const STUB_ACTIVE_ENV = "EDS_NPM_STUB_ACTIVE";
+
 function realpathOrNull(candidate) {
   try {
     return fs.realpathSync(candidate);
@@ -171,7 +178,31 @@ function findExternalCommand(command, selfRealpaths) {
   return null;
 }
 
+/**
+ * True only for immediate self-shim re-entry, not for nested npm/npx invoked
+ * from lifecycle scripts (which inherit EDS_NPM_STUB_ACTIVE from the forwarded
+ * real npm and also set npm_lifecycle_event / npm_command).
+ */
+function isImmediateReentry() {
+  if (!process.env[STUB_ACTIVE_ENV]) {
+    return false;
+  }
+  if (process.env.npm_lifecycle_event || process.env.npm_command) {
+    return false;
+  }
+  return true;
+}
+
 function forward(command, entryScriptPath = process.argv[1]) {
+  if (isImmediateReentry()) {
+    console.error(
+      `eds-npm-cli-stub: refused to re-enter while forwarding ${command} ` +
+        `(${STUB_ACTIVE_ENV} is set). Self-shim detection likely failed; ` +
+        `check that the install path is handled correctly.`
+    );
+    process.exit(1);
+  }
+
   const selfRealpaths = collectSelfRealpaths(entryScriptPath);
   const target = findExternalCommand(command, selfRealpaths);
 
@@ -184,9 +215,10 @@ function forward(command, entryScriptPath = process.argv[1]) {
   const shell =
     process.platform === "win32" && /\.(?:cmd|bat)$/i.test(target);
 
+  const env = { ...process.env, [STUB_ACTIVE_ENV]: "1" };
   const result = spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
-    env: process.env,
+    env,
     shell,
   });
 
@@ -204,4 +236,6 @@ module.exports = {
   shimTargetsSelf,
   collectSelfRealpaths,
   findExternalCommand,
+  isImmediateReentry,
+  STUB_ACTIVE_ENV,
 };

--- a/tools/npm-cli-stub/package.json
+++ b/tools/npm-cli-stub/package.json
@@ -6,5 +6,8 @@
   "bin": {
     "npm": "bin/npm.js",
     "npx": "bin/npx.js"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
   }
 }

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -1,0 +1,151 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const {
+  extractJsRefs,
+  shimTargetsSelf,
+  collectSelfRealpaths,
+  findExternalCommand,
+  STUB_ACTIVE_ENV,
+} = require("../lib/forward.js");
+
+describe("extractJsRefs", () => {
+  it("captures quoted .js paths that contain spaces", () => {
+    const dir = String.raw`C:\Users\John Doe\repo\node_modules\.bin`;
+    const expanded =
+      String.raw`"%_prog%"  "` + dir + String.raw`\..\eds-npm-cli-stub\bin\npm.js" %*`;
+    const refs = extractJsRefs(expanded, dir);
+    assert.ok(
+      refs.some((r) => r.includes("John Doe") && r.endsWith("npm.js")),
+      `expected spaced path in refs, got: ${JSON.stringify(refs)}`
+    );
+  });
+
+  it("captures unquoted dir-prefixed .js paths that contain spaces", () => {
+    const dir = "/Users/John Doe/repo/node_modules/.bin";
+    const expanded = `exec node ${dir}/../eds-npm-cli-stub/bin/npm.js "$@"`;
+    const refs = extractJsRefs(expanded, dir);
+    assert.ok(
+      refs.some((r) => r.includes("John Doe") && r.endsWith("npm.js")),
+      `expected spaced path in refs, got: ${JSON.stringify(refs)}`
+    );
+  });
+
+  it("still captures plain unquoted refs without spaces", () => {
+    const dir = "/repo/node_modules/.bin";
+    const expanded = 'exec node ../eds-npm-cli-stub/bin/npm.js "$@"';
+    const refs = extractJsRefs(expanded, dir);
+    assert.ok(refs.includes("../eds-npm-cli-stub/bin/npm.js"));
+  });
+
+  it("does not treat .json as a .js reference", () => {
+    const dir = "/repo/.bin";
+    const expanded = `${dir}/package.json and "${dir}/other.json"`;
+    const refs = extractJsRefs(expanded, dir);
+    assert.deepEqual(refs, []);
+  });
+});
+
+describe("shimTargetsSelf with spaced install path", () => {
+  let root;
+  let binDir;
+  let stubJs;
+  let selfRealpaths;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-stub spaced-"));
+    binDir = path.join(root, "node_modules", ".bin");
+    const stubPkg = path.join(root, "node_modules", "eds-npm-cli-stub", "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(stubPkg, { recursive: true });
+    stubJs = path.join(stubPkg, "npm.js");
+    fs.writeFileSync(stubJs, '#!/usr/bin/env node\nconsole.log("stub");\n');
+
+    // Mimic a Windows cmd-shim that points at our stub via %dp0%.
+    const cmdShim = `@ECHO off
+SETLOCAL
+SET dp0=%~dp0
+"%_prog%"  "%dp0%\\..\\eds-npm-cli-stub\\bin\\npm.js" %*
+`;
+    fs.writeFileSync(path.join(binDir, "npm.cmd"), cmdShim);
+
+    // Mimic a Git Bash shim that points at our stub via $basedir.
+    const bashShim = `#!/bin/sh
+basedir=$(dirname "$0")
+exec node  "$basedir/../eds-npm-cli-stub/bin/npm.js" "$@"
+`;
+    fs.writeFileSync(path.join(binDir, "npm"), bashShim);
+
+    selfRealpaths = new Set([fs.realpathSync(stubJs)]);
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("detects cmd-shim targeting self when path has spaces", () => {
+    const shim = path.join(binDir, "npm.cmd");
+    assert.equal(shimTargetsSelf(shim, selfRealpaths), true);
+  });
+
+  it("detects Git Bash shim targeting self when path has spaces", () => {
+    const shim = path.join(binDir, "npm");
+    assert.equal(shimTargetsSelf(shim, selfRealpaths), true);
+  });
+
+  it("does not treat an unrelated shim as self", () => {
+    const other = path.join(binDir, "other.cmd");
+    fs.writeFileSync(
+      other,
+      '@ECHO off\n"%_prog%"  "%dp0%\\..\\some-other-pkg\\bin\\cli.js" %*\n'
+    );
+    assert.equal(shimTargetsSelf(other, selfRealpaths), false);
+  });
+
+  it("skips self-shims when finding an external command", () => {
+    const externalDir = path.join(root, "external-bin");
+    fs.mkdirSync(externalDir, { recursive: true });
+    const external = path.join(externalDir, "npm");
+    fs.writeFileSync(external, "#!/bin/sh\necho external\n");
+    fs.chmodSync(external, 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = [binDir, externalDir].join(path.delimiter);
+    try {
+      const found = findExternalCommand("npm", selfRealpaths);
+      assert.equal(found, fs.realpathSync(external));
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+});
+
+describe("recursion guard", () => {
+  it("fails fast when EDS_NPM_STUB_ACTIVE is already set", () => {
+    const npmBin = path.join(__dirname, "..", "bin", "npm.js");
+    const result = spawnSync(process.execPath, [npmBin, "--version"], {
+      encoding: "utf8",
+      env: { ...process.env, [STUB_ACTIVE_ENV]: "1", PATH: process.env.PATH },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /refused to re-enter/);
+    assert.match(result.stderr, new RegExp(STUB_ACTIVE_ENV));
+  });
+});
+
+describe("collectSelfRealpaths", () => {
+  it("includes package bin entrypoints", () => {
+    const entry = path.join(__dirname, "..", "bin", "npm.js");
+    const self = collectSelfRealpaths(entry);
+    assert.ok(self.has(fs.realpathSync(entry)));
+    assert.ok(
+      self.has(fs.realpathSync(path.join(__dirname, "..", "bin", "npx.js")))
+    );
+  });
+});

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -5,12 +5,15 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 
 const {
   extractJsRefs,
   shimTargetsSelf,
   collectSelfRealpaths,
   findExternalCommand,
+  isImmediateReentry,
+  STUB_ACTIVE_ENV,
 } = require("../lib/forward.js");
 
 describe("extractJsRefs", () => {
@@ -120,6 +123,98 @@ exec node  "$basedir/../eds-npm-cli-stub/bin/npm.js" "$@"
       assert.equal(found, fs.realpathSync(external));
     } finally {
       process.env.PATH = prevPath;
+    }
+  });
+});
+
+describe("recursion guard", () => {
+  function withEnv(overrides, fn) {
+    const keys = Object.keys(overrides);
+    const previous = {};
+    for (const key of keys) {
+      previous[key] = process.env[key];
+      if (overrides[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = overrides[key];
+      }
+    }
+    try {
+      return fn();
+    } finally {
+      for (const key of keys) {
+        if (previous[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous[key];
+        }
+      }
+    }
+  }
+
+  it("treats bare EDS_NPM_STUB_ACTIVE as immediate re-entry", () => {
+    withEnv(
+      {
+        [STUB_ACTIVE_ENV]: "1",
+        npm_lifecycle_event: undefined,
+        npm_command: undefined,
+      },
+      () => {
+        assert.equal(isImmediateReentry(), true);
+      }
+    );
+  });
+
+  it("allows nested npm during lifecycle scripts despite the marker", () => {
+    withEnv(
+      {
+        [STUB_ACTIVE_ENV]: "1",
+        npm_lifecycle_event: "build",
+        npm_command: undefined,
+      },
+      () => {
+        assert.equal(isImmediateReentry(), false);
+      }
+    );
+  });
+
+  it("fails fast on immediate re-entry via bin entrypoint", () => {
+    const npmBin = path.join(__dirname, "..", "bin", "npm.js");
+    const env = { ...process.env, [STUB_ACTIVE_ENV]: "1", PATH: process.env.PATH };
+    delete env.npm_lifecycle_event;
+    delete env.npm_command;
+    const result = spawnSync(process.execPath, [npmBin, "--version"], {
+      encoding: "utf8",
+      env,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /refused to re-enter/);
+    assert.match(result.stderr, new RegExp(STUB_ACTIVE_ENV));
+  });
+
+  it("does not refuse re-entry when npm_command is set (nested npm)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-stub-nested-"));
+    try {
+      const externalDir = path.join(root, "bin");
+      fs.mkdirSync(externalDir, { recursive: true });
+      const external = path.join(externalDir, "npm");
+      fs.writeFileSync(external, "#!/bin/sh\necho nested-ok\n");
+      fs.chmodSync(external, 0o755);
+
+      const npmBin = path.join(__dirname, "..", "bin", "npm.js");
+      const result = spawnSync(process.execPath, [npmBin, "--version"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          [STUB_ACTIVE_ENV]: "1",
+          npm_command: "run-script",
+          PATH: externalDir,
+        },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /nested-ok/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -5,14 +5,12 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { spawnSync } = require("node:child_process");
 
 const {
   extractJsRefs,
   shimTargetsSelf,
   collectSelfRealpaths,
   findExternalCommand,
-  STUB_ACTIVE_ENV,
 } = require("../lib/forward.js");
 
 describe("extractJsRefs", () => {
@@ -123,19 +121,6 @@ exec node  "$basedir/../eds-npm-cli-stub/bin/npm.js" "$@"
     } finally {
       process.env.PATH = prevPath;
     }
-  });
-});
-
-describe("recursion guard", () => {
-  it("fails fast when EDS_NPM_STUB_ACTIVE is already set", () => {
-    const npmBin = path.join(__dirname, "..", "bin", "npm.js");
-    const result = spawnSync(process.execPath, [npmBin, "--version"], {
-      encoding: "utf8",
-      env: { ...process.env, [STUB_ACTIVE_ENV]: "1", PATH: process.env.PATH },
-    });
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /refused to re-enter/);
-    assert.match(result.stderr, new RegExp(STUB_ACTIVE_ENV));
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes Windows self-shim detection in `tools/npm-cli-stub` when the checkout or user directory contains spaces. Follow-up to the unresolved Codex review comment on #400 ([discussion](https://github.com/dborgards/eds-dcf-net/pull/400#discussion_r3696436481)).

Closes #403

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

Does this PR modify public members in `EdsDcfNet` (for example `CanOpenFile`,
format entry points, or models consumed by library callers)?

- [x] **No** public API changes
- [ ] **Yes** — I completed the
      [Public API compatibility checklist](https://github.com/dborgards/eds-dcf-net/blob/develop/CONTRIBUTING.md#public-api-compatibility-checklist)
      in `CONTRIBUTING.md`

## Summary of changes

- **Whitespace-tolerant `.js` extraction** in `shimTargetsSelf`: capture quoted segments first, then dir-anchored refs (may contain spaces), with the previous unquoted no-space pattern as fallback. Expanding `%dp0%` / `$basedir` under paths like `C:\Users\John Doe\…` no longer truncates at the first space, so local `node_modules/.bin` shims are skipped instead of re-entering the stub.
- **Scoped recursion guard**: set `EDS_NPM_STUB_ACTIVE=1` when spawning the forwarded command; fail fast only for *immediate* re-entry. Nested `npm`/`npx` from lifecycle scripts (where `npm_lifecycle_event` or `npm_command` is set) are allowed so legitimate nested invocations keep working.
- **Tests**: `tools/npm-cli-stub/test/forward.test.js` via `node --test` (quoted/spaced paths, cmd-shim + Git Bash fixtures, external PATH skip, immediate vs nested recursion guard).

## Testing

- [ ] `dotnet test --configuration Release` passes locally (N/A — no C# changes)
- [ ] `dotnet build --configuration Release` passes locally (N/A)
- [x] `npm test --prefix tools/npm-cli-stub` (13 tests pass)
- [ ] CI build/test on this PR

## Boundary & regression matrix

N/A — JavaScript tooling change only; no EDS/DCF parser, writer, validator, or converter changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785860426182909?thread_ts=1785860426.182909&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-c82a8069-6b2e-52f7-8718-4de39e91a096?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82a8069-6b2e-52f7-8718-4de39e91a096&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

