### PR TITLE
fix(xdd): reject unknown baud rates under StrictParsing (#414)

### DIFF
--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -38,6 +38,7 @@ flowchart TD
 - **Optional fields**: Missing optional values result in `null` or default values.
 - **Unknown INI sections**: Preserved in `AdditionalSections` (no warning, no error).
 - **Duplicate INI keys**: Last write wins by default. With `CanOpenFileOptions.StrictParsing = true` (or `IniParser` `strictParsing: true`), duplicates throw `EdsParseException`.
+- **XDD/XDC baud-rate strings**: Unknown `supportedBaudRate`, `actualBaudRate`, and `baudRate/@defaultValue` values map to `0` / are ignored by default. With `StrictParsing = true`, they throw `EdsParseException`.
 - **CiA 311 XML**: Parsed against supported profile structures; unsupported XML nodes are not represented as generic passthrough data.
 
 ### Input Size Limits

--- a/src/EdsDcfNet/CanOpenFileOptions.cs
+++ b/src/EdsDcfNet/CanOpenFileOptions.cs
@@ -37,6 +37,7 @@ public sealed class CanOpenFileOptions
     /// <para>Currently enforced for:</para>
     /// <list type="bullet">
     /// <item><description>Duplicate keys within an INI section (default: last write wins)</description></item>
+    /// <item><description>Unknown XDD/XDC baud-rate strings (default: treat as 0 / ignore)</description></item>
     /// </list>
     /// Additional coercion sites may join this switch in follow-up work (see issue #428).
     /// </remarks>

--- a/src/EdsDcfNet/CanOpenFileOptions.cs
+++ b/src/EdsDcfNet/CanOpenFileOptions.cs
@@ -37,7 +37,7 @@ public sealed class CanOpenFileOptions
     /// <para>Currently enforced for:</para>
     /// <list type="bullet">
     /// <item><description>Duplicate keys within an INI section (default: last write wins)</description></item>
-    /// <item><description>Unknown XDD/XDC baud-rate strings (default: treat as 0 / ignore)</description></item>
+    /// <item><description>Unknown XDD/XDC baud-rate strings on <c>supportedBaudRate</c>, <c>actualBaudRate</c>, and <c>baudRate/@defaultValue</c> (default: treat as 0 / ignore)</description></item>
     /// </list>
     /// Additional coercion sites may join this switch in follow-up work (see issue #428).
     /// </remarks>

--- a/src/EdsDcfNet/Parsers/XddCommNetProfileParser.cs
+++ b/src/EdsDcfNet/Parsers/XddCommNetProfileParser.cs
@@ -283,6 +283,12 @@ internal static class XddCommNetProfileParser
         if (baudRate == null)
             return;
 
+        // defaultValue is not mapped into DeviceInfo (write-only on emit), but under
+        // StrictParsing it must still match the CiA 311 baud vocabulary.
+        var defaultValue = baudRate.Attribute("defaultValue")?.Value;
+        if (!string.IsNullOrEmpty(defaultValue))
+            ParseBaudRateString(defaultValue);
+
         foreach (var supported in baudRate.Elements()
             .Where(e => e.Name.LocalName == "supportedBaudRate"))
         {

--- a/src/EdsDcfNet/Parsers/XddCommNetProfileParser.cs
+++ b/src/EdsDcfNet/Parsers/XddCommNetProfileParser.cs
@@ -285,8 +285,8 @@ internal static class XddCommNetProfileParser
 
         // defaultValue is not mapped into DeviceInfo (write-only on emit), but under
         // StrictParsing it must still match the CiA 311 baud vocabulary.
-        var defaultValue = baudRate.Attribute("defaultValue")?.Value;
-        if (!string.IsNullOrEmpty(defaultValue))
+        var defaultValue = baudRate.Attribute("defaultValue")?.Value ?? string.Empty;
+        if (defaultValue.Length > 0)
             ParseBaudRateString(defaultValue);
 
         foreach (var supported in baudRate.Elements()

--- a/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
+++ b/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
@@ -148,6 +148,8 @@ internal static class XddParsingPrimitives
             return 0;
 
         value = value.Trim();
+        if (value.Length == 0)
+            return 0;
 
         if (value.Equals("10 Kbps", StringComparison.OrdinalIgnoreCase)) return 10;
         if (value.Equals("20 Kbps", StringComparison.OrdinalIgnoreCase)) return 20;

--- a/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
+++ b/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
@@ -131,6 +131,17 @@ internal static class XddParsingPrimitives
                value.Equals("1", StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Parses a CiA 311 baud-rate vocabulary string such as <c>250 Kbps</c>.
+    /// </summary>
+    /// <remarks>
+    /// Supported values (case-insensitive):
+    /// <c>10 Kbps</c>, <c>20 Kbps</c>, <c>50 Kbps</c>, <c>125 Kbps</c>,
+    /// <c>250 Kbps</c>, <c>500 Kbps</c>, <c>800 Kbps</c>, <c>1000 Kbps</c>.
+    /// Empty input returns <c>0</c>. Unknown non-empty values return <c>0</c> when
+    /// lenient, or throw <see cref="EdsParseException"/> when
+    /// <see cref="StrictParsingScope"/> is enabled.
+    /// </remarks>
     internal static ushort ParseBaudRateString(string value)
     {
         if (string.IsNullOrEmpty(value))
@@ -146,6 +157,15 @@ internal static class XddParsingPrimitives
         if (value.Equals("500 Kbps", StringComparison.OrdinalIgnoreCase)) return 500;
         if (value.Equals("800 Kbps", StringComparison.OrdinalIgnoreCase)) return 800;
         if (value.Equals("1000 Kbps", StringComparison.OrdinalIgnoreCase)) return 1000;
+
+        if (StrictParsingScope.IsEnabled)
+        {
+            throw new EdsParseException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Unknown baud-rate string '{0}'. Expected one of: 10 Kbps, 20 Kbps, 50 Kbps, 125 Kbps, 250 Kbps, 500 Kbps, 800 Kbps, 1000 Kbps.",
+                    value));
+        }
 
         return 0;
     }

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1201,6 +1201,32 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void ParseBaudRates_MissingDefaultValueAttribute_StillParsesSupportedRates()
+    {
+        // Covers Attribute("defaultValue")?.Value null path and Length == 0 skip
+        var xdd = MinimalXdd.Replace(
+            @"<baudRate defaultValue=""250 Kbps"">",
+            "<baudRate>");
+
+        var result = _reader.ReadString(xdd);
+
+        result.DeviceInfo.SupportedBaudRates.BaudRate250.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate500.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseBaudRates_EmptyDefaultValue_StrictParsing_DoesNotThrow()
+    {
+        var xdd = MinimalXdd.Replace(
+            @"defaultValue=""250 Kbps""",
+            @"defaultValue=""""");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void ParseBaudRateString_WhitespaceOnly_IsTreatedAsEmpty()
     {
         var xdd = MinimalXdd.Replace(

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1174,6 +1174,45 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void ParseBaudRates_UnknownDefaultValue_StrictParsing_ThrowsEdsParseException()
+    {
+        // defaultValue is not mapped into DeviceInfo, but StrictParsing still validates vocabulary
+        var xdd = MinimalXdd.Replace(
+            @"defaultValue=""250 Kbps""",
+            @"defaultValue=""999 Kbps""");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*Unknown baud-rate string '999 Kbps'*");
+    }
+
+    [Fact]
+    public void ParseBaudRates_UnknownDefaultValue_Lenient_Succeeds()
+    {
+        var xdd = MinimalXdd.Replace(
+            @"defaultValue=""250 Kbps""",
+            @"defaultValue=""999 Kbps""");
+
+        var result = _reader.ReadString(xdd);
+
+        result.DeviceInfo.SupportedBaudRates.BaudRate250.Should().BeTrue();
+        result.DeviceInfo.SupportedBaudRates.BaudRate500.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseBaudRateString_WhitespaceOnly_IsTreatedAsEmpty()
+    {
+        var xdd = MinimalXdd.Replace(
+            "<supportedBaudRate value=\"500 Kbps\"/>",
+            "<supportedBaudRate value=\"   \"/>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void ParseDeviceCommissioning_UnknownActualBaudRate_StrictParsing_ThrowsEdsParseException()
     {
         const string xdc = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1161,6 +1161,58 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void ParseBaudRates_UnknownBaudRate_StrictParsing_ThrowsEdsParseException()
+    {
+        var xdd = MinimalXdd.Replace(
+            "<supportedBaudRate value=\"500 Kbps\"/>",
+            "<supportedBaudRate value=\"999 Kbps\"/>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*Unknown baud-rate string '999 Kbps'*");
+    }
+
+    [Fact]
+    public void ParseDeviceCommissioning_UnknownActualBaudRate_StrictParsing_ThrowsEdsParseException()
+    {
+        const string xdc = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<ISO15745ProfileContainer xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <ISO15745Profile>
+    <ProfileHeader><ProfileClassID>Device</ProfileClassID></ProfileHeader>
+    <ProfileBody xsi:type=""ProfileBody_Device_CANopen"" fileName=""t.xdc"" fileVersion=""1"">
+      <DeviceIdentity><vendorName>V</vendorName><vendorID>0x1</vendorID><productName>P</productName><productID>0x1</productID></DeviceIdentity>
+      <DeviceManager/><DeviceFunction/>
+    </ProfileBody>
+  </ISO15745Profile>
+  <ISO15745Profile>
+    <ProfileHeader><ProfileClassID>CommunicationNetwork</ProfileClassID></ProfileHeader>
+    <ProfileBody xsi:type=""ProfileBody_CommunicationNetwork_CANopen"" fileName=""t.xdc"" fileVersion=""1"">
+      <ApplicationLayers>
+        <CANopenObjectList mandatoryObjects=""0"" optionalObjects=""0"" manufacturerObjects=""0"">
+          <CANopenObject index=""1000"" name=""Device Type"" objectType=""7"" dataType=""0007""
+                         accessType=""ro"" PDOmapping=""no""/>
+        </CANopenObjectList>
+      </ApplicationLayers>
+      <TransportLayers><PhysicalLayer><baudRate defaultValue=""250 Kbps""/></PhysicalLayer></TransportLayers>
+      <NetworkManagement>
+        <CANopenGeneralFeatures granularity=""8"" nrOfRxPDO=""0"" nrOfTxPDO=""0""
+                                bootUpSlave=""false"" layerSettingServiceSlave=""false""
+                                groupMessaging=""false"" dynamicChannels=""0""/>
+        <CANopenMasterFeatures bootUpMaster=""false""/>
+        <deviceCommissioning nodeID=""1"" networkNumber=""0"" CANopenManager=""false"" actualBaudRate=""777 Kbps""/>
+      </NetworkManagement>
+    </ProfileBody>
+  </ISO15745Profile>
+</ISO15745ProfileContainer>";
+
+        var act = () => CanOpenFile.Xdc.ReadString(xdc, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*Unknown baud-rate string '777 Kbps'*");
+    }
+
+    [Fact]
     public void ParseDeviceCommissioning_HexNodeId_ParsedViaXdcReader()
     {
         // XDC with nodeID="0x05" (hex prefix) — covers the hex-parse branch in ParseDeviceCommissioning


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #414.

Unknown non-empty XDD/XDC baud-rate strings still map to `0` when lenient. With `CanOpenFileOptions.StrictParsing`, `ParseBaudRateString` throws `EdsParseException` listing the supported `N Kbps` vocabulary.

Covered paths:
- `supportedBaudRate/@value`
- `deviceCommissioning/@actualBaudRate`
- `baudRate/@defaultValue` (validated under StrictParsing even though not mapped into `DeviceInfo`)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [x] Documentation (`docs:`)
- [x] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes (uses existing `CanOpenFileOptions.StrictParsing` from #413)
- [ ] **Yes**

## Testing

### Boundary & regression matrix

| Area | Covered |
|------|---------|
| Lenient unknown supportedBaudRate | → 0 / ignored |
| Strict unknown supportedBaudRate | Throws |
| Strict unknown actualBaudRate | Throws |
| Strict unknown baudRate/@defaultValue | Throws |
| Lenient unknown defaultValue | Succeeds (supported rates still parsed) |
| Whitespace-only baud string | Treated as empty |
| Known vocabulary | Still parses |
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785941429272829?thread_ts=1785941429.272829&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-afeccd4b-ca4f-5028-868d-310d67f64f2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afeccd4b-ca4f-5028-868d-310d67f64f2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

