### PR TITLE
fix(parsers): require hex sub-index in IsSubObjectSection (#412)

### DIFF
--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -518,10 +518,34 @@ public abstract class CanOpenReaderBase
         if (suffix.Length == 0)
             return false;
 
-        return ushort.TryParse(prefix, NumberStyles.HexNumber,
+        // AllowHexSpecifier (not HexNumber): reject whitespace so names like
+        // "[1000sub 1]" are preserved in AdditionalSections rather than treated as known.
+        // Also reject an optional 0x prefix by requiring hex digits only first.
+        if (!IsHexDigitsOnly(prefix) || !IsHexDigitsOnly(suffix))
+            return false;
+
+        return ushort.TryParse(prefix, NumberStyles.AllowHexSpecifier,
                    CultureInfo.InvariantCulture, out _)
-               && byte.TryParse(suffix, NumberStyles.HexNumber,
+               && byte.TryParse(suffix, NumberStyles.AllowHexSpecifier,
                    CultureInfo.InvariantCulture, out _);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is non-empty and
+    /// consists solely of hexadecimal digits (no whitespace, no <c>0x</c> prefix).
+    /// </summary>
+    private static bool IsHexDigitsOnly(string value)
+    {
+        foreach (var c in value)
+        {
+            var isHexDigit = (c >= '0' && c <= '9') ||
+                             (c >= 'a' && c <= 'f') ||
+                             (c >= 'A' && c <= 'F');
+            if (!isHexDigit)
+                return false;
+        }
+
+        return value.Length > 0;
     }
 
     /// <summary>

--- a/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
+++ b/src/EdsDcfNet/Parsers/CanOpenReaderBase.cs
@@ -504,6 +504,8 @@ public abstract class CanOpenReaderBase
 
     /// <summary>
     /// Checks if a section name matches the sub-object pattern: {HexIndex}sub{HexSubIndex}.
+    /// The suffix after <c>sub</c> must be a valid hex sub-index (and nothing else),
+    /// matching <see cref="ParseSubObject"/> section naming.
     /// </summary>
     protected static bool IsSubObjectSection(string sectionName)
     {
@@ -512,8 +514,14 @@ public abstract class CanOpenReaderBase
             return false;
 
         var prefix = sectionName[..subPos];
+        var suffix = sectionName[(subPos + 3)..];
+        if (suffix.Length == 0)
+            return false;
+
         return ushort.TryParse(prefix, NumberStyles.HexNumber,
-            CultureInfo.InvariantCulture, out _);
+                   CultureInfo.InvariantCulture, out _)
+               && byte.TryParse(suffix, NumberStyles.HexNumber,
+                   CultureInfo.InvariantCulture, out _);
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1838,6 +1838,23 @@ VendorKey=SpacedSuffix
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubIndexOverflow_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "10000" is hex digits but does not fit in ushort (covers TryParse false branch)
+        var content = BuildMinimalDcf(extraSections: @"
+[10000sub0]
+VendorKey=OverflowPrefix
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("10000sub0");
+        result.AdditionalSections["10000sub0"]["VendorKey"].Should().Be("OverflowPrefix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section (no digit after "M")

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1821,6 +1821,23 @@ VendorKey=EmptySuffix
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubWithWhitespace_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - HexNumber would accept " 1", but ParseSubObject only looks up "1000sub1"
+        var content = BuildMinimalDcf(extraSections: @"
+[1000sub 1]
+VendorKey=SpacedSuffix
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert - must round-trip via AdditionalSections, not be swallowed as known
+        result.AdditionalSections.Should().ContainKey("1000sub 1");
+        result.AdditionalSections["1000sub 1"]["VendorKey"].Should().Be("SpacedSuffix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section (no digit after "M")

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1786,6 +1786,23 @@ VendorKey=VendorData
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubExtra_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "[1000subExtra]" has a hex prefix + "sub" but the suffix is not a hex sub-index
+        var content = BuildMinimalDcf(extraSections: @"
+[1000subExtra]
+VendorKey=VendorData
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert - custom hex-prefixed "sub*" names must round-trip via AdditionalSections
+        result.AdditionalSections.Should().ContainKey("1000subExtra");
+        result.AdditionalSections["1000subExtra"]["VendorKey"].Should().Be("VendorData");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section (no digit after "M")

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -1803,6 +1803,23 @@ VendorKey=VendorData
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubEmptySuffix_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "[1000sub]" has a hex prefix + "sub" but an empty suffix
+        var content = BuildMinimalDcf(extraSections: @"
+[1000sub]
+VendorKey=EmptySuffix
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("1000sub");
+        result.AdditionalSections["1000sub"]["VendorKey"].Should().Be("EmptySuffix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section (no digit after "M")

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -1946,6 +1946,38 @@ VendorKey=EmptySuffix
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubWithWhitespace_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - HexNumber would accept " 1", but ParseSubObject only looks up "1000sub1"
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+
+[1000sub 1]
+VendorKey=SpacedSuffix
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert - must round-trip via AdditionalSections, not be swallowed as known
+        result.AdditionalSections.Should().ContainKey("1000sub 1");
+        result.AdditionalSections["1000sub 1"]["VendorKey"].Should().Be("SpacedSuffix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -1914,6 +1914,38 @@ VendorKey=VendorData
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubEmptySuffix_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "[1000sub]" ends with "sub" and has no hex sub-index suffix
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+
+[1000sub]
+VendorKey=EmptySuffix
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert - empty suffix after "sub" must not be treated as a known sub-object
+        result.AdditionalSections.Should().ContainKey("1000sub");
+        result.AdditionalSections["1000sub"]["VendorKey"].Should().Be("EmptySuffix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -1871,6 +1871,49 @@ VendorKey=VendorData
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubExtra_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "[1000subExtra]" has a hex prefix + "sub" but the suffix is not a hex sub-index
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+
+[1000sub0]
+ParameterName=Highest sub-index
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x00
+PDOMapping=0
+
+[1000subExtra]
+VendorKey=VendorData
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert - custom hex-prefixed "sub*" names must round-trip via AdditionalSections
+        result.AdditionalSections.Should().ContainKey("1000subExtra");
+        result.AdditionalSections["1000subExtra"]["VendorKey"].Should().Be("VendorData");
+        // Valid [1000sub0] remains known (not dumped into AdditionalSections)
+        result.AdditionalSections.Should().NotContainKey("1000sub0");
+        result.ObjectDictionary.Objects.Should().ContainKey((ushort)0x1000);
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section

--- a/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/EdsReaderTests.cs
@@ -1978,6 +1978,38 @@ VendorKey=SpacedSuffix
     }
 
     [Fact]
+    public void ReadString_HexPrefixedSubIndexOverflow_NotSubObject_PreservedInAdditionalSections()
+    {
+        // Arrange - "10000" is hex digits but does not fit in ushort (covers TryParse false branch)
+        var content = @"
+[DeviceInfo]
+VendorName=Test
+
+[MandatoryObjects]
+SupportedObjects=1
+1=0x1000
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x191
+PDOMapping=0
+
+[10000sub0]
+VendorKey=OverflowPrefix
+";
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        result.AdditionalSections.Should().ContainKey("10000sub0");
+        result.AdditionalSections["10000sub0"]["VendorKey"].Should().Be("OverflowPrefix");
+    }
+
+    [Fact]
     public void ReadString_SectionStartingWithM_NotModule_PreservedInAdditionalSections()
     {
         // Arrange - "Manufacturing" starts with "M" but is NOT a module section


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #412.

`IsSubObjectSection` previously treated any section whose name contained `sub` after a hex prefix as known (e.g. `[1000subExtra]`), so those sections were excluded from `AdditionalSections` but never parsed as real sub-objects — silent round-trip loss.

This tightens the match so the suffix after `sub` must be a valid hex sub-index (and nothing else), aligning with `ParseSubObject` naming.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] Targeted parser tests for `[1000subExtra]`, `[SubSystem]`, and valid `[1018sub1]` pass
- [ ] `dotnet test --configuration Release` passes locally
- [ ] `dotnet build --configuration Release` passes locally (required when public API or XML docs changed)

### Boundary & regression matrix

| Area | Covered |
|------|---------|
| Section name classification | `[1000subExtra]` → AdditionalSections; `[1000sub0]` / `[1018sub1]` remain known |
| Round-trip fidelity (EDS/DCF) | Custom hex-prefixed `sub*` vendor sections preserved |
| Regression | Existing `SubSystem` (no hex prefix) still preserved |
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785941429272829?thread_ts=1785941429.272829&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-afeccd4b-ca4f-5028-868d-310d67f64f2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afeccd4b-ca4f-5028-868d-310d67f64f2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

