### PR TITLE
fix(writers): emit CompactSubObj [xxxxValue]/[xxxxDenotation]/[xxxxName]

### DIFF
--- a/src/EdsDcfNet/Writers/DcfWriter.cs
+++ b/src/EdsDcfNet/Writers/DcfWriter.cs
@@ -193,6 +193,75 @@ public class DcfWriter : IniWriterBase
         }
     }
 
+    /// <inheritdoc/>
+    protected override void WriteCompactValueAndDenotationSections(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
+        WriteCompactListSection(
+            sb,
+            obj,
+            compactMax,
+            expandedSubIndexes,
+            writeSection,
+            "Value",
+            static sub => sub.ParameterValue);
+
+        WriteCompactListSection(
+            sb,
+            obj,
+            compactMax,
+            expandedSubIndexes,
+            writeSection,
+            "Denotation",
+            static sub => sub.Denotation);
+    }
+
+    private static void WriteCompactListSection(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection,
+        string suffix,
+        Func<CanOpenSubObject, string?> selectValue)
+    {
+        var entries = new SortedDictionary<byte, string>();
+        for (var i = 1; i <= compactMax; i++)
+        {
+            var subIndex = (byte)i;
+            if (expandedSubIndexes.Contains(subIndex))
+                continue;
+            if (!obj.SubObjects.TryGetValue(subIndex, out var subObj))
+                continue;
+
+            var value = selectValue(subObj);
+            if (!string.IsNullOrEmpty(value))
+                entries[subIndex] = value!;
+        }
+
+        if (entries.Count == 0)
+            return;
+
+        var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}{1}", obj.Index, suffix);
+        writeSection(
+            sectionName,
+            () =>
+            {
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}{1}]", obj.Index, suffix));
+                WriteKeyValue(sb, "NrOfEntries", entries.Count.ToString(CultureInfo.InvariantCulture));
+                foreach (var entry in entries)
+                {
+                    WriteKeyValue(sb, entry.Key.ToString(CultureInfo.InvariantCulture), entry.Value);
+                }
+
+                sb.AppendLine();
+            });
+    }
+
     #endregion
 
     #region DCF-only sections

--- a/src/EdsDcfNet/Writers/IniWriterBase.cs
+++ b/src/EdsDcfNet/Writers/IniWriterBase.cs
@@ -239,6 +239,8 @@ public abstract class IniWriterBase
 
     private static bool MatchesCompactSub0Template(CanOpenObject parent, CanOpenSubObject subObj)
     {
+        // Sub0 has no compact Value/Denotation list entry (CiA 306 keys are 1..254),
+        // so non-empty ParameterValue/Denotation must force an expanded [xxxsub0].
         return subObj.ObjectType == CanOpenObjectType.Var
                && subObj.DataType == 0x0005
                && subObj.AccessType == AccessType.ReadOnly
@@ -249,6 +251,8 @@ public abstract class IniWriterBase
                && !subObj.PdoMapping
                && string.IsNullOrEmpty(subObj.LowLimit)
                && string.IsNullOrEmpty(subObj.HighLimit)
+               && string.IsNullOrEmpty(subObj.ParameterValue)
+               && string.IsNullOrEmpty(subObj.Denotation)
                && !HasNonCompactExclusiveFields(subObj)
                && (string.IsNullOrEmpty(subObj.ParameterName)
                    || subObj.ParameterName.Equals("NrOfObjects", StringComparison.Ordinal));

--- a/src/EdsDcfNet/Writers/IniWriterBase.cs
+++ b/src/EdsDcfNet/Writers/IniWriterBase.cs
@@ -110,10 +110,12 @@ public abstract class IniWriterBase
 
         sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}]", obj.Index));
 
-        // CiA 306: SubNumber is not supported when CompactSubObj is used.
-        if (!useCompact && obj.SubNumber.HasValue && obj.SubNumber.Value > 0)
+        // CiA 306: SubNumber is normally omitted under CompactSubObj. Keep/emit it when
+        // expanded sub-objects exist above the compact range so the reader can reach them.
+        var subNumberToWrite = ResolveSubNumberForWrite(obj, compactMax, useCompact);
+        if (subNumberToWrite > 0)
         {
-            WriteKeyValue(sb, "SubNumber", obj.SubNumber.Value.ToString(CultureInfo.InvariantCulture));
+            WriteKeyValue(sb, "SubNumber", subNumberToWrite.ToString(CultureInfo.InvariantCulture));
         }
 
         WriteKeyValue(sb, "ParameterName", obj.ParameterName);
@@ -217,6 +219,33 @@ public abstract class IniWriterBase
         if (!obj.CompactSubObj.HasValue || obj.CompactSubObj.Value == 0)
             return 0;
         return Math.Min((int)obj.CompactSubObj.Value, 254);
+    }
+
+    /// <summary>
+    /// Chooses the SubNumber to emit. Under compact storage this is usually omitted,
+    /// except when expanded sub-objects above the compact range must remain reachable.
+    /// </summary>
+    private static byte ResolveSubNumberForWrite(CanOpenObject obj, int compactMax, bool useCompact)
+    {
+        if (!useCompact)
+            return obj.SubNumber.GetValueOrDefault();
+
+        byte maxExpandedBeyondCompact = 0;
+        var hasBeyond = false;
+        foreach (var key in obj.SubObjects.Keys)
+        {
+            if (key <= compactMax)
+                continue;
+            hasBeyond = true;
+            if (key > maxExpandedBeyondCompact)
+                maxExpandedBeyondCompact = key;
+        }
+
+        if (!hasBeyond)
+            return 0;
+
+        var fromModel = obj.SubNumber.GetValueOrDefault();
+        return fromModel > maxExpandedBeyondCompact ? fromModel : maxExpandedBeyondCompact;
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Writers/IniWriterBase.cs
+++ b/src/EdsDcfNet/Writers/IniWriterBase.cs
@@ -99,12 +99,19 @@ public abstract class IniWriterBase
     /// <summary>
     /// Writes the shared (EDS) fields of a <see cref="CanOpenObject"/>.
     /// DCF overrides <see cref="WriteObjectExtension"/> to append DCF-specific fields.
+    /// When <see cref="CanOpenObject.CompactSubObj"/> is non-zero, redundant
+    /// <c>[xxxsubN]</c> sections are omitted and compact <c>[xxxxName]</c> /
+    /// <c>[xxxxValue]</c> / <c>[xxxxDenotation]</c> lists are emitted (CiA 306).
     /// </summary>
     protected void WriteObject(StringBuilder sb, CanOpenObject obj, Action<string, Action> writeSection)
     {
+        var compactMax = GetCompactMaxSubIndex(obj);
+        var useCompact = compactMax > 0;
+
         sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}]", obj.Index));
 
-        if (obj.SubNumber.HasValue && obj.SubNumber.Value > 0)
+        // CiA 306: SubNumber is not supported when CompactSubObj is used.
+        if (!useCompact && obj.SubNumber.HasValue && obj.SubNumber.Value > 0)
         {
             WriteKeyValue(sb, "SubNumber", obj.SubNumber.Value.ToString(CultureInfo.InvariantCulture));
         }
@@ -151,22 +158,34 @@ public abstract class IniWriterBase
             WriteKeyValue(sb, "ObjFlags", ValueConverter.FormatInteger(obj.ObjFlags));
         }
 
-        if (obj.CompactSubObj.HasValue && obj.CompactSubObj.Value > 0)
+        if (useCompact)
         {
-            WriteKeyValue(sb, "CompactSubObj", obj.CompactSubObj.Value.ToString(CultureInfo.InvariantCulture));
+            WriteKeyValue(sb, "CompactSubObj", obj.CompactSubObj!.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         WriteObjectExtension(sb, obj);
 
         sb.AppendLine();
 
+        var expandedSubIndexes = new HashSet<byte>();
         if (obj.SubObjects.Count > 0)
         {
             foreach (var subObjEntry in obj.SubObjects.OrderBy(s => s.Key))
             {
+                var subObj = subObjEntry.Value;
+                if (useCompact && !MustExpandCompactSubObject(obj, subObj, compactMax))
+                    continue;
+
+                expandedSubIndexes.Add(subObjEntry.Key);
                 var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}sub{1:X}", obj.Index, subObjEntry.Key);
-                writeSection(sectionName, () => WriteSubObject(sb, obj.Index, subObjEntry.Value));
+                writeSection(sectionName, () => WriteSubObject(sb, obj.Index, subObj));
             }
+        }
+
+        if (useCompact)
+        {
+            WriteCompactNameSection(sb, obj, compactMax, expandedSubIndexes, writeSection);
+            WriteCompactValueAndDenotationSections(sb, obj, compactMax, expandedSubIndexes, writeSection);
         }
 
         if (obj.ObjectLinks.Count > 0)
@@ -187,6 +206,127 @@ public abstract class IniWriterBase
                     sb.AppendLine();
                 });
         }
+    }
+
+    /// <summary>
+    /// Highest compact-listable sub-index for <paramref name="obj"/>, or 0 when
+    /// CompactSubObj is absent/zero. Caps at 254 per CiA 306.
+    /// </summary>
+    private static int GetCompactMaxSubIndex(CanOpenObject obj)
+    {
+        if (!obj.CompactSubObj.HasValue || obj.CompactSubObj.Value == 0)
+            return 0;
+        return Math.Min((int)obj.CompactSubObj.Value, 254);
+    }
+
+    /// <summary>
+    /// Returns whether a sub-object must be written as an expanded <c>[xxxsubN]</c>
+    /// section under CompactSubObj storage (non-template fields that compact lists
+    /// cannot represent).
+    /// </summary>
+    private static bool MustExpandCompactSubObject(CanOpenObject parent, CanOpenSubObject subObj, int compactMax)
+    {
+        if (subObj.SubIndex > compactMax)
+            return true;
+
+        if (subObj.SubIndex == 0)
+            return !MatchesCompactSub0Template(parent, subObj);
+
+        // 1..compactMax: expand only when fields cannot go in Name/Value/Denotation.
+        return !MatchesCompactElementTemplate(parent, subObj)
+               || HasNonCompactExclusiveFields(subObj);
+    }
+
+    private static bool MatchesCompactSub0Template(CanOpenObject parent, CanOpenSubObject subObj)
+    {
+        return subObj.ObjectType == CanOpenObjectType.Var
+               && subObj.DataType == 0x0005
+               && subObj.AccessType == AccessType.ReadOnly
+               && string.Equals(
+                   subObj.DefaultValue,
+                   parent.CompactSubObj!.Value.ToString(CultureInfo.InvariantCulture),
+                   StringComparison.Ordinal)
+               && !subObj.PdoMapping
+               && string.IsNullOrEmpty(subObj.LowLimit)
+               && string.IsNullOrEmpty(subObj.HighLimit)
+               && !HasNonCompactExclusiveFields(subObj)
+               && (string.IsNullOrEmpty(subObj.ParameterName)
+                   || subObj.ParameterName.Equals("NrOfObjects", StringComparison.Ordinal));
+    }
+
+    private static bool MatchesCompactElementTemplate(CanOpenObject parent, CanOpenSubObject subObj)
+    {
+        var expectedDataType = parent.DataType ?? 0;
+        return subObj.ObjectType == CanOpenObjectType.Var
+               && subObj.DataType == expectedDataType
+               && subObj.AccessType == parent.AccessType
+               && string.Equals(subObj.DefaultValue, parent.DefaultValue, StringComparison.Ordinal)
+               && subObj.PdoMapping == parent.PdoMapping
+               && string.IsNullOrEmpty(subObj.LowLimit)
+               && string.IsNullOrEmpty(subObj.HighLimit);
+    }
+
+    private static bool HasNonCompactExclusiveFields(CanOpenSubObject subObj)
+        => subObj.SrdoMapping
+           || !string.IsNullOrEmpty(subObj.InvertedSrad)
+           || !string.IsNullOrEmpty(subObj.ParamRefd);
+
+    private static void WriteCompactNameSection(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
+        var names = new SortedDictionary<byte, string>();
+        for (var i = 1; i <= compactMax; i++)
+        {
+            var subIndex = (byte)i;
+            if (expandedSubIndexes.Contains(subIndex))
+                continue;
+            if (!obj.SubObjects.TryGetValue(subIndex, out var subObj))
+                continue;
+
+            var defaultName = string.Concat(
+                obj.ParameterName,
+                subIndex.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrEmpty(subObj.ParameterName)
+                && !subObj.ParameterName.Equals(defaultName, StringComparison.Ordinal))
+            {
+                names[subIndex] = subObj.ParameterName;
+            }
+        }
+
+        if (names.Count == 0)
+            return;
+
+        var sectionName = string.Format(CultureInfo.InvariantCulture, "{0:X}Name", obj.Index);
+        writeSection(
+            sectionName,
+            () =>
+            {
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "[{0:X}Name]", obj.Index));
+                WriteKeyValue(sb, "NrOfEntries", names.Count.ToString(CultureInfo.InvariantCulture));
+                foreach (var entry in names)
+                {
+                    WriteKeyValue(sb, entry.Key.ToString(CultureInfo.InvariantCulture), entry.Value);
+                }
+
+                sb.AppendLine();
+            });
+    }
+
+    /// <summary>
+    /// Writes compact <c>[xxxxValue]</c> / <c>[xxxxDenotation]</c> lists.
+    /// EDS: no-op. DCF: emits ParameterValue and Denotation for non-expanded subs.
+    /// </summary>
+    protected virtual void WriteCompactValueAndDenotationSections(
+        StringBuilder sb,
+        CanOpenObject obj,
+        int compactMax,
+        HashSet<byte> expandedSubIndexes,
+        Action<string, Action> writeSection)
+    {
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -621,6 +621,66 @@ public class DcfWriterTests
     }
 
     [Fact]
+    public void GenerateString_CompactSubObj_PreservesSubNumberForExpandedBeyondCompactRange()
+    {
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 2,
+            SubNumber = 255
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "2"
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "1"
+        };
+        obj.SubObjects[255] = new CanOpenSubObject
+        {
+            SubIndex = 255,
+            ParameterName = "Identity",
+            ObjectType = 0x7,
+            DataType = 0x0007,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            ParameterValue = "keep"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        var written = _writer.GenerateString(dcf);
+        written.Should().Contain("CompactSubObj=2");
+        written.Should().Contain("SubNumber=255");
+        written.Should().Contain("[2100subFF]");
+        written.Should().Contain("[2100Value]");
+
+        var parsed = new DcfReader().ReadString(written);
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects.Should().ContainKey(255);
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects[255].ParameterValue.Should().Be("keep");
+        parsed.ObjectDictionary.Objects[0x2100].SubObjects[1].ParameterValue.Should().Be("1");
+    }
+
+    [Fact]
     public void GenerateString_OptionalObjects_WritesCorrectly()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -562,6 +562,65 @@ public class DcfWriterTests
     }
 
     [Fact]
+    public void GenerateString_CompactSubObj_ExpandsSub0WhenParameterValueOrDenotationSet()
+    {
+        // Arrange — sub0 matches structural template but carries DCF fields that
+        // cannot be stored in compact [xxxxValue]/[xxxxDenotation] (keys 1..254).
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 1
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "1",
+            PdoMapping = false,
+            ParameterValue = "1",
+            Denotation = "Count"
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "10"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var written = _writer.GenerateString(dcf);
+        var parsed = new DcfReader().ReadString(written);
+
+        // Assert
+        written.Should().Contain("[2100sub0]");
+        written.Should().Contain("ParameterValue=1");
+        written.Should().Contain("Denotation=Count");
+        written.Should().Contain("[2100Value]");
+        written.Should().NotContain("[2100sub1]");
+
+        var roundTripped = parsed.ObjectDictionary.Objects[0x2100];
+        roundTripped.SubObjects[0].ParameterValue.Should().Be("1");
+        roundTripped.SubObjects[0].Denotation.Should().Be("Count");
+        roundTripped.SubObjects[1].ParameterValue.Should().Be("10");
+    }
+
+    [Fact]
     public void GenerateString_OptionalObjects_WritesCorrectly()
     {
         // Arrange

--- a/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/DcfWriterTests.cs
@@ -1,8 +1,10 @@
 namespace EdsDcfNet.Tests.Writers;
 
+using System.Globalization;
 using System.Reflection;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
+using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
 using FluentAssertions;
 using Xunit;
@@ -426,6 +428,137 @@ public class DcfWriterTests
 
         // Assert
         result.Should().Contain("ParameterValue=0x999");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_WritesValueAndDenotationSections()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 3
+        };
+        obj.SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "3",
+            PdoMapping = false
+        };
+        obj.SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "ConfigArray1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "10",
+            Denotation = "Label A"
+        };
+        obj.SubObjects[2] = new CanOpenSubObject
+        {
+            SubIndex = 2,
+            ParameterName = "ConfigArray2",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "20"
+        };
+        obj.SubObjects[3] = new CanOpenSubObject
+        {
+            SubIndex = 3,
+            ParameterName = "ConfigArray3",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            ParameterValue = "30",
+            Denotation = "Label C"
+        };
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var result = _writer.GenerateString(dcf);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=3");
+        result.Should().NotContain("[2100sub");
+        result.Should().Contain("[2100Value]");
+        result.Should().Contain("NrOfEntries=3");
+        result.Should().Contain("1=10");
+        result.Should().Contain("2=20");
+        result.Should().Contain("3=30");
+        result.Should().Contain("[2100Denotation]");
+        result.Should().Contain("1=Label A");
+        result.Should().Contain("3=Label C");
+        result.Should().NotContain("ParameterValue=10");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_ValidatedRoundTrip_PreservesValuesAndDenotations()
+    {
+        // Arrange
+        var dcf = CreateMinimalDcf();
+        dcf.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        var obj = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "ConfigArray",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadWrite,
+            DefaultValue = "0",
+            PdoMapping = true,
+            CompactSubObj = 2
+        };
+        for (byte i = 0; i <= 2; i++)
+        {
+            obj.SubObjects[i] = new CanOpenSubObject
+            {
+                SubIndex = i,
+                ParameterName = i == 0 ? "NrOfObjects" : "ConfigArray" + i.ToString(CultureInfo.InvariantCulture),
+                ObjectType = 0x7,
+                DataType = 0x0005,
+                AccessType = i == 0 ? AccessType.ReadOnly : AccessType.ReadWrite,
+                DefaultValue = i == 0 ? "2" : "0",
+                PdoMapping = i != 0,
+                ParameterValue = i == 0 ? null : (i * 10).ToString(CultureInfo.InvariantCulture),
+                Denotation = i == 0 ? null : "Label " + i.ToString(CultureInfo.InvariantCulture)
+            };
+        }
+        dcf.ObjectDictionary.Objects[0x2100] = obj;
+
+        // Act
+        var written = _writer.GenerateString(dcf);
+        var parsed = new DcfReader().ReadString(written);
+
+        // Assert
+        written.Should().Contain("[2100Value]");
+        written.Should().Contain("[2100Denotation]");
+        written.Should().NotContain("[2100sub");
+
+        var roundTripped = parsed.ObjectDictionary.Objects[0x2100];
+        roundTripped.CompactSubObj.Should().Be(2);
+        roundTripped.SubObjects.Should().HaveCount(3);
+        roundTripped.SubObjects[1].ParameterValue.Should().Be("10");
+        roundTripped.SubObjects[2].ParameterValue.Should().Be("20");
+        roundTripped.SubObjects[1].Denotation.Should().Be("Label 1");
+        roundTripped.SubObjects[2].Denotation.Should().Be("Label 2");
+        roundTripped.SubObjects[1].PdoMapping.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
+++ b/tests/EdsDcfNet.Tests/Writers/EdsWriterTests.cs
@@ -216,7 +216,6 @@ public class EdsWriterTests
             SrdoMapping = true,
             InvertedSrad = "0x2000",
             ObjFlags = 0x10,
-            CompactSubObj = 2,
             SubNumber = 1
         };
 
@@ -248,11 +247,121 @@ public class EdsWriterTests
         result.Should().Contain("SRDOMapping=1");
         result.Should().Contain("InvertedSRAD=0x2000");
         result.Should().Contain("ObjFlags=0x10");
-        result.Should().Contain("CompactSubObj=2");
         result.Should().Contain("[2000sub1]");
         result.Should().Contain("LowLimit=0");
         result.Should().Contain("HighLimit=5");
         result.Should().Contain("InvertedSRAD=0x3000");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_OmitsRedundantSubsAndWritesNameSection()
+    {
+        // Arrange
+        var eds = CreateMinimalEds();
+        eds.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        eds.ObjectDictionary.Objects[0x2100] = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "StatusBits",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true,
+            CompactSubObj = 2,
+            SubNumber = 2 // must be omitted in compact form
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "NrOfObjects",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "2",
+            PdoMapping = false
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "FirstBit",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[2] = new CanOpenSubObject
+        {
+            SubIndex = 2,
+            ParameterName = "StatusBits2",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = true
+        };
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("CompactSubObj=2");
+        result.Should().NotContain("SubNumber=");
+        result.Should().NotContain("[2100sub0]");
+        result.Should().NotContain("[2100sub1]");
+        result.Should().NotContain("[2100sub2]");
+        result.Should().Contain("[2100Name]");
+        result.Should().Contain("NrOfEntries=1");
+        result.Should().Contain("1=FirstBit");
+        result.Should().NotContain("2=StatusBits2");
+    }
+
+    [Fact]
+    public void GenerateString_CompactSubObj_ExpandsSub0WhenNameDiffersFromTemplate()
+    {
+        // Arrange
+        var eds = CreateMinimalEds();
+        eds.ObjectDictionary.ManufacturerObjects.Add(0x2100);
+        eds.ObjectDictionary.Objects[0x2100] = new CanOpenObject
+        {
+            Index = 0x2100,
+            ParameterName = "StatusBits",
+            ObjectType = 0x8,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = false,
+            CompactSubObj = 1
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[0] = new CanOpenSubObject
+        {
+            SubIndex = 0,
+            ParameterName = "Number of Elements",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "1",
+            PdoMapping = false
+        };
+        eds.ObjectDictionary.Objects[0x2100].SubObjects[1] = new CanOpenSubObject
+        {
+            SubIndex = 1,
+            ParameterName = "StatusBits1",
+            ObjectType = 0x7,
+            DataType = 0x0005,
+            AccessType = AccessType.ReadOnly,
+            DefaultValue = "0",
+            PdoMapping = false
+        };
+
+        // Act
+        var result = _writer.GenerateString(eds);
+
+        // Assert
+        result.Should().Contain("[2100sub0]");
+        result.Should().Contain("ParameterName=Number of Elements");
+        result.Should().NotContain("[2100sub1]");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- When `CompactSubObj > 0`, writers omit redundant expanded `[xxxsubN]` sections and emit compact `[xxxxName]` (EDS/DCF) plus `[xxxxValue]` / `[xxxxDenotation]` (DCF) per CiA 306.
- `SubNumber` is omitted under compact storage.
- Sub-objects that cannot be represented in compact form (limits, SRDO, ParamRefd, template mismatches, custom sub0) still expand.

Fixes #406

**Depends on:** #433 (reader synthesis) — this PR is stacked on `fix/405-compact-subobj-synthesize`. After #433 merges, retarget base to `develop`.

## Test plan
- [x] EDS compact write omits redundant subs + writes `[xxxxName]` for overrides
- [x] Custom sub0 name still expands `[xxxsub0]`
- [x] DCF writes `[xxxxValue]` / `[xxxxDenotation]` without inline ParameterValue
- [x] Validated round-trip preserves values/denotations after compact write+read
- [x] Full suite: 1588 passed

### Boundary & regression matrix

| Dimension | What to cover | This PR |
|---|---|---|
| Numeric boundaries | CompactSubObj list range 1..254 | writer caps compact max at 254 (shared with #433) |
| Round-trip fidelity | DCF compact write → read | `GenerateString_CompactSubObj_ValidatedRoundTrip_PreservesValuesAndDenotations` |
| Validation modes | n/a | write-path shape; Validated not required for compact lists |
| Representative fixtures | kitchen-sink optional fields | CompactSubObj removed from unrelated optional-fields test; dedicated compact tests added |
| API contract assertions | n/a | no public signature change |


Made with [Cursor](https://cursor.com)