### PR TITLE
ci: share Cobertura coverage gate between build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,68 +50,11 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
 
+    # Shared gate with semantic-release.yml — see tools/enforce-coverage-threshold.sh.
     - name: Enforce coverage threshold
       id: coverage_gate
       shell: bash
-      run: |
-        mapfile -t coverage_files < <(find . -type f -name 'coverage.cobertura.xml' -print | sort)
-        if (( ${#coverage_files[@]} == 0 )); then
-          echo "No coverage.cobertura.xml found."
-          exit 1
-        fi
-
-        coverage_files_csv="$(IFS=,; echo "${coverage_files[*]}")"
-        echo "coverage_files=${coverage_files_csv}" >> "$GITHUB_OUTPUT"
-        echo "Found ${#coverage_files[@]} coverage report(s)."
-
-        total_lines_covered=0
-        total_lines_valid=0
-        for coverage_file in "${coverage_files[@]}"; do
-          lines_covered="$(awk '
-            /<coverage / {
-              if (match($0, /lines-covered="[0-9]+"/)) {
-                value = substr($0, RSTART, RLENGTH)
-                sub(/lines-covered="/, "", value)
-                sub(/"$/, "", value)
-                print value
-                exit
-              }
-            }
-          ' "$coverage_file")"
-          lines_valid="$(awk '
-            /<coverage / {
-              if (match($0, /lines-valid="[0-9]+"/)) {
-                value = substr($0, RSTART, RLENGTH)
-                sub(/lines-valid="/, "", value)
-                sub(/"$/, "", value)
-                print value
-                exit
-              }
-            }
-          ' "$coverage_file")"
-
-          if [[ -z "$lines_covered" || -z "$lines_valid" ]]; then
-            echo "Could not read lines-covered/lines-valid from $coverage_file"
-            exit 1
-          fi
-
-          total_lines_covered=$((total_lines_covered + lines_covered))
-          total_lines_valid=$((total_lines_valid + lines_valid))
-        done
-
-        if (( total_lines_valid == 0 )); then
-          echo "Could not calculate coverage: lines-valid sum is zero."
-          exit 1
-        fi
-
-        coverage_percent="$(awk "BEGIN { printf \"%.2f\", ($total_lines_covered / $total_lines_valid) * 100 }")"
-        echo "Line coverage: ${coverage_percent}% (required: >= ${COVERAGE_MIN_PERCENT}%)"
-        echo "coverage_percent=${coverage_percent}" >> "$GITHUB_OUTPUT"
-
-        awk "BEGIN { exit !($coverage_percent >= $COVERAGE_MIN_PERCENT) }" || {
-          echo "Coverage gate failed."
-          exit 1
-        }
+      run: bash tools/enforce-coverage-threshold.sh .
 
     - name: Upload coverage reports to Codecov
       if: always() && steps.coverage_gate.outputs.coverage_files != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/develop')

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,35 +50,10 @@ jobs:
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
 
+      # Shared gate with build.yml — see tools/enforce-coverage-threshold.sh.
       - name: Enforce coverage threshold
         shell: bash
-        run: |
-          coverage_file="$(find . -type f -name 'coverage.cobertura.xml' -print -quit)"
-          if [[ -z "$coverage_file" ]]; then
-            echo "No coverage.cobertura.xml found."
-            exit 1
-          fi
-
-          line_rate="$(awk '
-            /line-rate="/ {
-              match($0, /line-rate="[^"]+"/)
-              value = substr($0, RSTART + 11, RLENGTH - 12)
-              print value
-              exit
-            }
-          ' "$coverage_file")"
-          if [[ -z "$line_rate" ]]; then
-            echo "Could not read line-rate from $coverage_file"
-            exit 1
-          fi
-
-          coverage_percent="$(awk "BEGIN { printf \"%.2f\", $line_rate * 100 }")"
-          echo "Line coverage: ${coverage_percent}% (required: >= ${COVERAGE_MIN_PERCENT}%)"
-
-          awk "BEGIN { exit !($coverage_percent >= $COVERAGE_MIN_PERCENT) }" || {
-            echo "Coverage gate failed."
-            exit 1
-          }
+        run: bash tools/enforce-coverage-threshold.sh .
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -96,6 +96,15 @@ flowchart LR
     style SR fill:#9B59B6,color:#fff
 ```
 
+### Coverage gate
+
+PR (`build.yml`) and release (`semantic-release.yml`) both run
+`tools/enforce-coverage-threshold.sh` after `dotnet test` with XPlat Code Coverage.
+The script finds every `coverage.cobertura.xml`, sums Cobertura `lines-covered` /
+`lines-valid`, and fails if the weighted line percentage is below
+`COVERAGE_MIN_PERCENT` (95.0). Using one script avoids PR/release gate drift when
+multiple Cobertura files exist.
+
 ### Release Rules
 
 | Commit Type    | Release Impact     |

--- a/tools/enforce-coverage-threshold.sh
+++ b/tools/enforce-coverage-threshold.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Enforce the repository line-coverage gate from Cobertura reports.
+#
+# Used by both .github/workflows/build.yml and semantic-release.yml so PR and
+# release runs apply the same metric.
+#
+# Metric:
+#   Sum lines-covered and lines-valid from every coverage.cobertura.xml under
+#   the search root (sorted paths for stable logs), then:
+#     percent = (sum(lines-covered) / sum(lines-valid)) * 100
+#   Fail if percent < COVERAGE_MIN_PERCENT (default 95.0).
+#
+# Why sum counts instead of averaging line-rate attributes:
+#   Multiple Cobertura files (e.g. one per test host TFM) must be weighted by
+#   lines-valid. Averaging line-rate or taking only the first file can pass PR
+#   CI while failing release (or the reverse) for the same commit.
+#
+# Environment:
+#   COVERAGE_MIN_PERCENT  Minimum allowed percent (default: 95.0)
+#   GITHUB_OUTPUT         When set, writes coverage_files and coverage_percent
+#
+# Usage:
+#   tools/enforce-coverage-threshold.sh [search-root]
+#   search-root defaults to the current working directory.
+set -euo pipefail
+
+search_root="${1:-.}"
+min_percent="${COVERAGE_MIN_PERCENT:-95.0}"
+
+if [[ ! -d "$search_root" ]]; then
+  echo "Search root is not a directory: $search_root" >&2
+  exit 1
+fi
+
+coverage_files=()
+while IFS= read -r coverage_file; do
+  coverage_files+=("$coverage_file")
+done < <(find "$search_root" -type f -name 'coverage.cobertura.xml' -print | sort)
+
+if (( ${#coverage_files[@]} == 0 )); then
+  echo "No coverage.cobertura.xml found under $search_root."
+  exit 1
+fi
+
+# Portable join (Bash 3.2+): comma-separated list for Codecov upload.
+coverage_files_csv=""
+for coverage_file in "${coverage_files[@]}"; do
+  if [[ -z "$coverage_files_csv" ]]; then
+    coverage_files_csv="$coverage_file"
+  else
+    coverage_files_csv="${coverage_files_csv},${coverage_file}"
+  fi
+done
+
+echo "Found ${#coverage_files[@]} coverage report(s)."
+for coverage_file in "${coverage_files[@]}"; do
+  echo "  - $coverage_file"
+done
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "coverage_files=${coverage_files_csv}" >> "$GITHUB_OUTPUT"
+fi
+
+total_lines_covered=0
+total_lines_valid=0
+for coverage_file in "${coverage_files[@]}"; do
+  lines_covered="$(awk '
+    /<coverage / {
+      if (match($0, /lines-covered="[0-9]+"/)) {
+        value = substr($0, RSTART, RLENGTH)
+        sub(/lines-covered="/, "", value)
+        sub(/"$/, "", value)
+        print value
+        exit
+      }
+    }
+  ' "$coverage_file")"
+  lines_valid="$(awk '
+    /<coverage / {
+      if (match($0, /lines-valid="[0-9]+"/)) {
+        value = substr($0, RSTART, RLENGTH)
+        sub(/lines-valid="/, "", value)
+        sub(/"$/, "", value)
+        print value
+        exit
+      }
+    }
+  ' "$coverage_file")"
+
+  if [[ -z "$lines_covered" || -z "$lines_valid" ]]; then
+    echo "Could not read lines-covered/lines-valid from $coverage_file"
+    exit 1
+  fi
+
+  total_lines_covered=$((total_lines_covered + lines_covered))
+  total_lines_valid=$((total_lines_valid + lines_valid))
+done
+
+if (( total_lines_valid == 0 )); then
+  echo "Could not calculate coverage: lines-valid sum is zero."
+  exit 1
+fi
+
+coverage_percent="$(awk "BEGIN { printf \"%.2f\", ($total_lines_covered / $total_lines_valid) * 100 }")"
+echo "Line coverage: ${coverage_percent}% (required: >= ${min_percent}%)"
+echo "Aggregated lines-covered=${total_lines_covered} lines-valid=${total_lines_valid}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "coverage_percent=${coverage_percent}" >> "$GITHUB_OUTPUT"
+fi
+
+awk "BEGIN { exit !($coverage_percent >= $min_percent) }" || {
+  echo "Coverage gate failed."
+  exit 1
+}


### PR DESCRIPTION
## Summary
- Extract the PR coverage gate into `tools/enforce-coverage-threshold.sh` and call it from both `build.yml` and `semantic-release.yml`.
- Always aggregate every `coverage.cobertura.xml` via summed `lines-covered` / `lines-valid` (never first-file `line-rate`), so PR and release apply the same 95% metric.
- Document the shared gate in `docs/architecture/07-deployment-view.md` and the script header.

Fixes #418

## Test plan
- [x] Local fixture proof: two Cobertura files (90/100 + 10/100) → 50.00%; pass at 50%, fail at 95%
- [x] `GITHUB_OUTPUT` writes `coverage_files` CSV and `coverage_percent`
- [x] Empty search root fails clearly
- [ ] CI build job green on this PR
- [x] Codecov upload/status unchanged for PR path
- [x] Confirm release workflow still invokes the same script (review diff)


Made with [Cursor](https://cursor.com)