### PR TITLE
ci: detect Codecov check runs when waiting for patch status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         fail_ci_if_error: true
 
     # Same event gate as the Codecov upload step (PR/develop). Feature-branch
-    # pushes never upload, so waiting for codecov[bot] would burn ~4 minutes.
+    # pushes never upload, so waiting for Codecov would burn ~4 minutes.
     # Still run when coverage_files is empty so a gate failure with no Cobertura
     # reports can post failure (avoids a pending required check); the wait loop
     # below is skipped in that case because upload did not run.
@@ -97,10 +97,14 @@ jobs:
           exit 0
         fi
 
-        # Wait for the Codecov webhook only when upload ran (coverage files
-        # present). With no files, codecov[bot] never posts; waiting wastes ~4m.
+        # Wait for Codecov only when upload ran (coverage files present). With no
+        # files, Codecov never reports; waiting wastes ~4m.
+        # Codecov may report as a commit status (codecov[bot], typical on develop
+        # pushes) or as a Check Run (Codecov GitHub App, typical on PRs). Poll both;
+        # looking only at statuses misses PR check-runs and burns the full timeout.
         # Portable loop (Git Bash on windows-latest may lack `seq`).
-        # Required by the develop branch ruleset integration_id constraint.
+        # Required by the develop branch ruleset integration_id constraint: our
+        # Actions status must be posted after Codecov's report.
         if [[ -n "${{ steps.coverage_gate.outputs.coverage_files }}" ]]; then
           i=1
           while [[ "$i" -le 24 ]]; do
@@ -110,7 +114,13 @@ jobs:
               echo "Codecov webhook status detected (${codecov_bot_status}) after ~$((i * 10))s"
               break
             fi
-            echo "Waiting for Codecov webhook... (attempt $i/24)"
+            codecov_check=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/check-runs" \
+              --jq '[.check_runs[] | select(.name == "codecov/patch" and .app.slug == "codecov" and .status == "completed")][0].conclusion // empty' 2>/dev/null || true)
+            if [[ -n "$codecov_check" ]]; then
+              echo "Codecov check run detected (${codecov_check}) after ~$((i * 10))s"
+              break
+            fi
+            echo "Waiting for Codecov webhook/check... (attempt $i/24)"
             sleep 10
             i=$((i + 1))
           done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

On PRs, Codecov posts `codecov/patch` as a **Check Run** (GitHub App), not as a commit status from `codecov[bot]`. The wait loop in `build.yml` only polled the Statuses API, so it never saw the completed check and always burned ~4 minutes (24×10s) before posting our Actions status.

Example: [run 31184714079](https://github.com/dborgards/eds-dcf-net/actions/runs/31184714079) — Codecov check completed at ~13:55:42, wait ran until attempt 24/24 at ~13:59:05.

This PR also polls completed `codecov/patch` check runs from the Codecov app, while keeping the existing `codecov[bot]` status detection (still used on develop pushes).

Follow-up to #448 (feature-branch skip); that merge did not address PR waits.

## Type of change

- [x] CI / build (`ci:` / `build:`)
- [x] Bug fix (`fix:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [x] Validated jq filters against the failing PR commit (check-run → `success`) and a develop commit (status → `success`)
- [x] Verified on this PR’s CI ([run 31185946163](https://github.com/dborgards/eds-dcf-net/actions/runs/31185946163)): `Codecov check run detected (success) after ~100s` (attempt ~9/24), not the full ~4 minute timeout

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1786110243777549?thread_ts=1786110243.777549&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-15817cda-4239-5e58-a328-5df32c22d57b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15817cda-4239-5e58-a328-5df32c22d57b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

