### PR TITLE
fix(parsers): synthesize CompactSubObj sub-objects from parent template

### DIFF
--- a/docs/architecture/12-glossary.md
+++ b/docs/architecture/12-glossary.md
@@ -30,7 +30,7 @@
 | **RECORD**                    | Object Dictionary object type (0x09) for a structure with heterogeneous sub-objects.              |
 | **INI format**                | Simple text format with sections (`[Section]`) and key-value pairs (`Key=Value`). Basis for EDS/DCF files. |
 | **$NODEID formula**           | Expression in DCF files (e.g., `$NODEID+0x600`) evaluated relative to the device's node ID.      |
-| **CompactSubObj**             | Compact representation of sub-objects where not every sub-object needs to be defined individually. |
+| **CompactSubObj**             | Compact array storage (CiA 306 §4.5.2.4.2): parent object is the template for sub-indexes `0..N`; individual `[xxxsubN]` sections are optional. Values/denotations/names use `[xxxxValue]`, `[xxxxDenotation]`, `[xxxxName]`. |
 | **CompactPDO**                | Compact storage of PDO value and denotation information in dedicated sections.                    |
 | **Round-trip fidelity**       | Property that a file does not lose information after being read and written back unchanged.        |
 | **Semantic Versioning (SemVer)** | Versioning scheme with the format `MAJOR.MINOR.PATCH` that communicates the nature of changes. |

--- a/src/EdsDcfNet/Models/ObjectDictionary.cs
+++ b/src/EdsDcfNet/Models/ObjectDictionary.cs
@@ -106,7 +106,10 @@ public class CanOpenObject
     public Dictionary<byte, CanOpenSubObject> SubObjects { get; } = new();
 
     /// <summary>
-    /// For compact sub-object storage: number of sub-indexes with equal description.
+    /// For compact sub-object storage (CiA 306 §4.5.2.4.2): highest sub-index described
+    /// by the parent object template. When non-zero, missing <c>[xxxsubN]</c> sections are
+    /// synthesized from this object; ParameterValues/Denotations use <c>[xxxxValue]</c> /
+    /// <c>[xxxxDenotation]</c> (DCF) and optional names use <c>[xxxxName]</c>.
     /// </summary>
     public byte? CompactSubObj { get; set; }
 

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -393,7 +393,7 @@ public abstract class CanOpenReaderBase
             if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
                 continue;
 
-            if (subIndex < 1)
+            if (subIndex < 1 || subIndex > MaxCompactListableSubIndex)
                 continue;
 
             if (obj.SubObjects.TryGetValue(subIndex, out var subObj))
@@ -410,7 +410,7 @@ public abstract class CanOpenReaderBase
     /// Highest sub-index covered by CompactSubObj value/name/denotation lists (CiA 306).
     /// Sub-index <c>0xFF</c> is reserved and is never synthesized from the template.
     /// </summary>
-    private const int MaxCompactListableSubIndex = 254;
+    private protected const int MaxCompactListableSubIndex = 254;
 
     /// <summary>
     /// Parses a single sub-object at the given <paramref name="index"/> and <paramref name="subIndex"/>.

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -93,23 +93,18 @@ public abstract class CanOpenReaderBase
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="sectionName"/> is a
     /// <c>[xxxxName]</c> section for an object that uses CompactSubObj storage
-    /// (and was therefore consumed by <see cref="ApplyCompactNameOverrides"/>).
+    /// (and was therefore consumed by <see cref="ApplyCompactListSection"/>).
     /// Orphan name sections remain in <c>AdditionalSections</c> for round-trip.
     /// </summary>
     private protected static bool IsCompactNameSectionForExistingObject(
         string sectionName,
         ObjectDictionary objectDictionary)
     {
-        if (!IsHexPrefixedSection(sectionName, "Name"))
-            return false;
-
-        var prefix = sectionName[..^"Name".Length];
-        if (!ushort.TryParse(prefix, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
+        if (!TryParseHexPrefixedSection(sectionName, NameSectionSuffix, out var index))
             return false;
 
         return objectDictionary.Objects.TryGetValue(index, out var obj)
-               && obj.CompactSubObj.HasValue
-               && obj.CompactSubObj.Value > 0;
+               && obj.CompactSubObj.GetValueOrDefault() > 0;
     }
 
     /// <summary>
@@ -330,7 +325,13 @@ public abstract class CanOpenReaderBase
 
         if (compactMax > 0)
         {
-            ApplyCompactNameOverrides(sections, index, obj);
+            // Optional [xxxxName] parameter-name overrides (CiA 306 §4.5.2.4.2).
+            ApplyCompactListSection(
+                sections,
+                index,
+                NameSectionSuffix,
+                obj,
+                static (subObj, name) => subObj.ParameterName = name);
         }
     }
 
@@ -369,57 +370,70 @@ public abstract class CanOpenReaderBase
     }
 
     /// <summary>
-    /// Applies optional <c>[xxxxName]</c> parameter-name overrides for compact sub-objects
-    /// (CiA 306 §4.5.2.4.2). Keys are decimal sub-indexes (1..254) and may be sparse;
-    /// <c>NrOfEntries</c> is the list length, not a loop bound.
+    /// Applies a compact sub-object list section — <c>[xxxxName]</c> (CiA 306 §4.5.2.4.2)
+    /// and, for DCF, <c>[xxxxValue]</c> / <c>[xxxxDenotation]</c> (CiA 306 §5.2.3.2) — to the
+    /// sub-objects of <paramref name="obj"/> via <paramref name="apply"/>.
+    /// Keys are decimal sub-indexes (1..254) and may be sparse: <c>NrOfEntries</c> is the list
+    /// length, not a loop bound, but a present value is still validated (throws on malformed).
+    /// Entries with an empty value, a non-numeric key, a key outside 1..254, or a key without a
+    /// matching sub-object are ignored.
     /// </summary>
-    private static void ApplyCompactNameOverrides(
+    private protected static void ApplyCompactListSection(
         Dictionary<string, Dictionary<string, string>> sections,
         ushort index,
-        CanOpenObject obj)
+        string sectionSuffix,
+        CanOpenObject obj,
+        Action<CanOpenSubObject, string> apply)
     {
-        var nameSection = string.Concat(ToHexInvariant(index), "Name");
-        if (!IniParser.HasSection(sections, nameSection))
+        var sectionName = string.Concat(ToHexInvariant(index), sectionSuffix);
+        if (!sections.TryGetValue(sectionName, out var section))
             return;
 
-        var section = sections[nameSection];
-        foreach (var key in section.Keys)
+        // Validate even when not used as a loop bound (preserves prior ParseUInt16 failure mode).
+        if (section.TryGetValue(NrOfEntriesKey, out var nrOfEntries))
         {
-            if (!key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
-                continue;
-            _ = ValueConverter.ParseUInt16(section[key]);
-            break;
+            _ = ValueConverter.ParseUInt16(nrOfEntries);
         }
 
         foreach (var entry in section)
         {
-            if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
+            // Rejects NrOfEntries and any other non sub-index key.
+            if (!TryParseCompactListSubIndex(entry.Key, out var subIndex))
                 continue;
 
             if (string.IsNullOrEmpty(entry.Value))
                 continue;
 
-            if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
-                continue;
-
-            if (subIndex < 1 || subIndex > MaxCompactListableSubIndex)
-                continue;
-
             if (obj.SubObjects.TryGetValue(subIndex, out var subObj))
             {
-                subObj.ParameterName = entry.Value;
+                apply(subObj, entry.Value);
             }
         }
     }
 
+    /// <summary>
+    /// Parses a compact list key as a decimal sub-index in the CiA 306 range 1..254.
+    /// Reserved sub-index <c>0xFF</c> and non-numeric keys are rejected.
+    /// </summary>
+    private static bool TryParseCompactListSubIndex(string key, out byte subIndex)
+        => byte.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out subIndex)
+           && subIndex >= 1
+           && subIndex <= MaxCompactListableSubIndex;
+
     /// <summary>CiA 301 / CiA 306 UNSIGNED8 data-type index.</summary>
     private const ushort Unsigned8DataType = 0x0005;
+
+    /// <summary>Section-name suffix of the optional compact parameter-name list.</summary>
+    private const string NameSectionSuffix = "Name";
+
+    /// <summary>Entry-count key shared by all compact list sections.</summary>
+    private const string NrOfEntriesKey = "NrOfEntries";
 
     /// <summary>
     /// Highest sub-index covered by CompactSubObj value/name/denotation lists (CiA 306).
     /// Sub-index <c>0xFF</c> is reserved and is never synthesized from the template.
     /// </summary>
-    private protected const int MaxCompactListableSubIndex = 254;
+    private const int MaxCompactListableSubIndex = 254;
 
     /// <summary>
     /// Parses a single sub-object at the given <paramref name="index"/> and <paramref name="subIndex"/>.
@@ -509,14 +523,22 @@ public abstract class CanOpenReaderBase
     /// Checks if a section name has a valid hex object index prefix followed by the given suffix.
     /// </summary>
     protected static bool IsHexPrefixedSection(string sectionName, string suffix)
+        => TryParseHexPrefixedSection(sectionName, suffix, out _);
+
+    /// <summary>
+    /// Parses a section name of the form <c>{hex object index}{suffix}</c> (for example
+    /// <c>1018Name</c>) and returns the object index. Returns <see langword="false"/> when
+    /// the suffix does not match or the prefix is not a hexadecimal object index.
+    /// </summary>
+    private protected static bool TryParseHexPrefixedSection(string sectionName, string suffix, out ushort index)
     {
+        index = 0;
+
         if (!sectionName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
             return false;
 
         var prefix = sectionName[..^suffix.Length];
-        return prefix.Length > 0 && ushort.TryParse(prefix,
-            NumberStyles.HexNumber,
-            CultureInfo.InvariantCulture, out _);
+        return ushort.TryParse(prefix, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out index);
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -293,7 +293,9 @@ public abstract class CanOpenReaderBase
     /// <see cref="CanOpenObject.SubObjects"/>.
     /// When <see cref="CanOpenObject.CompactSubObj"/> is non-zero, missing
     /// <c>[xxxsubN]</c> sections are synthesized from the parent object template
-    /// per CiA 306 §4.5.2.4.2, then optional <c>[xxxxName]</c> overrides are applied.
+    /// per CiA 306 §4.5.2.4.2 (sub-indexes <c>0..min(CompactSubObj, 254)</c>;
+    /// sub-index <c>0xFF</c> is never synthesized), then optional <c>[xxxxName]</c>
+    /// overrides are applied.
     /// Derived classes may override this to handle additional compact storage formats.
     /// </summary>
     protected virtual void ParseSubObjects(Dictionary<string, Dictionary<string, string>> sections, ushort index, CanOpenObject obj)
@@ -301,9 +303,13 @@ public abstract class CanOpenReaderBase
         // Determine the number of sub-objects to parse
         var maxSubIndex = (int)(obj.SubNumber ?? 0);
         var compactSubObj = obj.CompactSubObj.GetValueOrDefault();
-        if (compactSubObj > 0)
+        // CiA 306 compact lists use sub-indexes 1..254; never synthesize 0xFF.
+        var compactMax = compactSubObj == 0
+            ? 0
+            : Math.Min((int)compactSubObj, MaxCompactListableSubIndex);
+        if (compactMax > 0)
         {
-            maxSubIndex = Math.Max(maxSubIndex, compactSubObj);
+            maxSubIndex = Math.Max(maxSubIndex, compactMax);
         }
 
         // Use an int loop counter so a max sub-index of 0xFF does not wrap back to 0.
@@ -311,7 +317,7 @@ public abstract class CanOpenReaderBase
         {
             var subIndexValue = (byte)subIndex;
             var subObj = ParseSubObject(sections, index, subIndexValue);
-            if (subObj == null && compactSubObj > 0 && subIndex <= compactSubObj)
+            if (subObj == null && compactMax > 0 && subIndex <= compactMax)
             {
                 subObj = SynthesizeCompactSubObject(obj, subIndexValue);
             }
@@ -322,7 +328,7 @@ public abstract class CanOpenReaderBase
             }
         }
 
-        if (compactSubObj > 0)
+        if (compactMax > 0)
         {
             ApplyCompactNameOverrides(sections, index, obj);
         }
@@ -399,6 +405,12 @@ public abstract class CanOpenReaderBase
 
     /// <summary>CiA 301 / CiA 306 UNSIGNED8 data-type index.</summary>
     private const ushort Unsigned8DataType = 0x0005;
+
+    /// <summary>
+    /// Highest sub-index covered by CompactSubObj value/name/denotation lists (CiA 306).
+    /// Sub-index <c>0xFF</c> is reserved and is never synthesized from the template.
+    /// </summary>
+    private const int MaxCompactListableSubIndex = 254;
 
     /// <summary>
     /// Parses a single sub-object at the given <paramref name="index"/> and <paramref name="subIndex"/>.

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -238,8 +238,11 @@ public abstract class CanOpenReaderBase
             obj.CompactSubObj = ValueConverter.ParseByte(compactSubObjStr);
         }
 
-        // Parse sub-objects for composite types (DEFSTRUCT, ARRAY, RECORD)
-        if (obj.SubNumber > 0 || CanOpenObjectType.HasSubObjects(obj.ObjectType))
+        // Parse sub-objects for composite types, CompactSubObj templates (CiA 306 §4.5.2.4.2),
+        // or an explicit SubNumber. CompactSubObj may be non-zero while SubNumber is 0/absent.
+        if (obj.SubNumber > 0 ||
+            (obj.CompactSubObj.HasValue && obj.CompactSubObj.Value > 0) ||
+            CanOpenObjectType.HasSubObjects(obj.ObjectType))
         {
             ParseSubObjects(sections, index, obj);
         }
@@ -265,15 +268,19 @@ public abstract class CanOpenReaderBase
     /// <summary>
     /// Parses all sub-objects for the given <paramref name="obj"/> and populates
     /// <see cref="CanOpenObject.SubObjects"/>.
+    /// When <see cref="CanOpenObject.CompactSubObj"/> is non-zero, missing
+    /// <c>[xxxsubN]</c> sections are synthesized from the parent object template
+    /// per CiA 306 §4.5.2.4.2, then optional <c>[xxxxName]</c> overrides are applied.
     /// Derived classes may override this to handle additional compact storage formats.
     /// </summary>
     protected virtual void ParseSubObjects(Dictionary<string, Dictionary<string, string>> sections, ushort index, CanOpenObject obj)
     {
         // Determine the number of sub-objects to parse
         var maxSubIndex = (int)(obj.SubNumber ?? 0);
-        if (obj.CompactSubObj.HasValue && obj.CompactSubObj.Value > 0)
+        var compactSubObj = obj.CompactSubObj.GetValueOrDefault();
+        if (compactSubObj > 0)
         {
-            maxSubIndex = Math.Max(maxSubIndex, obj.CompactSubObj.Value);
+            maxSubIndex = Math.Max(maxSubIndex, compactSubObj);
         }
 
         // Use an int loop counter so a max sub-index of 0xFF does not wrap back to 0.
@@ -281,12 +288,94 @@ public abstract class CanOpenReaderBase
         {
             var subIndexValue = (byte)subIndex;
             var subObj = ParseSubObject(sections, index, subIndexValue);
+            if (subObj == null && compactSubObj > 0 && subIndex <= compactSubObj)
+            {
+                subObj = SynthesizeCompactSubObject(obj, subIndexValue);
+            }
+
             if (subObj != null)
             {
                 obj.SubObjects[subIndexValue] = subObj;
             }
         }
+
+        if (compactSubObj > 0)
+        {
+            ApplyCompactNameOverrides(sections, index, obj);
+        }
     }
+
+    /// <summary>
+    /// Builds a sub-object from the parent object template when CompactSubObj storage
+    /// omits an individual <c>[xxxsubN]</c> section (CiA 306 §4.5.2.4.2).
+    /// </summary>
+    private static CanOpenSubObject SynthesizeCompactSubObject(CanOpenObject parent, byte subIndex)
+    {
+        if (subIndex == 0)
+        {
+            return new CanOpenSubObject
+            {
+                SubIndex = 0,
+                ParameterName = "NrOfObjects",
+                ObjectType = CanOpenObjectType.Var,
+                DataType = Unsigned8DataType,
+                AccessType = AccessType.ReadOnly,
+                DefaultValue = parent.CompactSubObj!.Value.ToString(CultureInfo.InvariantCulture),
+                PdoMapping = false
+            };
+        }
+
+        return new CanOpenSubObject
+        {
+            SubIndex = subIndex,
+            ParameterName = string.Concat(
+                parent.ParameterName,
+                subIndex.ToString(CultureInfo.InvariantCulture)),
+            ObjectType = CanOpenObjectType.Var,
+            DataType = parent.DataType ?? 0,
+            AccessType = parent.AccessType,
+            DefaultValue = parent.DefaultValue,
+            PdoMapping = parent.PdoMapping
+        };
+    }
+
+    /// <summary>
+    /// Applies optional <c>[xxxxName]</c> parameter-name overrides for compact sub-objects
+    /// (CiA 306 §4.5.2.4.2). Keys are decimal sub-indexes (1..254) and may be sparse;
+    /// <c>NrOfEntries</c> is the list length, not a loop bound.
+    /// </summary>
+    private static void ApplyCompactNameOverrides(
+        Dictionary<string, Dictionary<string, string>> sections,
+        ushort index,
+        CanOpenObject obj)
+    {
+        var nameSection = string.Concat(ToHexInvariant(index), "Name");
+        if (!IniParser.HasSection(sections, nameSection))
+            return;
+
+        foreach (var entry in sections[nameSection])
+        {
+            if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (string.IsNullOrEmpty(entry.Value))
+                continue;
+
+            if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
+                continue;
+
+            if (subIndex < 1)
+                continue;
+
+            if (obj.SubObjects.TryGetValue(subIndex, out var subObj))
+            {
+                subObj.ParameterName = entry.Value;
+            }
+        }
+    }
+
+    /// <summary>CiA 301 / CiA 306 UNSIGNED8 data-type index.</summary>
+    private const ushort Unsigned8DataType = 0x0005;
 
     /// <summary>
     /// Parses a single sub-object at the given <paramref name="index"/> and <paramref name="subIndex"/>.
@@ -333,6 +422,10 @@ public abstract class CanOpenReaderBase
 
         // Check for sub-object sections (hex index + "sub" + hex subindex)
         if (IsSubObjectSection(sectionName))
+            return true;
+
+        // CompactSubObj optional name overrides: [xxxxName]
+        if (IsHexPrefixedSection(sectionName, "Name"))
             return true;
 
         // Check for module sections (M + digits + known suffix)

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -289,23 +289,20 @@ public abstract class CanOpenReaderBase
     /// When <see cref="CanOpenObject.CompactSubObj"/> is non-zero, missing
     /// <c>[xxxsubN]</c> sections are synthesized from the parent object template
     /// per CiA 306 §4.5.2.4.2 (sub-indexes <c>0..min(CompactSubObj, 254)</c>;
-    /// sub-index <c>0xFF</c> is never synthesized), then optional <c>[xxxxName]</c>
-    /// overrides are applied.
+    /// sub-index <c>0xFF</c> is never synthesized, but an explicit <c>[xxxxsubFF]</c>
+    /// section is still parsed), then optional <c>[xxxxName]</c> overrides are applied.
     /// Derived classes may override this to handle additional compact storage formats.
     /// </summary>
     protected virtual void ParseSubObjects(Dictionary<string, Dictionary<string, string>> sections, ushort index, CanOpenObject obj)
     {
-        // Determine the number of sub-objects to parse
-        var maxSubIndex = (int)(obj.SubNumber ?? 0);
-        var compactSubObj = obj.CompactSubObj.GetValueOrDefault();
-        // CiA 306 compact lists use sub-indexes 1..254; never synthesize 0xFF.
-        var compactMax = compactSubObj == 0
-            ? 0
-            : Math.Min((int)compactSubObj, MaxCompactListableSubIndex);
-        if (compactMax > 0)
-        {
-            maxSubIndex = Math.Max(maxSubIndex, compactMax);
-        }
+        // Scan every sub-index the object can describe: an explicit [xxxxsubFF] section is
+        // parsed even when it is only reachable through CompactSubObj=0xFF.
+        var compactSubObj = (int)obj.CompactSubObj.GetValueOrDefault();
+        var maxSubIndex = Math.Max((int)(obj.SubNumber ?? 0), compactSubObj);
+
+        // CiA 306 compact lists cover sub-indexes 1..254, so 0xFF is never *synthesized*
+        // from the template — only an explicit section can populate it.
+        var compactMax = Math.Min(compactSubObj, MaxCompactListableSubIndex);
 
         // Use an int loop counter so a max sub-index of 0xFF does not wrap back to 0.
         for (var subIndex = 0; subIndex <= maxSubIndex; subIndex++)

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -382,7 +382,16 @@ public abstract class CanOpenReaderBase
         if (!IniParser.HasSection(sections, nameSection))
             return;
 
-        foreach (var entry in sections[nameSection])
+        var section = sections[nameSection];
+        foreach (var key in section.Keys)
+        {
+            if (!key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
+                continue;
+            _ = ValueConverter.ParseUInt16(section[key]);
+            break;
+        }
+
+        foreach (var entry in section)
         {
             if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
                 continue;

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -84,10 +84,33 @@ public abstract class CanOpenReaderBase
     /// <summary>
     /// Extension point that reports whether a section was already captured by
     /// format-specific parsing and therefore must not be preserved in
-    /// <c>AdditionalSections</c> (DCF: <c>ObjectLinks</c> sections of existing objects).
+    /// <c>AdditionalSections</c> (DCF: <c>ObjectLinks</c> of existing objects;
+    /// shared: consumed <c>[xxxxName]</c> for compact objects).
     /// </summary>
     private protected virtual bool IsSectionHandledByFormat(string sectionName, ICanOpenFileModel model)
-        => false;
+        => IsCompactNameSectionForExistingObject(sectionName, model.ObjectDictionary);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="sectionName"/> is a
+    /// <c>[xxxxName]</c> section for an object that uses CompactSubObj storage
+    /// (and was therefore consumed by <see cref="ApplyCompactNameOverrides"/>).
+    /// Orphan name sections remain in <c>AdditionalSections</c> for round-trip.
+    /// </summary>
+    private protected static bool IsCompactNameSectionForExistingObject(
+        string sectionName,
+        ObjectDictionary objectDictionary)
+    {
+        if (!IsHexPrefixedSection(sectionName, "Name"))
+            return false;
+
+        var prefix = sectionName[..^"Name".Length];
+        if (!ushort.TryParse(prefix, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var index))
+            return false;
+
+        return objectDictionary.Objects.TryGetValue(index, out var obj)
+               && obj.CompactSubObj.HasValue
+               && obj.CompactSubObj.Value > 0;
+    }
 
     /// <summary>
     /// Parses the <c>[FileInfo]</c> section into an <see cref="EdsFileInfo"/> object.
@@ -422,10 +445,6 @@ public abstract class CanOpenReaderBase
 
         // Check for sub-object sections (hex index + "sub" + hex subindex)
         if (IsSubObjectSection(sectionName))
-            return true;
-
-        // CompactSubObj optional name overrides: [xxxxName]
-        if (IsHexPrefixedSection(sectionName, "Name"))
             return true;
 
         // Check for module sections (M + digits + known suffix)

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -208,13 +208,24 @@ public class DcfReader : CanOpenReaderBase, IFileReader<DeviceConfigurationFile>
 
     /// <summary>
     /// Applies compact list entries whose keys are decimal sub-indexes (1..254).
-    /// <c>NrOfEntries</c> is the list length, not a loop bound — keys may be sparse.
+    /// <c>NrOfEntries</c> is the list length, not a loop bound — keys may be sparse —
+    /// but a present <c>NrOfEntries</c> value is still validated (throws on malformed).
     /// </summary>
     private static void ApplyCompactSubObjectEntries(
         Dictionary<string, string> section,
         CanOpenObject obj,
         Action<CanOpenSubObject, string> apply)
     {
+        foreach (var key in section.Keys)
+        {
+            if (!key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Validate even when not used as a loop bound (preserves prior ParseUInt16 failure mode).
+            _ = ValueConverter.ParseUInt16(section[key]);
+            break;
+        }
+
         foreach (var entry in section)
         {
             if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -184,41 +184,53 @@ public class DcfReader : CanOpenReaderBase, IFileReader<DeviceConfigurationFile>
     {
         base.ParseSubObjects(sections, index, obj);
 
-        // Parse compact value storage
+        // Parse compact value storage (CiA 306 §5.2.3.2): keys are sub-indexes 1..254
         var valueSectionName = string.Concat(ToHexInvariant(index), "Value");
         if (IniParser.HasSection(sections, valueSectionName))
         {
-            var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, valueSectionName, "NrOfEntries", "0"));
-            for (int i = 1; i <= count; i++)
-            {
-                var value = IniParser.GetValue(sections, valueSectionName, i.ToString(CultureInfo.InvariantCulture));
-                if (!string.IsNullOrEmpty(value) && i <= 254)
-                {
-                    var subIndex = (byte)i;
-                    if (obj.SubObjects.TryGetValue(subIndex, out var subObjForValue))
-                    {
-                        subObjForValue.ParameterValue = value;
-                    }
-                }
-            }
+            ApplyCompactSubObjectEntries(
+                sections[valueSectionName],
+                obj,
+                static (subObj, value) => subObj.ParameterValue = value);
         }
 
-        // Parse compact denotation storage
+        // Parse compact denotation storage (CiA 306 §5.2.3.2)
         var denotationSectionName = string.Concat(ToHexInvariant(index), "Denotation");
         if (IniParser.HasSection(sections, denotationSectionName))
         {
-            var count = ValueConverter.ParseUInt16(IniParser.GetValue(sections, denotationSectionName, "NrOfEntries", "0"));
-            for (int i = 1; i <= count; i++)
+            ApplyCompactSubObjectEntries(
+                sections[denotationSectionName],
+                obj,
+                static (subObj, value) => subObj.Denotation = value);
+        }
+    }
+
+    /// <summary>
+    /// Applies compact list entries whose keys are decimal sub-indexes (1..254).
+    /// <c>NrOfEntries</c> is the list length, not a loop bound — keys may be sparse.
+    /// </summary>
+    private static void ApplyCompactSubObjectEntries(
+        Dictionary<string, string> section,
+        CanOpenObject obj,
+        Action<CanOpenSubObject, string> apply)
+    {
+        foreach (var entry in section)
+        {
+            if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (string.IsNullOrEmpty(entry.Value))
+                continue;
+
+            if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
+                continue;
+
+            if (subIndex < 1)
+                continue;
+
+            if (obj.SubObjects.TryGetValue(subIndex, out var subObj))
             {
-                var denotation = IniParser.GetValue(sections, denotationSectionName, i.ToString(CultureInfo.InvariantCulture));
-                if (!string.IsNullOrEmpty(denotation) && i <= 254)
-                {
-                    var subIndex = (byte)i;
-                    if (obj.SubObjects.TryGetValue(subIndex, out var subObjForDenotation))
-                    {
-                        subObjForDenotation.Denotation = denotation;
-                    }
-                }
+                apply(subObj, entry.Value);
             }
         }
     }

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -226,7 +226,7 @@ public class DcfReader : CanOpenReaderBase, IFileReader<DeviceConfigurationFile>
             if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
                 continue;
 
-            if (subIndex < 1)
+            if (subIndex < 1 || subIndex > MaxCompactListableSubIndex)
                 continue;
 
             if (obj.SubObjects.TryGetValue(subIndex, out var subObj))

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -146,7 +146,8 @@ public class DcfReader : CanOpenReaderBase, IFileReader<DeviceConfigurationFile>
 
     /// <inheritdoc/>
     private protected override bool IsSectionHandledByFormat(string sectionName, ICanOpenFileModel model)
-        => ObjectLinksSectionHelper.IsObjectLinksSectionForExistingObject(sectionName, model.ObjectDictionary);
+        => base.IsSectionHandledByFormat(sectionName, model)
+           || ObjectLinksSectionHelper.IsObjectLinksSectionForExistingObject(sectionName, model.ObjectDictionary);
 
     /// <inheritdoc/>
     protected override EdsFileInfo ParseFileInfo(Dictionary<string, Dictionary<string, string>> sections)

--- a/src/EdsDcfNet/Parsers/DcfReader.cs
+++ b/src/EdsDcfNet/Parsers/DcfReader.cs
@@ -186,65 +186,20 @@ public class DcfReader : CanOpenReaderBase, IFileReader<DeviceConfigurationFile>
         base.ParseSubObjects(sections, index, obj);
 
         // Parse compact value storage (CiA 306 §5.2.3.2): keys are sub-indexes 1..254
-        var valueSectionName = string.Concat(ToHexInvariant(index), "Value");
-        if (IniParser.HasSection(sections, valueSectionName))
-        {
-            ApplyCompactSubObjectEntries(
-                sections[valueSectionName],
-                obj,
-                static (subObj, value) => subObj.ParameterValue = value);
-        }
+        ApplyCompactListSection(
+            sections,
+            index,
+            "Value",
+            obj,
+            static (subObj, value) => subObj.ParameterValue = value);
 
         // Parse compact denotation storage (CiA 306 §5.2.3.2)
-        var denotationSectionName = string.Concat(ToHexInvariant(index), "Denotation");
-        if (IniParser.HasSection(sections, denotationSectionName))
-        {
-            ApplyCompactSubObjectEntries(
-                sections[denotationSectionName],
-                obj,
-                static (subObj, value) => subObj.Denotation = value);
-        }
-    }
-
-    /// <summary>
-    /// Applies compact list entries whose keys are decimal sub-indexes (1..254).
-    /// <c>NrOfEntries</c> is the list length, not a loop bound — keys may be sparse —
-    /// but a present <c>NrOfEntries</c> value is still validated (throws on malformed).
-    /// </summary>
-    private static void ApplyCompactSubObjectEntries(
-        Dictionary<string, string> section,
-        CanOpenObject obj,
-        Action<CanOpenSubObject, string> apply)
-    {
-        foreach (var key in section.Keys)
-        {
-            if (!key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            // Validate even when not used as a loop bound (preserves prior ParseUInt16 failure mode).
-            _ = ValueConverter.ParseUInt16(section[key]);
-            break;
-        }
-
-        foreach (var entry in section)
-        {
-            if (entry.Key.Equals("NrOfEntries", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            if (string.IsNullOrEmpty(entry.Value))
-                continue;
-
-            if (!byte.TryParse(entry.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var subIndex))
-                continue;
-
-            if (subIndex < 1 || subIndex > MaxCompactListableSubIndex)
-                continue;
-
-            if (obj.SubObjects.TryGetValue(subIndex, out var subObj))
-            {
-                apply(subObj, entry.Value);
-            }
-        }
+        ApplyCompactListSection(
+            sections,
+            index,
+            "Denotation",
+            obj,
+            static (subObj, denotation) => subObj.Denotation = denotation);
     }
 
     /// <inheritdoc/>

--- a/src/EdsDcfNet/Writers/DcfWriter.cs
+++ b/src/EdsDcfNet/Writers/DcfWriter.cs
@@ -193,6 +193,75 @@ public class DcfWriter : IniWriterBase
         }
     }
 
+    /// <inheritdoc/>
+    protected override void WriteCompactValueAndDenotationSections(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
+        WriteCompactListSection(
+            sb,
+            obj,
+            compactMax,
+            expandedSubIndexes,
+            writeSection,
+            "Value",
+            static sub => sub.ParameterValue);
+
+        WriteCompactListSection(
+            sb,
+            obj,
+            compactMax,
+            expandedSubIndexes,
+            writeSection,
+            "Denotation",
+            static sub => sub.Denotation);
+    }
+
+    private static void WriteCompactListSection(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection,
+        string suffix,
+        Func<CanOpenSubObject, string?> selectValue)
+    {
+        var entries = new SortedDictionary<byte, string>();
+        for (var i = 1; i <= compactMax; i++)
+        {
+            var subIndex = (byte)i;
+            if (expandedSubIndexes.Contains(subIndex))
+                continue;
+            if (!obj.SubObjects.TryGetValue(subIndex, out var subObj))
+                continue;
+
+            var value = selectValue(subObj);
+            if (!string.IsNullOrEmpty(value))
+                entries[subIndex] = value!;
+        }
+
+        if (entries.Count == 0)
+            return;
+
+        var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}{1}", obj.Index, suffix);
+        writeSection(
+            sectionName,
+            () =>
+            {
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}{1}]", obj.Index, suffix));
+                WriteKeyValue(sb, "NrOfEntries", entries.Count.ToString(CultureInfo.InvariantCulture));
+                foreach (var entry in entries)
+                {
+                    WriteKeyValue(sb, entry.Key.ToString(CultureInfo.InvariantCulture), entry.Value);
+                }
+
+                sb.AppendLine();
+            });
+    }
+
     #endregion
 
     #region DCF-only sections

--- a/src/EdsDcfNet/Writers/IniWriterBase.cs
+++ b/src/EdsDcfNet/Writers/IniWriterBase.cs
@@ -99,14 +99,23 @@ public abstract class IniWriterBase
     /// <summary>
     /// Writes the shared (EDS) fields of a <see cref="CanOpenObject"/>.
     /// DCF overrides <see cref="WriteObjectExtension"/> to append DCF-specific fields.
+    /// When <see cref="CanOpenObject.CompactSubObj"/> is non-zero, redundant
+    /// <c>[xxxsubN]</c> sections are omitted and compact <c>[xxxxName]</c> /
+    /// <c>[xxxxValue]</c> / <c>[xxxxDenotation]</c> lists are emitted (CiA 306).
     /// </summary>
     protected void WriteObject(StringBuilder sb, CanOpenObject obj, Action<string, Action> writeSection)
     {
+        var compactMax = GetCompactMaxSubIndex(obj);
+        var useCompact = compactMax > 0;
+
         sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}]", obj.Index));
 
-        if (obj.SubNumber.HasValue && obj.SubNumber.Value > 0)
+        // CiA 306: SubNumber is normally omitted under CompactSubObj. Keep/emit it when
+        // expanded sub-objects exist above the compact range so the reader can reach them.
+        var subNumberToWrite = ResolveSubNumberForWrite(obj, compactMax, useCompact);
+        if (subNumberToWrite > 0)
         {
-            WriteKeyValue(sb, "SubNumber", obj.SubNumber.Value.ToString(CultureInfo.InvariantCulture));
+            WriteKeyValue(sb, "SubNumber", subNumberToWrite.ToString(CultureInfo.InvariantCulture));
         }
 
         WriteKeyValue(sb, "ParameterName", obj.ParameterName);
@@ -151,22 +160,34 @@ public abstract class IniWriterBase
             WriteKeyValue(sb, "ObjFlags", ValueConverter.FormatInteger(obj.ObjFlags));
         }
 
-        if (obj.CompactSubObj.HasValue && obj.CompactSubObj.Value > 0)
+        if (useCompact)
         {
-            WriteKeyValue(sb, "CompactSubObj", obj.CompactSubObj.Value.ToString(CultureInfo.InvariantCulture));
+            WriteKeyValue(sb, "CompactSubObj", obj.CompactSubObj!.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         WriteObjectExtension(sb, obj);
 
         sb.AppendLine();
 
+        var expandedSubIndexes = new HashSet<byte>();
         if (obj.SubObjects.Count > 0)
         {
             foreach (var subObjEntry in obj.SubObjects.OrderBy(s => s.Key))
             {
+                var subObj = subObjEntry.Value;
+                if (useCompact && !MustExpandCompactSubObject(obj, subObj, compactMax))
+                    continue;
+
+                expandedSubIndexes.Add(subObjEntry.Key);
                 var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}sub{1:X}", obj.Index, subObjEntry.Key);
-                writeSection(sectionName, () => WriteSubObject(sb, obj.Index, subObjEntry.Value));
+                writeSection(sectionName, () => WriteSubObject(sb, obj.Index, subObj));
             }
+        }
+
+        if (useCompact)
+        {
+            WriteCompactNameSection(sb, obj, compactMax, expandedSubIndexes, writeSection);
+            WriteCompactValueAndDenotationSections(sb, obj, compactMax, expandedSubIndexes, writeSection);
         }
 
         if (obj.ObjectLinks.Count > 0)
@@ -187,6 +208,158 @@ public abstract class IniWriterBase
                     sb.AppendLine();
                 });
         }
+    }
+
+    /// <summary>
+    /// Highest compact-listable sub-index for <paramref name="obj"/>, or 0 when
+    /// CompactSubObj is absent/zero. Caps at 254 per CiA 306.
+    /// </summary>
+    private static int GetCompactMaxSubIndex(CanOpenObject obj)
+    {
+        if (!obj.CompactSubObj.HasValue || obj.CompactSubObj.Value == 0)
+            return 0;
+        return Math.Min((int)obj.CompactSubObj.Value, 254);
+    }
+
+    /// <summary>
+    /// Chooses the SubNumber to emit. Under compact storage this is usually omitted,
+    /// except when expanded sub-objects above the compact range must remain reachable.
+    /// </summary>
+    private static byte ResolveSubNumberForWrite(CanOpenObject obj, int compactMax, bool useCompact)
+    {
+        if (!useCompact)
+            return obj.SubNumber.GetValueOrDefault();
+
+        byte maxExpandedBeyondCompact = 0;
+        var hasBeyond = false;
+        foreach (var key in obj.SubObjects.Keys)
+        {
+            if (key <= compactMax)
+                continue;
+            hasBeyond = true;
+            if (key > maxExpandedBeyondCompact)
+                maxExpandedBeyondCompact = key;
+        }
+
+        if (!hasBeyond)
+            return 0;
+
+        var fromModel = obj.SubNumber.GetValueOrDefault();
+        return fromModel > maxExpandedBeyondCompact ? fromModel : maxExpandedBeyondCompact;
+    }
+
+    /// <summary>
+    /// Returns whether a sub-object must be written as an expanded <c>[xxxsubN]</c>
+    /// section under CompactSubObj storage (non-template fields that compact lists
+    /// cannot represent).
+    /// </summary>
+    private static bool MustExpandCompactSubObject(CanOpenObject parent, CanOpenSubObject subObj, int compactMax)
+    {
+        if (subObj.SubIndex > compactMax)
+            return true;
+
+        if (subObj.SubIndex == 0)
+            return !MatchesCompactSub0Template(parent, subObj);
+
+        // 1..compactMax: expand only when fields cannot go in Name/Value/Denotation.
+        return !MatchesCompactElementTemplate(parent, subObj)
+               || HasNonCompactExclusiveFields(subObj);
+    }
+
+    private static bool MatchesCompactSub0Template(CanOpenObject parent, CanOpenSubObject subObj)
+    {
+        // Sub0 has no compact Value/Denotation list entry (CiA 306 keys are 1..254),
+        // so non-empty ParameterValue/Denotation must force an expanded [xxxsub0].
+        return subObj.ObjectType == CanOpenObjectType.Var
+               && subObj.DataType == 0x0005
+               && subObj.AccessType == AccessType.ReadOnly
+               && string.Equals(
+                   subObj.DefaultValue,
+                   parent.CompactSubObj!.Value.ToString(CultureInfo.InvariantCulture),
+                   StringComparison.Ordinal)
+               && !subObj.PdoMapping
+               && string.IsNullOrEmpty(subObj.LowLimit)
+               && string.IsNullOrEmpty(subObj.HighLimit)
+               && string.IsNullOrEmpty(subObj.ParameterValue)
+               && string.IsNullOrEmpty(subObj.Denotation)
+               && !HasNonCompactExclusiveFields(subObj)
+               && (string.IsNullOrEmpty(subObj.ParameterName)
+                   || subObj.ParameterName.Equals("NrOfObjects", StringComparison.Ordinal));
+    }
+
+    private static bool MatchesCompactElementTemplate(CanOpenObject parent, CanOpenSubObject subObj)
+    {
+        var expectedDataType = parent.DataType ?? 0;
+        return subObj.ObjectType == CanOpenObjectType.Var
+               && subObj.DataType == expectedDataType
+               && subObj.AccessType == parent.AccessType
+               && string.Equals(subObj.DefaultValue, parent.DefaultValue, StringComparison.Ordinal)
+               && subObj.PdoMapping == parent.PdoMapping
+               && string.IsNullOrEmpty(subObj.LowLimit)
+               && string.IsNullOrEmpty(subObj.HighLimit);
+    }
+
+    private static bool HasNonCompactExclusiveFields(CanOpenSubObject subObj)
+        => subObj.SrdoMapping
+           || !string.IsNullOrEmpty(subObj.InvertedSrad)
+           || !string.IsNullOrEmpty(subObj.ParamRefd);
+
+    private static void WriteCompactNameSection(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
+        var names = new SortedDictionary<byte, string>();
+        for (var i = 1; i <= compactMax; i++)
+        {
+            var subIndex = (byte)i;
+            if (expandedSubIndexes.Contains(subIndex))
+                continue;
+            if (!obj.SubObjects.TryGetValue(subIndex, out var subObj))
+                continue;
+
+            var defaultName = string.Concat(
+                obj.ParameterName,
+                subIndex.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrEmpty(subObj.ParameterName)
+                && !subObj.ParameterName.Equals(defaultName, StringComparison.Ordinal))
+            {
+                names[subIndex] = subObj.ParameterName;
+            }
+        }
+
+        if (names.Count == 0)
+            return;
+
+        var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}Name", obj.Index);
+        writeSection(
+            sectionName,
+            () =>
+            {
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}Name]", obj.Index));
+                WriteKeyValue(sb, "NrOfEntries", names.Count.ToString(CultureInfo.InvariantCulture));
+                foreach (var entry in names)
+                {
+                    WriteKeyValue(sb, entry.Key.ToString(CultureInfo.InvariantCulture), entry.Value);
+                }
+
+                sb.AppendLine();
+            });
+    }
+
+    /// <summary>
+    /// Writes compact <c>[xxxxValue]</c> / <c>[xxxxDenotation]</c> lists.
+    /// EDS: no-op. DCF: emits ParameterValue and Denotation for non-expanded subs.
+    /// </summary>
+    protected virtual void WriteCompactValueAndDenotationSections(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1103,6 +1103,48 @@ CompactSubObj=255
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_255_ParsesExplicitSubFFWithoutSubNumber()
+    {
+        // Arrange — CompactSubObj=255 without SubNumber: 0xFF is not synthesized, but an
+        // explicit [2100subFF] section must still be parsed instead of silently dropped.
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=BigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=255
+
+[2100subFF]
+ParameterName=Identity
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+ParameterValue=keep-me
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects.Should().HaveCount(256); // 0..254 synthesized + explicit 0xFF
+        obj.SubObjects[255].ParameterName.Should().Be("Identity");
+        obj.SubObjects[255].DataType.Should().Be(0x0007);
+        obj.SubObjects[255].ParameterValue.Should().Be("keep-me");
+        obj.SubObjects[254].ParameterName.Should().Be("BigArray254"); // still synthesized
+        result.AdditionalSections.Should().NotContainKey("2100subFF");
+    }
+
+    [Fact]
     public void ReadString_CompactSubObj_ValueKey255_DoesNotApplyToSubFF()
     {
         // Arrange — compact lists are 1..254; key 255 must not touch SubObjects[0xFF]

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1173,6 +1173,115 @@ NrOfEntries=oops
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_ValueSection_IgnoresKeysOutsideCompactListRange()
+    {
+        // Arrange — compact value lists cover sub-indexes 1..254 only; sub-index 0, non-numeric
+        // keys, empty values and keys without a matching sub-object must all be ignored.
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2100Value]
+NrOfEntries=2
+0=NotTheEntryCount
+Comment=NotASubIndex
+1=10
+2=
+9=99
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects.Should().HaveCount(3); // 0..2 — no sub-object is created by a value entry
+        obj.SubObjects[0].ParameterValue.Should().BeNull(); // key 0 ignored
+        obj.SubObjects[1].ParameterValue.Should().Be("10");
+        obj.SubObjects[2].ParameterValue.Should().BeNull(); // empty value ignored
+        obj.SubObjects.Should().NotContainKey(9);
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_NameSection_OverridesNamesAndIsConsumed()
+    {
+        // Arrange — [xxxxName] is shared EDS/DCF compact storage (CiA 306 §4.5.2.4.2)
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2100Name]
+NrOfEntries=1
+2=SecondEntry
+
+[2100Value]
+NrOfEntries=1
+2=20
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects[1].ParameterName.Should().Be("ConfigArray1");
+        obj.SubObjects[2].ParameterName.Should().Be("SecondEntry");
+        obj.SubObjects[2].ParameterValue.Should().Be("20");
+        result.AdditionalSections.Should().NotContainKey("2100Name");
+    }
+
+    [Fact]
+    public void ReadString_OrphanNameSection_PreservedInAdditionalSections()
+    {
+        // Arrange — [xxxxName] without a matching CompactSubObj object must round-trip
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2200Name]
+NrOfEntries=1
+1=OrphanName
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("2200Name");
+        result.AdditionalSections["2200Name"]["1"].Should().Be("OrphanName");
+    }
+
+    [Fact]
     public void ReadString_SubObject_AllFieldsParsed()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1103,6 +1103,49 @@ CompactSubObj=255
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_ValueKey255_DoesNotApplyToSubFF()
+    {
+        // Arrange — compact lists are 1..254; key 255 must not touch SubObjects[0xFF]
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=BigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+SubNumber=255
+CompactSubObj=2
+
+[2100subFF]
+ParameterName=Identity
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+ParameterValue=keep-me
+
+[2100Value]
+NrOfEntries=2
+1=10
+255=should-not-apply
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects[1].ParameterValue.Should().Be("10");
+        obj.SubObjects[255].ParameterValue.Should().Be("keep-me");
+    }
+
+    [Fact]
     public void ReadString_SubObject_AllFieldsParsed()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1071,6 +1071,38 @@ NrOfEntries=2
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_255_DoesNotSynthesizeSubIndexFF()
+    {
+        // Arrange — CompactSubObj=255 must not fabricate SubObjects[0xFF]
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=BigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=255
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj.Should().Be(255);
+        obj.SubObjects.Should().HaveCount(255); // 0..254 only
+        obj.SubObjects.Should().ContainKey(0);
+        obj.SubObjects.Should().ContainKey(254);
+        obj.SubObjects.Should().NotContainKey(255);
+        obj.SubObjects[0].DefaultValue.Should().Be("255");
+    }
+
+    [Fact]
     public void ReadString_SubObject_AllFieldsParsed()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1146,6 +1146,33 @@ NrOfEntries=2
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_MalformedNrOfEntries_Throws()
+    {
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=1
+
+[2100Value]
+NrOfEntries=oops
+1=10
+");
+
+        var act = () => _reader.ReadString(content);
+
+        act.Should().Throw<EdsParseException>();
+    }
+
+    [Fact]
     public void ReadString_SubObject_AllFieldsParsed()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -898,6 +898,179 @@ NrOfEntries=2
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_TemplateOnly_SynthesizesSubObjectsAndAppliesValues()
+    {
+        // Arrange — CiA 306 compact form: parent template only, no [xxxsubN] sections
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=1
+CompactSubObj=3
+
+[2100Value]
+NrOfEntries=3
+1=10
+2=20
+3=30
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj.Should().Be(3);
+        obj.SubObjects.Should().HaveCount(4); // 0..3
+
+        var sub0 = obj.SubObjects[0];
+        sub0.ParameterName.Should().Be("NrOfObjects");
+        sub0.ObjectType.Should().Be(0x7);
+        sub0.DataType.Should().Be(0x0005);
+        sub0.AccessType.Should().Be(AccessType.ReadOnly);
+        sub0.DefaultValue.Should().Be("3");
+        sub0.PdoMapping.Should().BeFalse();
+        sub0.ParameterValue.Should().BeNull();
+
+        obj.SubObjects[1].ParameterName.Should().Be("ConfigArray1");
+        obj.SubObjects[1].DataType.Should().Be(0x0005);
+        obj.SubObjects[1].AccessType.Should().Be(AccessType.ReadWrite);
+        obj.SubObjects[1].DefaultValue.Should().Be("0");
+        obj.SubObjects[1].PdoMapping.Should().BeTrue();
+        obj.SubObjects[1].ParameterValue.Should().Be("10");
+
+        obj.SubObjects[2].ParameterValue.Should().Be("20");
+        obj.SubObjects[3].ParameterValue.Should().Be("30");
+        obj.SubObjects[3].ParameterName.Should().Be("ConfigArray3");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_TemplateOnly_AppliesDenotations()
+    {
+        // Arrange
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=ConfigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2100Denotation]
+NrOfEntries=2
+1=Label A
+2=Label B
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects.Should().HaveCount(3);
+        obj.SubObjects[1].Denotation.Should().Be("Label A");
+        obj.SubObjects[2].Denotation.Should().Be("Label B");
+        obj.SubObjects[0].Denotation.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_TemplateOnly_PartialExpandedSub0_PreservesExplicitAndSynthesizesRest()
+    {
+        // Arrange — hybrid: explicit sub0, synthesize 1..N from template
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=DigitalInput
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=1
+CompactSubObj=2
+
+[2100sub0]
+ParameterName=Number of Elements
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=2
+PDOMapping=0
+
+[2100Value]
+NrOfEntries=2
+1=0xAA
+2=0xBB
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects.Should().HaveCount(3);
+        obj.SubObjects[0].ParameterName.Should().Be("Number of Elements");
+        obj.SubObjects[0].DefaultValue.Should().Be("2");
+        obj.SubObjects[1].ParameterName.Should().Be("DigitalInput1");
+        obj.SubObjects[1].ParameterValue.Should().Be("0xAA");
+        obj.SubObjects[2].ParameterValue.Should().Be("0xBB");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_AtMaxValue_SynthesizesAllSubIndexes()
+    {
+        // Arrange — CompactSubObj = 254 (max listable value sub-index per CiA 306)
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=BigArray
+ObjectType=0x8
+DataType=0x0005
+AccessType=rw
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=254
+
+[2100Value]
+NrOfEntries=2
+1=1
+254=254
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj.Should().Be(254);
+        obj.SubObjects.Should().HaveCount(255); // 0..254
+        obj.SubObjects[0].DefaultValue.Should().Be("254");
+        obj.SubObjects[1].ParameterValue.Should().Be("1");
+        obj.SubObjects[254].ParameterValue.Should().Be("254");
+        obj.SubObjects[254].ParameterName.Should().Be("BigArray254");
+        obj.SubObjects[100].ParameterValue.Should().BeNull();
+        obj.SubObjects[100].DefaultValue.Should().Be("0");
+    }
+
+    [Fact]
     public void ReadString_SubObject_AllFieldsParsed()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -520,6 +520,114 @@ PDOMapping=0
     }
 
     [Fact]
+    public void ReadString_CompactSubObj_TemplateOnly_SynthesizesFromParentTemplate()
+    {
+        // Arrange — EDS compact storage without any [xxxsubN] sections
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=1
+CompactSubObj=2
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj.Should().Be(2);
+        obj.SubObjects.Should().HaveCount(3);
+
+        obj.SubObjects[0].ParameterName.Should().Be("NrOfObjects");
+        obj.SubObjects[0].AccessType.Should().Be(AccessType.ReadOnly);
+        obj.SubObjects[0].DataType.Should().Be(0x0005);
+        obj.SubObjects[0].DefaultValue.Should().Be("2");
+        obj.SubObjects[0].PdoMapping.Should().BeFalse();
+
+        obj.SubObjects[1].ParameterName.Should().Be("StatusBits1");
+        obj.SubObjects[1].ObjectType.Should().Be(0x7);
+        obj.SubObjects[1].DataType.Should().Be(0x0005);
+        obj.SubObjects[1].AccessType.Should().Be(AccessType.ReadOnly);
+        obj.SubObjects[1].DefaultValue.Should().Be("0");
+        obj.SubObjects[1].PdoMapping.Should().BeTrue();
+
+        obj.SubObjects[2].ParameterName.Should().Be("StatusBits2");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_NameSection_OverridesDefaultNames()
+    {
+        // Arrange
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=3
+
+[2100Name]
+NrOfEntries=2
+1=FirstBit
+3=ThirdBit
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects[0].ParameterName.Should().Be("NrOfObjects");
+        obj.SubObjects[1].ParameterName.Should().Be("FirstBit");
+        obj.SubObjects[2].ParameterName.Should().Be("StatusBits2"); // default rule
+        obj.SubObjects[3].ParameterName.Should().Be("ThirdBit");
+        result.AdditionalSections.Should().NotContainKey("2100Name");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_SampleDevice_SynthesizesMissingArrayElements()
+    {
+        // Arrange — sample_device.eds uses CompactSubObj with only sub0 expanded
+        var result = _reader.ReadFile("Fixtures/sample_device.eds");
+
+        // Assert
+        var digitalIn = result.ObjectDictionary.Objects[0x6000];
+        digitalIn.CompactSubObj.Should().Be(16);
+        digitalIn.SubObjects.Should().HaveCount(17); // 0..16
+        digitalIn.SubObjects[0].ParameterName.Should().Be("Number of Elements"); // explicit
+        digitalIn.SubObjects[1].ParameterName.Should().Be("Digital Input 8-Bit1");
+        digitalIn.SubObjects[1].AccessType.Should().Be(AccessType.ReadOnly);
+        digitalIn.SubObjects[1].PdoMapping.Should().BeTrue();
+        digitalIn.SubObjects[16].ParameterName.Should().Be("Digital Input 8-Bit16");
+
+        var rpdoMap = result.ObjectDictionary.Objects[0x1600];
+        rpdoMap.CompactSubObj.Should().Be(8);
+        rpdoMap.SubObjects.Should().HaveCount(9); // 0..8
+        rpdoMap.SubObjects[0].ParameterName.Should().Be("Number of Entries");
+        rpdoMap.SubObjects[1].ParameterName.Should().Be("RPDO Mapping Parameter1");
+    }
+
+    [Fact]
     public void ReadString_AccessTypes_ParsesAllTypes()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -605,6 +605,81 @@ NrOfEntries=2
     }
 
     [Fact]
+    public void ReadString_OrphanNameSection_PreservedInAdditionalSections()
+    {
+        // Arrange — [xxxxName] without a matching CompactSubObj object must round-trip
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+[2100Name]
+NrOfEntries=1
+1=OrphanName
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("2100Name");
+        result.AdditionalSections["2100Name"]["1"].Should().Be("OrphanName");
+    }
+
+    [Fact]
+    public void ReadString_NameSectionWithoutCompactSubObj_PreservedInAdditionalSections()
+    {
+        // Arrange — object exists but CompactSubObj is absent/zero
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+SubNumber=1
+
+[2100sub0]
+ParameterName=Number of Entries
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=1
+PDOMapping=0
+
+[2100Name]
+NrOfEntries=1
+1=ShouldStayAdditional
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("2100Name");
+        result.ObjectDictionary.Objects[0x2100].SubObjects.Should().NotContainKey(1);
+    }
+
+    [Fact]
     public void ReadString_CompactSubObj_SampleDevice_SynthesizesMissingArrayElements()
     {
         // Arrange — sample_device.eds uses CompactSubObj with only sub0 expanded

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -680,6 +680,158 @@ NrOfEntries=1
     }
 
     [Fact]
+    public void ReadString_NameSectionWithCompactSubObjZero_PreservedInAdditionalSections()
+    {
+        // Arrange — CompactSubObj=0 means no compact storage, so [2100Name] is not consumed
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=0
+
+[2100Name]
+NrOfEntries=1
+1=ShouldStayAdditional
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj.Should().Be(0);
+        obj.SubObjects.Should().BeEmpty();
+        result.AdditionalSections.Should().ContainKey("2100Name");
+        result.AdditionalSections["2100Name"]["1"].Should().Be("ShouldStayAdditional");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_NameSection_IgnoresKeysOutsideCompactListRange()
+    {
+        // Arrange — compact name lists cover sub-indexes 1..254 only; everything else is ignored:
+        // sub-index 0 and 255 are out of range, non-numeric keys are not sub-indexes, empty values
+        // carry no name, and keys without a matching sub-object have nothing to rename.
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2100Name]
+NrOfEntries=2
+0=NotTheEntryCount
+255=ReservedSubIndex
+Comment=NotASubIndex
+1=FirstBit
+2=
+9=NoSuchSubObject
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects.Should().HaveCount(3); // 0..2 — no sub-object is created by a name entry
+        obj.SubObjects[0].ParameterName.Should().Be("NrOfObjects"); // key 0 ignored
+        obj.SubObjects[1].ParameterName.Should().Be("FirstBit");
+        obj.SubObjects[2].ParameterName.Should().Be("StatusBits2"); // empty value ignored
+        obj.SubObjects.Should().NotContainKey(9);
+        obj.SubObjects.Should().NotContainKey(255);
+        result.AdditionalSections.Should().NotContainKey("2100Name");
+    }
+
+    [Fact]
+    public void ReadString_CompactSubObj_NameSectionWithoutNrOfEntries_AppliesNames()
+    {
+        // Arrange — NrOfEntries is optional: the keys themselves define the list
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[2100Name]
+1=FirstBit
+2=SecondBit
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2100];
+        obj.SubObjects[1].ParameterName.Should().Be("FirstBit");
+        obj.SubObjects[2].ParameterName.Should().Be("SecondBit");
+    }
+
+    [Fact]
+    public void ReadString_SectionEndingInNameWithNonHexPrefix_PreservedInAdditionalSections()
+    {
+        // Arrange — only a hex object index before "Name" makes a compact name section
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x2100
+
+[2100]
+ParameterName=StatusBits
+ObjectType=0x8
+DataType=0x0005
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+CompactSubObj=2
+
+[CustomName]
+1=NotACompactList
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("CustomName");
+        result.AdditionalSections["CustomName"]["1"].Should().Be("NotACompactList");
+    }
+
+    [Fact]
     public void ReadString_CompactSubObj_SampleDevice_SynthesizesMissingArrayElements()
     {
         // Arrange — sample_device.eds uses CompactSubObj with only sub0 expanded

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -1,8 +1,10 @@
 namespace EdsDcfNet.Tests.Writers;
 
+using System.Globalization;
 using System.Reflection;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
+using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
 using FluentAssertions;
 using Xunit;
@@ -426,6 +428,256 @@ public class DcfWriterTests
 
         // Assert
         result.Should().Contain("ParameterValue=0x999");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_WritesValueAndDenotationSections()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 3
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "3",
+            PdoMapping = false
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "10",
+            Denotation = "Label A"
+        };
+        obj.SubObjects[2] = new CanOpenSubObject
+        {
+            SubIndex = 2,
+            ParameterName = "ConfigArray2",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "20"
+        };
+        obj.SubObjects[3] = new CanOpenSubObject
+        {
+            SubIndex = 3,
+            ParameterName = "ConfigArray3",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "30",
+            Denotation = "Label C"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var result = _writer.GenerateString(dcf);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=3");
+        result.Should().NotContain("[2100sub");
+        result.Should().Contain("[2100Value]");
+        result.Should().Contain("NrOfEntries=3");
+        result.Should().Contain("1=10");
+        result.Should().Contain("2=20");
+        result.Should().Contain("3=30");
+        result.Should().Contain("[2100Denotation]");
+        result.Should().Contain("1=Label A");
+        result.Should().Contain("3=Label C");
+        result.Should().NotContain("ParameterValue=10");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_ValidatedRoundTrip_PreservesValuesAndDenotations()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = true,
+            CompactSubObj = 2
+        };
+        for (byte i = 0; i <= 2; i++)
+        {
+            obj.SubObjects[i] = new CanOpenSubObject
+            {
+                SubIndex = i,
+                ParameterName = i == 0 ? "NrOfObjects" : "ConfigArray" + i.ToString(CultureInfo.InvariantCulture),
+                ObjectType = 0x7,
+                DataType = 0x0005,
+                AccessType = i == 0 ? AccessType.ReadOnly : AccessType.ReadWrite,
+                DefaultValue = i == 0 ? "2" : "0",
+                PdoMapping = i != 0,
+                ParameterValue = i == 0 ? null : (i * 10).ToString(CultureInfo.InvariantCulture),
+                Denotation = i == 0 ? null : "Label " + i.ToString(CultureInfo.InvariantCulture)
+            };
+        }
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var written = _writer.GenerateString(dcf);
+        var parsed = new DcfReader().ReadString(written);
+
+        // Assert
+        written.Should().Contain("[2100Value]");
+        written.Should().Contain("[2100Denotation]");
+        written.Should().NotContain("[2100sub");
+
+        var roundTripped = parsed.ObjectDictionary.Objects[0x2100];
+        roundTripped.CompactSubObj.Should().Be(2);
+        roundTripped.SubObjects.Should().HaveCount(3);
+        roundTripped.SubObjects[1].ParameterValue.Should().Be("10");
+        roundTripped.SubObjects[2].ParameterValue.Should().Be("20");
+        roundTripped.SubObjects[1].Denotation.Should().Be("Label 1");
+        roundTripped.SubObjects[2].Denotation.Should().Be("Label 2");
+        roundTripped.SubObjects[1].PdoMapping.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_ExpandsSub0WhenParameterValueOrDenotationSet()
+    {
+        // Arrange — sub0 matches structural template but carries DCF fields that
+        // cannot be stored in compact [xxxxValue]/[xxxxDenotation] (keys 1..254).
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 1
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "1",
+            PdoMapping = false,
+            ParameterValue = "1",
+            Denotation = "Count"
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "10"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var written = _writer.GenerateString(dcf);
+        var parsed = new DcfReader().ReadString(written);
+
+        // Assert
+        written.Should().Contain("[2100sub0]");
+        written.Should().Contain("ParameterValue=1");
+        written.Should().Contain("Denotation=Count");
+        written.Should().Contain("[2100Value]");
+        written.Should().NotContain("[2100sub1]");
+
+        var roundTripped = parsed.ObjectDictionary.Objects[0x2100];
+        roundTripped.SubObjects[0].ParameterValue.Should().Be("1");
+        roundTripped.SubObjects[0].Denotation.Should().Be("Count");
+        roundTripped.SubObjects[1].ParameterValue.Should().Be("10");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_PreservesSubNumberForExpandedBeyondCompactRange()
+    {
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 2,
+            SubNumber = 255
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "2"
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "1"
+        };
+        obj.SubObjects[255] = new CanOpenSubObject
+        {
+            SubIndex = 255,
+            ParameterName = "Identity",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            ParameterValue = "keep"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        var written = _writer.GenerateString(dcf);
+        written.Should().Contain("CompactSubObj=2");
+        written.Should().Contain("SubNumber=255");
+        written.Should().Contain("[2100subFF]");
+        written.Should().Contain("[2100Value]");
+
+        var parsed = new DcfReader().ReadString(written);
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects.Should().ContainKey(255);
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects[255].ParameterValue.Should().Be("keep");
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects[1].ParameterValue.Should().Be("1");
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
@@ -216,7 +216,6 @@ public class EdsWriterTests
             SrdoMapping = true,
             InvertedSrad = "0x2000",
             ObjFlags = 0x10,
-            CompactSubObj = 2,
             SubNumber = 1
         };
 
@@ -248,11 +247,121 @@ public class EdsWriterTests
         result.Should().Contain("SRDOMapping=1");
         result.Should().Contain("InvertedSRAD=0x2000");
         result.Should().Contain("ObjFlags=0x10");
-        result.Should().Contain("CompactSubObj=2");
         result.Should().Contain("[2000sub1]");
         result.Should().Contain("LowLimit=0");
         result.Should().Contain("HighLimit=5");
         result.Should().Contain("InvertedSRAD=0x3000");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_OmitsRedundantSubsAndWritesNameSection()
+    {
+        // Arrange
+        var eds = CreateMinimalEds();
+        eds.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        eds.ObjectDictionary.Objects[0x2100] = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "StatusBits",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true,
+            CompactSubObj = 2,
+            SubNumber = 2 // must be omitted in compact form
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "2",
+            PdoMapping = false
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "FirstBit",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[2] = new CanOpenSubObject
+        {
+            SubIndex = 2,
+            ParameterName = "StatusBits2",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true
+        };
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=2");
+        result.Should().NotContain("SubNumber=");
+        result.Should().NotContain("[2100sub0]");
+        result.Should().NotContain("[2100sub1]");
+        result.Should().NotContain("[2100sub2]");
+        result.Should().Contain("[2100Name]");
+        result.Should().Contain("NrOfEntries=1");
+        result.Should().Contain("1=FirstBit");
+        result.Should().NotContain("2=StatusBits2");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_ExpandsSub0WhenNameDiffersFromTemplate()
+    {
+        // Arrange
+        var eds = CreateMinimalEds();
+        eds.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        eds.ObjectDictionary.Objects[0x2100] = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "StatusBits",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 1
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "Number of Elements",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "1",
+            PdoMapping = false
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "StatusBits1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = false
+        };
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("[2100sub0]");
+        result.Should().Contain("ParameterName=Number of Elements");
+        result.Should().NotContain("[2100sub1]");
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
@@ -1,5 +1,6 @@
 namespace EdsDcfNet.Tests.Writers;
 
+using System.Globalization;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
@@ -362,6 +363,232 @@ public class EdsWriterTests
         result.Should().Contain("[2100sub0]");
         result.Should().Contain("ParameterName=Number of Elements");
         result.Should().NotContain("[2100sub1]");
+    }
+
+    [Theory]
+    // Structural fields the compact template fixes (MatchesCompactElementTemplate)…
+    [InlineData("ObjectType")]
+    [InlineData("DataType")]
+    [InlineData("AccessType")]
+    [InlineData("DefaultValue")]
+    [InlineData("PdoMapping")]
+    [InlineData("LowLimit")]
+    [InlineData("HighLimit")]
+    // …and fields no compact list can carry (HasNonCompactExclusiveFields).
+    [InlineData("SrdoMapping")]
+    [InlineData("InvertedSrad")]
+    [InlineData("ParamRefd")]
+    public void GenerateString_CompactSubObj_ExpandsElementDeviatingFromTemplate(string deviation)
+    {
+        // Arrange — sub1 matches the parent template except for one field, which the
+        // compact [xxxxName]/[xxxxValue]/[xxxxDenotation] lists cannot express.
+        var eds = CreateCompactEds(out var element);
+        ApplyDeviation(element, deviation);
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("[2100sub1]", $"a deviating {deviation} cannot be stored compactly");
+        result.Should().NotContain("[2100sub2]"); // untouched element stays compact
+    }
+
+    [Theory]
+    [InlineData("ObjectType")]
+    [InlineData("DataType")]
+    [InlineData("AccessType")]
+    [InlineData("DefaultValue")]
+    [InlineData("PdoMapping")]
+    [InlineData("LowLimit")]
+    [InlineData("HighLimit")]
+    [InlineData("Denotation")]
+    [InlineData("SrdoMapping")]
+    [InlineData("InvertedSrad")]
+    [InlineData("ParamRefd")]
+    public void GenerateString_CompactSubObj_ExpandsSub0DeviatingFromTemplate(string deviation)
+    {
+        // Arrange — sub0 has no compact list entry at all (CiA 306 keys are 1..254),
+        // so any deviation from the synthesized NrOfObjects template must expand it.
+        var eds = CreateCompactEds(out _);
+        var sub0 = eds.ObjectDictionary.Objects[0x2100].SubObjects[0];
+        ApplyDeviation(sub0, deviation);
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("[2100sub0]", $"a deviating {deviation} cannot be stored compactly");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_UnnamedSubObjects_StayCompact()
+    {
+        // Arrange — an empty ParameterName carries no information the reader cannot
+        // synthesize, so it must not force an expanded section or a [xxxxName] entry.
+        var eds = CreateCompactEds(out var element);
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[0].ParameterName = string.Empty;
+        element.ParameterName = string.Empty;
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=2");
+        result.Should().NotContain("[2100sub0]");
+        result.Should().NotContain("[2100sub1]");
+        result.Should().NotContain("[2100Name]");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_SparseSubObjects_SkipsMissingSubIndexes()
+    {
+        // Arrange — CompactSubObj=3 with sub2 absent: the gap is skipped, not defaulted
+        var eds = CreateCompactEds(out var element);
+        var obj = eds.ObjectDictionary.Objects[0x2100];
+        obj.CompactSubObj = 3;
+        obj.SubObjects[0].DefaultValue = "3";
+        obj.SubObjects.Remove(2);
+        element.ParameterName = "FirstBit";
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=3");
+        result.Should().Contain("[2100Name]");
+
+        // Only sub1 has a name to store; the absent sub2 and sub3 contribute nothing.
+        var nameSection = result[result.IndexOf("[2100Name]", StringComparison.Ordinal)..];
+        nameSection.Should().Contain("NrOfEntries=1");
+        nameSection.Should().Contain("1=FirstBit");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObjZero_WritesPlainExpandedObject()
+    {
+        // Arrange — CompactSubObj=0 is not compact storage
+        var eds = CreateCompactEds(out _);
+        eds.ObjectDictionary.Objects[0x2100].CompactSubObj = 0;
+        eds.ObjectDictionary.Objects[0x2100].SubNumber = 3;
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().NotContain("CompactSubObj=");
+        result.Should().Contain("SubNumber=3");
+        result.Should().Contain("[2100sub0]");
+        result.Should().Contain("[2100sub1]");
+        result.Should().Contain("[2100sub2]");
+        result.Should().NotContain("[2100Name]");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_SubNumberCoversHighestExpandedSubIndex()
+    {
+        // Arrange — several sub-objects above the compact range: SubNumber must stay high
+        // enough for the reader to reach all of them. Inserted highest-first so the writer
+        // sees the descending order.
+        var eds = CreateCompactEds(out _);
+        var obj = eds.ObjectDictionary.Objects[0x2100];
+        obj.SubNumber = 255;
+        obj.SubObjects[200] = new CanOpenSubObject
+        {
+            SubIndex = 200,
+            ParameterName = "Beyond200",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0"
+        };
+        obj.SubObjects[150] = new CanOpenSubObject
+        {
+            SubIndex = 150,
+            ParameterName = "Beyond150",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0"
+        };
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert — the model's SubNumber wins because it exceeds the highest expanded index
+        result.Should().Contain("SubNumber=255");
+        result.Should().Contain("CompactSubObj=2");
+        result.Should().Contain("[2100sub96]");  // 150 = 0x96
+        result.Should().Contain("[2100subC8]"); // 200 = 0xC8
+    }
+
+    /// <summary>
+    /// Builds an EDS with one CompactSubObj=2 object whose sub-objects all match the
+    /// template, so a single deviation is what forces an expanded section.
+    /// </summary>
+    private static ElectronicDataSheet CreateCompactEds(out CanOpenSubObject element)
+    {
+        var eds = CreateMinimalEds();
+        eds.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "StatusBits",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 2
+        };
+
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "2",
+            PdoMapping = false
+        };
+
+        for (byte subIndex = 1; subIndex <= 2; subIndex++)
+        {
+            obj.SubObjects[subIndex] = new CanOpenSubObject
+            {
+                SubIndex = subIndex,
+                ParameterName = "StatusBits" + subIndex.ToString(CultureInfo.InvariantCulture),
+                ObjectType = 0x7,
+                DataType = 0x0005,
+                AccessType = AccessType.ReadOnly,
+                DefaultValue = "0",
+                PdoMapping = false
+            };
+        }
+
+        eds.ObjectDictionary.Objects[0x2100] = obj;
+        element = obj.SubObjects[1];
+        return eds;
+    }
+
+    private static void ApplyDeviation(CanOpenSubObject subObj, string deviation)
+    {
+        switch (deviation)
+        {
+            case "ObjectType": subObj.ObjectType = 0x9; break;
+            case "DataType": subObj.DataType = 0x0007; break;
+            case "AccessType": subObj.AccessType = AccessType.ReadWrite; break;
+            case "DefaultValue": subObj.DefaultValue = "42"; break;
+            case "PdoMapping": subObj.PdoMapping = true; break;
+            case "LowLimit": subObj.LowLimit = "0"; break;
+            case "HighLimit": subObj.HighLimit = "5"; break;
+            case "Denotation": subObj.Denotation = "Label"; break;
+            case "SrdoMapping": subObj.SrdoMapping = true; break;
+            case "InvertedSrad": subObj.InvertedSrad = "0x2000"; break;
+            case "ParamRefd": subObj.ParamRefd = "0x1000"; break;
+            default: throw new ArgumentOutOfRangeException(nameof(deviation), deviation, "Unknown deviation");
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- When `CompactSubObj > 0`, synthesize missing sub-indexes `0..N` from the parent object template per CiA 306 §4.5.2.4.2 (explicit `[xxxsubN]` sections still win).
- Apply `[xxxxName]` overrides; apply DCF `[xxxxValue]` / `[xxxxDenotation]` onto synthesized entries.
- Fix sparse compact-list keys (keys are sub-indexes; `NrOfEntries` is list length, not a `1..N` loop bound).

Fixes #405

## Test plan
- [x] Template-only compact DCF populates `SubObjects` + ParameterValues
- [x] Template-only compact denotations
- [x] Hybrid: explicit sub0 preserved, rest synthesized
- [x] `CompactSubObj=254` boundary + sparse Value key `254`
- [x] EDS `[xxxxName]` sparse overrides
- [x] `sample_device.eds` synthesizes 6000/1600 missing elements
- [x] Full suite: 1580 passed; netstandard2.0 build OK

### Boundary & regression matrix

| Dimension | What to cover | This PR |
|---|---|---|
| Numeric boundaries | CompactSubObj max listable sub-index | `CompactSubObj=254` synthesizes `0..254`; sparse Value key `254` applied |
| Round-trip fidelity | EDS/DCF read of compact form | template-only + hybrid + `sample_device.eds` reader coverage (writer compact form is #406) |
| Validation modes | n/a | read-path only |
| Representative fixtures | `sample_device.eds` CompactSubObj arrays | asserted synthesized counts/names |
| API contract assertions | n/a | no public signature change |


Made with [Cursor](https://cursor.com)