### PR TITLE
docs(converter): document leading-zero octal decision (#411)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ EDS/DCF file → IniParser → EdsReader/DcfReader → Models → DcfWriter → 
 - **`IniParser`** — low-level INI section/key-value parsing (case-insensitive)
 - **`EdsReader`** / **`DcfReader`** — domain-specific parsers producing `ElectronicDataSheet` / `DeviceConfigurationFile`
 - **`DcfWriter`** — serializes `DeviceConfigurationFile` back to DCF format
-- **`ValueConverter`** — parses integers (decimal/hex `0x`/octal), booleans, `$NODEID` formulas, AccessType enum
+- **`ValueConverter`** — parses integers (decimal/hex `0x`/octal `0`+digit), booleans, `$NODEID` formulas, AccessType enum
 
 ### Key Models
 

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ Rules for adding such an option:
 - ✅ Compact Storage (CompactSubObj, CompactPDO)
 - ✅ Object Links
 - ✅ Modular device concept
-- ✅ Hexadecimal, decimal, and octal numbers
+- ✅ Hexadecimal (`0x`), decimal, and octal (`0`+digit, e.g. `010` → 8 — not padded decimal)
 - ✅ $NODEID formula evaluation (e.g., $NODEID+0x200)
 - ✅ CANopen Safety (EN 50325-5) - SRDOMapping, InvertedSRAD
 - ✅ Comments and additional sections

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -78,18 +78,37 @@ value.ToString();
 
 ## 8.3 Number Format Processing
 
-The `ValueConverter` supports three number formats specified in CiA DS 306:
+The `ValueConverter` (and typed OD conversion via `CanOpenValueConverter`) supports three
+integer literal forms aligned with the C-style conventions used by CiA DS 306 tooling:
 
 ```mermaid
 flowchart TD
     A["Input string"] --> B{"Starts with '0x' or '0X'?"}
     B -->|Yes| C["Parse as hexadecimal<br/>(e.g., 0x1A00)"]
-    B -->|No| D{"Starts with '0' and length > 1?"}
-    D -->|Yes| E["Parse as octal<br/>(e.g., 0177)"]
+    B -->|No| D{"Starts with '0' and length > 1<br/>and second char is a digit?"}
+    D -->|Yes| E["Parse as octal<br/>(e.g., 010 → 8, 0177 → 127)"]
     D -->|No| F{"Starts with '$NODEID'?"}
     F -->|Yes| G["Evaluate $NODEID formula<br/>(e.g., $NODEID+0x200)"]
-    F -->|No| H["Parse as decimal<br/>(e.g., 42)"]
+    F -->|No| H["Parse as decimal<br/>(e.g., 42, 10)"]
 ```
+
+### Leading-zero decision (#411)
+
+| Literal | Interpreted as | Result |
+|---------|----------------|--------|
+| `10` | decimal | 10 |
+| `010` | **octal** | 8 |
+| `08` / `09` | invalid octal | parse error (`EdsParseException`) |
+| `0x10` | hexadecimal | 16 |
+
+**Decision (current major line):** keep automatic octal for `0`+digit. Hexadecimal
+requires an explicit `0x` / `0X` prefix. Zero-padded *decimal* values in real EDS/DCF
+files (for example `DefaultValue=010` meaning ten) are therefore misread unless authors
+use unpadded decimal (`10`) or hex (`0x0A`).
+
+Changing the default to “leading zeros are decimal” would be a **breaking** behavior
+change for callers that rely on C-style octal; that switch is deferred to a planned
+major release or an opt-in parse mode (see issue #428), not done as a silent patch.
 
 ### $NODEID Formula
 

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -373,6 +373,7 @@ public static class CanOpenValueConverter
         }
     }
 
+    // Leading 0 + digit → octal (same rule as ValueConverter; see #411 / docs §8.3).
     private static bool IsOctal(string value) =>
         value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]);
 

--- a/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/CanOpenValueConverter.cs
@@ -24,7 +24,8 @@ public static class CanOpenValueConverter
     /// </param>
     /// <returns>The value represented by the corresponding .NET type.</returns>
     /// <remarks>
-    /// Integer values may use decimal, hexadecimal (<c>0x</c>), octal notation, or
+    /// Integer values may use decimal, hexadecimal (<c>0x</c>), octal notation
+    /// (leading <c>0</c> + digit, C-style / CiA DS 306 — <c>010</c> is 8, not 10), or
     /// <c>$NODEID</c> formulas. Empty or whitespace-only integer literals are treated as zero.
     /// REAL32/REAL64 values must be finite: <c>NaN</c> and literals that saturate to infinity
     /// (for example <c>3.5e40</c> for REAL32) are rejected because EDS/DCF has no

--- a/src/EdsDcfNet/Utilities/ValueConverter.cs
+++ b/src/EdsDcfNet/Utilities/ValueConverter.cs
@@ -17,8 +17,23 @@ public static class ValueConverter
     }
 
     /// <summary>
-    /// Parses an integer value from string (supports decimal, hexadecimal, and octal).
+    /// Parses an integer value from string (supports decimal, hexadecimal <c>0x</c>, and octal).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Base detection (CiA DS 306 / C-style, see architecture docs §8.3 and issue #411):
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>0x</c> / <c>0X</c> prefix → hexadecimal</description></item>
+    /// <item><description>leading <c>0</c> followed by a digit → octal (<c>010</c> is 8, not 10)</description></item>
+    /// <item><description>otherwise → decimal</description></item>
+    /// </list>
+    /// <para>
+    /// Zero-padded decimal literals such as <c>08</c>/<c>09</c> are invalid octal and throw
+    /// <see cref="EdsParseException"/>. Prefer unpadded decimal or an explicit <c>0x</c> prefix
+    /// when authoring EDS/DCF values.
+    /// </para>
+    /// </remarks>
     /// <param name="value">String value to parse</param>
     /// <param name="nodeId">Optional node ID for evaluating $NODEID formulas</param>
     public static uint ParseInteger(string value, byte? nodeId = null)
@@ -223,6 +238,8 @@ public static class ValueConverter
             return (hexDigits, NumericBase.Hexadecimal);
         }
 
+        // Leading 0 + digit → octal (CiA DS 306 / C-style). Not decimal padding.
+        // "010" → 8; "08"/"09" fail as invalid octal. See docs §8.3 / issue #411.
         if (value.Length > 1 && value[0] == '0' && char.IsDigit(value[1]))
             return (value, NumericBase.Octal);
 

--- a/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/DcfReaderTests.cs
@@ -3,6 +3,7 @@ namespace EdsDcfNet.Tests.Parsers;
 using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
+using EdsDcfNet.Utilities;
 
 public class DcfReaderTests
 {
@@ -2439,9 +2440,9 @@ PDOMapping=0
     }
 
     [Fact]
-    public void ReadString_OctalNotation_ParsedCorrectly()
+    public void ReadString_OctalNotation_PreservedAndConvertsAsOctal()
     {
-        // Arrange – Octal notation (0755 style)
+        // Arrange – Octal notation (0755 style); model stores the raw literal
         var content = BuildMinimalDcf(extraSections: @"
 [ManufacturerObjects]
 SupportedObjects=1
@@ -2459,9 +2460,39 @@ PDOMapping=0
         // Act
         var result = _reader.ReadString(content);
 
-        // Assert
+        // Assert — raw string preserved; numeric conversion follows octal (#411 decision)
         var obj = result.ObjectDictionary.Objects[0x2000];
         obj.DefaultValue.Should().Be("0755");
+        ValueConverter.ParseInteger(obj.DefaultValue).Should().Be(493u); // 7*64 + 5*8 + 5
+    }
+
+    [Fact]
+    public void ReadString_PaddedLookingDefaultValue_ConvertsAsOctalNotDecimal()
+    {
+        // Arrange — "010" is a common padded-decimal pitfall; library treats it as octal 8
+        var content = BuildMinimalDcf(extraSections: @"
+[ManufacturerObjects]
+SupportedObjects=1
+1=0x2001
+
+[2001]
+ParameterName=Padded Looking Value
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=010
+PDOMapping=0
+");
+
+        // Act
+        var result = _reader.ReadString(content);
+
+        // Assert
+        var obj = result.ObjectDictionary.Objects[0x2001];
+        obj.DefaultValue.Should().Be("010");
+        ValueConverter.ParseInteger(obj.DefaultValue).Should().Be(8u);
+        ValueConverter.ParseInteger("0x10").Should().Be(16u);
+        ValueConverter.ParseInteger("10").Should().Be(10u);
     }
 
     #endregion

--- a/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
+++ b/tests/EdsDcfNet.Tests/Utilities/ValueConverterTests.cs
@@ -58,6 +58,33 @@ public class ValueConverterTests
         result.Should().Be(expected);
     }
 
+    /// <summary>
+    /// Locks the #411 leading-zero decision: keep C-style octal; hex needs 0x; plain decimal
+    /// has no leading zero. Zero-padded decimals are intentionally NOT treated as decimal.
+    /// </summary>
+    [Theory]
+    [InlineData("10", 10u)]      // plain decimal
+    [InlineData("010", 8u)]      // octal, not padded decimal 10
+    [InlineData("0x10", 16u)]    // hex
+    [InlineData("0X10", 16u)]
+    public void ParseInteger_LeadingZeroDecision_Matrix_ParsesExpected(string input, uint expected)
+    {
+        ValueConverter.ParseInteger(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("08")]
+    [InlineData("09")]
+    public void ParseInteger_PaddedDecimalLookingOctal_ThrowsEdsParseException(string input)
+    {
+        // "08"/"09" look like zero-padded decimals but are invalid octal under the current rule
+        var act = () => ValueConverter.ParseInteger(input);
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage($"*'{input}'*")
+            .WithMessage("*octal literal contains characters outside 0-7*");
+    }
+
     [Theory]
     [InlineData("  123  ", 123u)]
     [InlineData("  0xFF  ", 255u)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #411.

**No behavior change.** Leading-zero numeric literals continue to parse as C-style octal (`010` → 8). Hexadecimal still requires an explicit `0x` prefix.

This records the decision against changing the default (that would be breaking), documents the padded-decimal pitfall (`08`/`09`/`010`), and locks the matrix with tests.

### Decision

| Literal | Result |
|---------|--------|
| `10` | decimal 10 |
| `010` | octal 8 |
| `08` / `09` | `EdsParseException` (invalid octal) |
| `0x10` | hex 16 |

A future major or opt-in parse mode (see #428) may offer decimal-preferring leading zeros; that is explicitly out of scope here.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [x] Documentation (`docs:`)
- [x] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes (XML remarks / comments only; parse behavior unchanged)
- [ ] **Yes**

## Testing

- [x] Leading-zero decision matrix + DCF fixture tests pass
- [ ] `dotnet test --configuration Release` passes locally
- [ ] `dotnet build --configuration Release` passes locally (required when public API or XML docs changed)

### Boundary & regression matrix

| Area | Covered |
|------|---------|
| Plain decimal `10` | → 10 |
| Octal `010` | → 8 |
| Invalid octal `08`/`09` | throws |
| Hex `0x10` | → 16 |
| DCF stored `0755` / `010` | raw preserved; conversion matches rule |
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1785941429272829?thread_ts=1785941429.272829&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-afeccd4b-ca4f-5028-868d-310d67f64f2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afeccd4b-ca4f-5028-868d-310d67f64f2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

