### PR TITLE
ci: ignore stale Codecov checks when waiting on re-runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,14 @@ jobs:
       shell: bash
       run: bash tools/enforce-coverage-threshold.sh .
 
+    # Timestamp before upload so the wait loop can ignore stale Codecov
+    # statuses/check-runs left on the same SHA from a previous workflow attempt.
+    - name: Record Codecov wait baseline
+      id: codecov_baseline
+      if: always() && steps.coverage_gate.outputs.coverage_files != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/develop')
+      shell: bash
+      run: echo "after=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
     - name: Upload coverage reports to Codecov
       if: always() && steps.coverage_gate.outputs.coverage_files != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/develop')
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
@@ -84,6 +92,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        CODECOV_AFTER: ${{ steps.codecov_baseline.outputs.after }}
       run: |
         outcome="${{ steps.coverage_gate.outcome }}"
         if [[ "$outcome" == "success" ]]; then
@@ -102,6 +111,9 @@ jobs:
         # Codecov may report as a commit status (codecov[bot], typical on develop
         # pushes) or as a Check Run (Codecov GitHub App, typical on PRs). Poll both;
         # looking only at statuses misses PR check-runs and burns the full timeout.
+        # Only accept reports created after CODECOV_AFTER (upload start) so a
+        # workflow re-run on the same SHA does not treat the previous attempt's
+        # completed codecov/patch as done before this upload finishes.
         # Portable loop (Git Bash on windows-latest may lack `seq`).
         # Required by the develop branch ruleset integration_id constraint: our
         # Actions status must be posted after Codecov's report.
@@ -109,13 +121,15 @@ jobs:
           i=1
           while [[ "$i" -le 24 ]]; do
             codecov_bot_status=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/statuses" \
-              --jq '[.[] | select(.context == "codecov/patch" and (.creator.login == "codecov[bot]"))][0].state // empty' 2>/dev/null || true)
+              --jq --arg after "${CODECOV_AFTER}" \
+              '[.[] | select(.context == "codecov/patch" and (.creator.login == "codecov[bot]") and (.created_at // "") >= $after)][0].state // empty' 2>/dev/null || true)
             if [[ -n "$codecov_bot_status" ]]; then
               echo "Codecov webhook status detected (${codecov_bot_status}) after ~$((i * 10))s"
               break
             fi
             codecov_check=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/check-runs" \
-              --jq '[.check_runs[] | select(.name == "codecov/patch" and .app.slug == "codecov" and .status == "completed")][0].conclusion // empty' 2>/dev/null || true)
+              --jq --arg after "${CODECOV_AFTER}" \
+              '[.check_runs[] | select(.name == "codecov/patch" and .app.slug == "codecov" and .status == "completed" and (.completed_at // "") >= $after)][0].conclusion // empty' 2>/dev/null || true)
             if [[ -n "$codecov_check" ]]; then
               echo "Codecov check run detected (${codecov_check}) after ~$((i * 10))s"
               break

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,16 +120,15 @@ jobs:
         if [[ -n "${{ steps.coverage_gate.outputs.coverage_files }}" ]]; then
           i=1
           while [[ "$i" -le 24 ]]; do
+            # Inline CODECOV_AFTER: `gh api --jq` does not support jq --arg.
             codecov_bot_status=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/statuses" \
-              --jq --arg after "${CODECOV_AFTER}" \
-              '[.[] | select(.context == "codecov/patch" and (.creator.login == "codecov[bot]") and (.created_at // "") >= $after)][0].state // empty' 2>/dev/null || true)
+              --jq "[.[] | select(.context == \"codecov/patch\" and (.creator.login == \"codecov[bot]\") and (.created_at // \"\") >= \"${CODECOV_AFTER}\")][0].state // empty" 2>/dev/null || true)
             if [[ -n "$codecov_bot_status" ]]; then
               echo "Codecov webhook status detected (${codecov_bot_status}) after ~$((i * 10))s"
               break
             fi
             codecov_check=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/check-runs" \
-              --jq --arg after "${CODECOV_AFTER}" \
-              '[.check_runs[] | select(.name == "codecov/patch" and .app.slug == "codecov" and .status == "completed" and (.completed_at // "") >= $after)][0].conclusion // empty' 2>/dev/null || true)
+              --jq "[.check_runs[] | select(.name == \"codecov/patch\" and .app.slug == \"codecov\" and .status == \"completed\" and (.completed_at // \"\") >= \"${CODECOV_AFTER}\")][0].conclusion // empty" 2>/dev/null || true)
             if [[ -n "$codecov_check" ]]; then
               echo "Codecov check run detected (${codecov_check}) after ~$((i * 10))s"
               break


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to #456 (Codex review landed after merge): when a PR workflow is re-run for the same head SHA, the wait loop could immediately match a completed `codecov/patch` check/status from the previous attempt, before the current upload produces its report. That lets the Actions status post too early and can violate the `integration_id` ordering constraint.

This PR records a baseline timestamp immediately before the Codecov upload and only accepts:

- `codecov[bot]` statuses with `created_at >= baseline`
- Codecov app check runs with `completed_at >= baseline`

The baseline is inlined into `gh api --jq` expressions (`gh api --jq` does not support jq `--arg`; an earlier draft failed silently and burned the full wait timeout).

## Type of change

- [x] CI / build (`ci:` / `build:`)
- [x] Bug fix (`fix:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [x] YAML syntax validated
- [x] Confirmed `gh api --jq --arg` is rejected; inlined filter returns `success` against a prior commit's check run
- [x] Verified on this PR’s CI ([run 31187816468](https://github.com/dborgards/eds-dcf-net/actions/runs/31187816468)): `Codecov check run detected (success) after ~50s`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1786112199158119?thread_ts=1786112199.158119&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-0548fac6-e200-5f45-9a8a-4eeaea0cd568?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0548fac6-e200-5f45-9a8a-4eeaea0cd568&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

