### PR TITLE
fix(npm-cli-stub): avoid unescaped shell argv on Windows .cmd targets

### DIFF
--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -218,7 +218,49 @@ function resolveNodeNearWrapper(wrapperDir) {
   } catch {
     // fall through
   }
-  return process.execPath;
+  // Match official npm.cmd / npx.cmd: when %~dp0\node.exe is absent, use
+  // PATH `node` — not the Node running this stub (which may differ).
+  return "node";
+}
+
+/**
+ * Mirror official npm.cmd / npx.cmd: run npm-prefix.js and, when a CLI exists
+ * under that prefix, prefer it over the bundled default path.
+ *
+ * @returns {string | null}
+ */
+function resolveCliViaNpmPrefix(nodeExe, prefixJs, preferName) {
+  try {
+    const result = spawnSync(nodeExe, [prefixJs], {
+      encoding: "utf8",
+      windowsHide: true,
+      shell: false,
+    });
+    if (result.error || result.status !== 0) {
+      return null;
+    }
+    const lines = String(result.stdout || "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const prefix = lines.length > 0 ? lines[lines.length - 1] : "";
+    if (!prefix) {
+      return null;
+    }
+    const candidate = path.join(
+      prefix,
+      "node_modules",
+      "npm",
+      "bin",
+      preferName
+    );
+    if (!fs.existsSync(candidate)) {
+      return null;
+    }
+    return realpathOrNull(candidate) || candidate;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -285,9 +327,17 @@ function resolveWinShellWrapper(target, command = "npm") {
     return null;
   }
 
+  const nodeExe = resolveNodeNearWrapper(dir);
+  const prefixJs = resolved.find(
+    (p) => path.basename(p).toLowerCase() === "npm-prefix.js"
+  );
+  const cli =
+    (prefixJs && resolveCliViaNpmPrefix(nodeExe, prefixJs, preferName)) ||
+    preferred;
+
   return {
-    command: resolveNodeNearWrapper(dir),
-    args: [preferred],
+    command: nodeExe,
+    args: [cli],
   };
 }
 

--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -364,11 +364,17 @@ function buildSpawnInvocation(target, forwardedArgs, command = "npm") {
 
   // Node rejects direct .cmd/.bat spawns without a shell (EINVAL / CVE-2024-27980).
   // Pre-escape every token because Node joins the array with spaces unescaped.
-  return {
-    file: escapeArgForCmd(target),
-    args: args.map(escapeArgForCmd),
-    shell: true,
-  };
+  // Only use cmd.exe escaping on Windows — elsewhere shell:true would invoke /bin/sh
+  // and the quoting would be wrong (e.g. an explicit path to a .cmd on Linux/macOS).
+  if (process.platform === "win32") {
+    return {
+      file: escapeArgForCmd(target),
+      args: args.map(escapeArgForCmd),
+      shell: true,
+    };
+  }
+
+  return { file: target, args, shell: false };
 }
 
 function forward(command, entryScriptPath = process.argv[1]) {

--- a/tools/npm-cli-stub/lib/forward.js
+++ b/tools/npm-cli-stub/lib/forward.js
@@ -193,6 +193,134 @@ function isImmediateReentry() {
   return true;
 }
 
+function isWinShellWrapper(target) {
+  return /\.(?:cmd|bat)$/i.test(target);
+}
+
+/**
+ * Escape one argv token for cmd.exe when Node will concatenate
+ * `file + ' ' + args.join(' ')` under `spawn({ shell: true })`.
+ *
+ * Double-quote the token, double embedded quotes, and neutralize `%` / `!`
+ * so env / delayed-expansion cannot rewrite the argument.
+ */
+function escapeArgForCmd(arg) {
+  const s = String(arg).replace(/%/g, "%%").replace(/!/g, "^!").replace(/"/g, '""');
+  return `"${s}"`;
+}
+
+function resolveNodeNearWrapper(wrapperDir) {
+  const sibling = path.join(wrapperDir, "node.exe");
+  try {
+    if (fs.existsSync(sibling)) {
+      return sibling;
+    }
+  } catch {
+    // fall through
+  }
+  return process.execPath;
+}
+
+/**
+ * Unwrap a Windows .cmd/.bat shim to `node <cli.js>` so we can spawn with
+ * `shell: false` and an intact argv array (avoids cmd metacharacter injection
+ * and space-splitting from Node's unescaped shell join).
+ *
+ * @returns {{ command: string, args: string[] } | null}
+ */
+function resolveWinShellWrapper(target, command = "npm") {
+  if (!isWinShellWrapper(target)) {
+    return null;
+  }
+
+  let content;
+  try {
+    const st = fs.statSync(target);
+    if (!st.isFile() || st.size > 65536) {
+      return null;
+    }
+    content = fs.readFileSync(target, "utf8");
+  } catch {
+    return null;
+  }
+  if (content.includes("\0")) {
+    return null;
+  }
+
+  const dir = path.dirname(target);
+  // %~dp0 includes a trailing separator; keep that so concatenated relative
+  // segments in official Node/npm wrappers resolve correctly.
+  const dp0 = dir.endsWith("\\") || dir.endsWith("/") ? dir : dir + path.sep;
+  const expanded = content
+    .replace(/%~dp0/gi, dp0)
+    .replace(/%dp0%/gi, dp0)
+    .replace(/\$basedir/g, dir);
+
+  const refs = extractJsRefs(expanded, dir);
+  const resolved = [];
+  const seen = new Set();
+  for (const ref of refs) {
+    const real = realpathOrNull(path.resolve(dir, ref.replace(/\\/g, "/")));
+    if (!real || seen.has(real) || !real.toLowerCase().endsWith(".js")) {
+      continue;
+    }
+    seen.add(real);
+    resolved.push(real);
+  }
+  if (resolved.length === 0) {
+    return null;
+  }
+
+  const preferName =
+    String(command).toLowerCase() === "npx" ? "npx-cli.js" : "npm-cli.js";
+  const preferred =
+    resolved.find((p) => path.basename(p).toLowerCase() === preferName) ||
+    resolved.find((p) => {
+      const base = path.basename(p).toLowerCase();
+      return base.endsWith("-cli.js") && !base.includes("prefix");
+    }) ||
+    resolved.find((p) => !path.basename(p).toLowerCase().includes("prefix"));
+
+  if (!preferred) {
+    return null;
+  }
+
+  return {
+    command: resolveNodeNearWrapper(dir),
+    args: [preferred],
+  };
+}
+
+/**
+ * Build the spawnSync file/args/shell triple for forwarding.
+ * Prefer unwrapping .cmd/.bat to node+js; fall back to shell:true with
+ * cmd-escaped arguments when unwrapping is not possible.
+ */
+function buildSpawnInvocation(target, forwardedArgs, command = "npm") {
+  const args = forwardedArgs.map(String);
+
+  if (!isWinShellWrapper(target)) {
+    return { file: target, args, shell: false };
+  }
+
+  const unwrapped = resolveWinShellWrapper(target, command);
+  if (unwrapped) {
+    return {
+      file: unwrapped.command,
+      args: [...unwrapped.args, ...args],
+      shell: false,
+    };
+  }
+
+  // Node rejects direct .cmd/.bat spawns without a shell (EINVAL / CVE-2024-27980).
+  // Pre-escape every token because Node joins the array with spaces unescaped.
+  return {
+    file: escapeArgForCmd(target),
+    args: args.map(escapeArgForCmd),
+    shell: true,
+  };
+}
+
 function forward(command, entryScriptPath = process.argv[1]) {
   if (isImmediateReentry()) {
     console.error(
@@ -211,15 +339,12 @@ function forward(command, entryScriptPath = process.argv[1]) {
     process.exit(1);
   }
 
-  // Node rejects direct .cmd/.bat spawns without a shell (EINVAL / CVE-2024-27980).
-  const shell =
-    process.platform === "win32" && /\.(?:cmd|bat)$/i.test(target);
-
+  const invocation = buildSpawnInvocation(target, process.argv.slice(2), command);
   const env = { ...process.env, [STUB_ACTIVE_ENV]: "1" };
-  const result = spawnSync(target, process.argv.slice(2), {
+  const result = spawnSync(invocation.file, invocation.args, {
     stdio: "inherit",
     env,
-    shell,
+    shell: invocation.shell,
   });
 
   if (result.error) {
@@ -237,5 +362,8 @@ module.exports = {
   collectSelfRealpaths,
   findExternalCommand,
   isImmediateReentry,
+  escapeArgForCmd,
+  resolveWinShellWrapper,
+  buildSpawnInvocation,
   STUB_ACTIVE_ENV,
 };

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -397,15 +397,44 @@ SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
     assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npxCli));
   });
 
-  it("falls back to shell:true with escaped args when unwrap is impossible", () => {
+  it("falls back to shell:true with escaped args on Windows when unwrap fails", () => {
     const opaque = path.join(root, "opaque.cmd");
     fs.writeFileSync(opaque, "@ECHO OFF\necho no js here\n");
 
     const args = ["run", "foo", "--", "a b", "x&y", "%PATH%"];
-    const invocation = buildSpawnInvocation(opaque, args, "npm");
-    assert.equal(invocation.shell, true);
-    assert.equal(invocation.file, escapeArgForCmd(opaque));
-    assert.deepEqual(invocation.args, args.map(escapeArgForCmd));
+    const original = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "win32",
+    });
+    try {
+      const invocation = buildSpawnInvocation(opaque, args, "npm");
+      assert.equal(invocation.shell, true);
+      assert.equal(invocation.file, escapeArgForCmd(opaque));
+      assert.deepEqual(invocation.args, args.map(escapeArgForCmd));
+    } finally {
+      Object.defineProperty(process, "platform", original);
+    }
+  });
+
+  it("does not use cmd shell fallback when unwrap fails off Windows", () => {
+    const opaque = path.join(root, "opaque-posix.cmd");
+    fs.writeFileSync(opaque, "@ECHO OFF\necho no js here\n");
+
+    const args = ["run", "foo", "--", "a b", "x&y"];
+    const original = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "linux",
+    });
+    try {
+      const invocation = buildSpawnInvocation(opaque, args, "npm");
+      assert.equal(invocation.shell, false);
+      assert.equal(invocation.file, opaque);
+      assert.deepEqual(invocation.args, args);
+    } finally {
+      Object.defineProperty(process, "platform", original);
+    }
   });
 
   it("keeps shell:false for non-wrapper targets", () => {

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -13,6 +13,9 @@ const {
   collectSelfRealpaths,
   findExternalCommand,
   isImmediateReentry,
+  escapeArgForCmd,
+  resolveWinShellWrapper,
+  buildSpawnInvocation,
   STUB_ACTIVE_ENV,
 } = require("../lib/forward.js");
 
@@ -227,5 +230,145 @@ describe("collectSelfRealpaths", () => {
     assert.ok(
       self.has(fs.realpathSync(path.join(__dirname, "..", "bin", "npx.js")))
     );
+  });
+});
+
+describe("escapeArgForCmd", () => {
+  it("wraps arguments in double quotes", () => {
+    assert.equal(escapeArgForCmd("a b"), '"a b"');
+  });
+
+  it("doubles embedded quotes and neutralizes % and !", () => {
+    assert.equal(escapeArgForCmd('x"y'), '"x""y"');
+    assert.equal(escapeArgForCmd("x%PATH%y"), '"x%%PATH%%y"');
+    assert.equal(escapeArgForCmd("a!b"), '"a^!b"');
+  });
+
+  it("preserves shell metacharacters inside the quoted token", () => {
+    assert.equal(escapeArgForCmd("x&y"), '"x&y"');
+    assert.equal(escapeArgForCmd("a|b>c"), '"a|b>c"');
+  });
+});
+
+describe("resolveWinShellWrapper / buildSpawnInvocation", () => {
+  let root;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-stub-unwrap-"));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("unwraps an official-style npm.cmd to node + npm-cli.js without a shell", () => {
+    const prefix = path.join(root, "Program Files", "nodejs");
+    const npmBin = path.join(prefix, "node_modules", "npm", "bin");
+    fs.mkdirSync(npmBin, { recursive: true });
+    const npmCli = path.join(npmBin, "npm-cli.js");
+    const npmPrefix = path.join(npmBin, "npm-prefix.js");
+    fs.writeFileSync(npmCli, "#!/usr/bin/env node\n");
+    fs.writeFileSync(npmPrefix, "#!/usr/bin/env node\n");
+
+    const npmCmd = path.join(prefix, "npm.cmd");
+    fs.writeFileSync(
+      npmCmd,
+      `@ECHO OFF
+SETLOCAL
+SET "NODE_EXE=%~dp0\\node.exe"
+SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"
+SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
+"%NODE_EXE%" "%NPM_CLI_JS%" %*
+`
+    );
+
+    const unwrapped = resolveWinShellWrapper(npmCmd, "npm");
+    assert.ok(unwrapped, "expected unwrap to succeed");
+    assert.equal(unwrapped.args.length, 1);
+    assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npmCli));
+
+    const spaced = ["run", "foo", "--", "a b", "x&y"];
+    const invocation = buildSpawnInvocation(npmCmd, spaced, "npm");
+    assert.equal(invocation.shell, false);
+    assert.deepEqual(invocation.args.slice(-spaced.length), spaced);
+    assert.equal(
+      fs.realpathSync(invocation.args[0]),
+      fs.realpathSync(npmCli)
+    );
+  });
+
+  it("prefers npx-cli.js when forwarding npx", () => {
+    const prefix = path.join(root, "npx-prefix");
+    const npmBin = path.join(prefix, "node_modules", "npm", "bin");
+    fs.mkdirSync(npmBin, { recursive: true });
+    const npxCli = path.join(npmBin, "npx-cli.js");
+    const npmCli = path.join(npmBin, "npm-cli.js");
+    fs.writeFileSync(npxCli, "#!/usr/bin/env node\n");
+    fs.writeFileSync(npmCli, "#!/usr/bin/env node\n");
+
+    const npxCmd = path.join(prefix, "npx.cmd");
+    fs.writeFileSync(
+      npxCmd,
+      `@ECHO OFF
+SET "NPX_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npx-cli.js"
+SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
+"%_prog%" "%NPX_CLI_JS%" %*
+`
+    );
+
+    const unwrapped = resolveWinShellWrapper(npxCmd, "npx");
+    assert.ok(unwrapped);
+    assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npxCli));
+  });
+
+  it("falls back to shell:true with escaped args when unwrap is impossible", () => {
+    const opaque = path.join(root, "opaque.cmd");
+    fs.writeFileSync(opaque, "@ECHO OFF\necho no js here\n");
+
+    const args = ["run", "foo", "--", "a b", "x&y", "%PATH%"];
+    const invocation = buildSpawnInvocation(opaque, args, "npm");
+    assert.equal(invocation.shell, true);
+    assert.equal(invocation.file, escapeArgForCmd(opaque));
+    assert.deepEqual(invocation.args, args.map(escapeArgForCmd));
+  });
+
+  it("keeps shell:false for non-wrapper targets", () => {
+    const unix = path.join(root, "npm");
+    fs.writeFileSync(unix, "#!/bin/sh\n");
+    const invocation = buildSpawnInvocation(unix, ["install", "a b"], "npm");
+    assert.equal(invocation.shell, false);
+    assert.equal(invocation.file, unix);
+    assert.deepEqual(invocation.args, ["install", "a b"]);
+  });
+
+  it("forwards spaced and metacharacter args intact via unwrapped spawn", () => {
+    const prefix = path.join(root, "echo-cli");
+    const bin = path.join(prefix, "bin");
+    fs.mkdirSync(bin, { recursive: true });
+    const cliJs = path.join(bin, "npm-cli.js");
+    // Print argv JSON so we can assert exact tokens after spawn.
+    fs.writeFileSync(
+      cliJs,
+      `#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)));
+`
+    );
+    const npmCmd = path.join(prefix, "npm.cmd");
+    fs.writeFileSync(
+      npmCmd,
+      `@ECHO OFF
+node "%~dp0\\bin\\npm-cli.js" %*
+`
+    );
+
+    const forwarded = ["run", "foo", "--", "a b", "x&y"];
+    const invocation = buildSpawnInvocation(npmCmd, forwarded, "npm");
+    assert.equal(invocation.shell, false);
+
+    const result = spawnSync(invocation.file, invocation.args, {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), forwarded);
   });
 });

--- a/tools/npm-cli-stub/test/forward.test.js
+++ b/tools/npm-cli-stub/test/forward.test.js
@@ -268,6 +268,7 @@ describe("resolveWinShellWrapper / buildSpawnInvocation", () => {
     const npmCli = path.join(npmBin, "npm-cli.js");
     const npmPrefix = path.join(npmBin, "npm-prefix.js");
     fs.writeFileSync(npmCli, "#!/usr/bin/env node\n");
+    // Empty stdout → keep bundled CLI (same as IF EXIST failing in the batch).
     fs.writeFileSync(npmPrefix, "#!/usr/bin/env node\n");
 
     const npmCmd = path.join(prefix, "npm.cmd");
@@ -276,6 +277,63 @@ describe("resolveWinShellWrapper / buildSpawnInvocation", () => {
       `@ECHO OFF
 SETLOCAL
 SET "NODE_EXE=%~dp0\\node.exe"
+IF NOT EXIST "%NODE_EXE%" (
+  SET "NODE_EXE=node"
+)
+SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"
+SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"') DO (
+  SET "NPM_PREFIX_NPM_CLI_JS=%%F\\node_modules\\npm\\bin\\npm-cli.js"
+)
+IF EXIST "%NPM_PREFIX_NPM_CLI_JS%" (
+  SET "NPM_CLI_JS=%NPM_PREFIX_NPM_CLI_JS%"
+)
+"%NODE_EXE%" "%NPM_CLI_JS%" %*
+`
+    );
+
+    const unwrapped = resolveWinShellWrapper(npmCmd, "npm");
+    assert.ok(unwrapped, "expected unwrap to succeed");
+    assert.equal(unwrapped.command, "node");
+    assert.equal(unwrapped.args.length, 1);
+    assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npmCli));
+
+    const spaced = ["run", "foo", "--", "a b", "x&y"];
+    const invocation = buildSpawnInvocation(npmCmd, spaced, "npm");
+    assert.equal(invocation.shell, false);
+    assert.equal(invocation.file, "node");
+    assert.deepEqual(invocation.args.slice(-spaced.length), spaced);
+    assert.equal(
+      fs.realpathSync(invocation.args[0]),
+      fs.realpathSync(npmCli)
+    );
+  });
+
+  it("applies npm-prefix.js override when that CLI exists", () => {
+    const bundled = path.join(root, "bundled-node");
+    const npmBin = path.join(bundled, "node_modules", "npm", "bin");
+    fs.mkdirSync(npmBin, { recursive: true });
+    const bundledCli = path.join(npmBin, "npm-cli.js");
+    const npmPrefix = path.join(npmBin, "npm-prefix.js");
+    fs.writeFileSync(bundledCli, "#!/usr/bin/env node\n");
+
+    const upgraded = path.join(root, "upgraded-prefix");
+    const upgradedBin = path.join(upgraded, "node_modules", "npm", "bin");
+    fs.mkdirSync(upgradedBin, { recursive: true });
+    const upgradedCli = path.join(upgradedBin, "npm-cli.js");
+    fs.writeFileSync(upgradedCli, "#!/usr/bin/env node\n");
+
+    fs.writeFileSync(
+      npmPrefix,
+      `#!/usr/bin/env node
+process.stdout.write(${JSON.stringify(upgraded)});
+`
+    );
+
+    const npmCmd = path.join(bundled, "npm.cmd");
+    fs.writeFileSync(
+      npmCmd,
+      `@ECHO OFF
 SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"
 SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
 "%NODE_EXE%" "%NPM_CLI_JS%" %*
@@ -283,18 +341,36 @@ SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
     );
 
     const unwrapped = resolveWinShellWrapper(npmCmd, "npm");
-    assert.ok(unwrapped, "expected unwrap to succeed");
-    assert.equal(unwrapped.args.length, 1);
-    assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npmCli));
-
-    const spaced = ["run", "foo", "--", "a b", "x&y"];
-    const invocation = buildSpawnInvocation(npmCmd, spaced, "npm");
-    assert.equal(invocation.shell, false);
-    assert.deepEqual(invocation.args.slice(-spaced.length), spaced);
+    assert.ok(unwrapped);
+    assert.equal(unwrapped.command, "node");
     assert.equal(
-      fs.realpathSync(invocation.args[0]),
-      fs.realpathSync(npmCli)
+      fs.realpathSync(unwrapped.args[0]),
+      fs.realpathSync(upgradedCli)
     );
+  });
+
+  it("uses sibling node.exe when present beside the wrapper", () => {
+    const prefix = path.join(root, "with-sibling-node");
+    const npmBin = path.join(prefix, "node_modules", "npm", "bin");
+    fs.mkdirSync(npmBin, { recursive: true });
+    const npmCli = path.join(npmBin, "npm-cli.js");
+    fs.writeFileSync(npmCli, "#!/usr/bin/env node\n");
+    const sibling = path.join(prefix, "node.exe");
+    fs.writeFileSync(sibling, "not-a-real-exe\n");
+
+    const npmCmd = path.join(prefix, "npm.cmd");
+    fs.writeFileSync(
+      npmCmd,
+      `@ECHO OFF
+SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"
+"%NODE_EXE%" "%NPM_CLI_JS%" %*
+`
+    );
+
+    const unwrapped = resolveWinShellWrapper(npmCmd, "npm");
+    assert.ok(unwrapped);
+    assert.equal(unwrapped.command, sibling);
+    assert.equal(fs.realpathSync(unwrapped.args[0]), fs.realpathSync(npmCli));
   });
 
   it("prefers npx-cli.js when forwarding npx", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes Windows forwarding in `tools/npm-cli-stub` when the resolved target is a `.cmd`/`.bat` wrapper.

Previously `spawnSync` used `shell: true` and passed the raw argv array. Node concatenates that array **without escaping**, so:

1. Arguments containing spaces were split incorrectly
2. Shell metacharacters (`&`, `|`, `%`, …) could be interpreted by `cmd.exe`

**Fix:** unwrap standard npm/npx `.cmd` wrappers to a direct `node <*-cli.js>` invocation with `shell: false` (intact argv). If unwrap is impossible, fall back to `shell: true` with each argument escaped for `cmd.exe`.

Closes #404

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] `npm test` in `tools/npm-cli-stub` (21 tests, including spaced/`x&y` argv regression via unwrapped spawn)
- [ ] `dotnet test --configuration Release` passes locally (N/A — JS-only change)
- [ ] `dotnet build --configuration Release` passes locally (N/A)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785865558542089?thread_ts=1785865558.542089&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-ef466cd0-7923-58ab-9e42-ad7e72380eba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef466cd0-7923-58ab-9e42-ad7e72380eba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

