### PR TITLE
fix: net48-safe string APIs in parameter-name contract tests

### DIFF
--- a/tests/EdsDcfNet.Tests/Integration/FormatEntryPointParameterNameContractTests.cs
+++ b/tests/EdsDcfNet.Tests/Integration/FormatEntryPointParameterNameContractTests.cs
@@ -153,7 +153,7 @@ public class FormatEntryPointParameterNameContractTests
                 return $"IReadOnlyList<{args}>";
 
             var name = type.Name;
-            var tick = name.IndexOf('`', StringComparison.Ordinal);
+            var tick = name.IndexOf('`');
             if (tick >= 0)
                 name = name[..tick];
             return $"{name}<{args}>";
@@ -183,5 +183,5 @@ public class FormatEntryPointParameterNameContractTests
     }
 
     private static string NormalizeNewlines(string text)
-        => text.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd() + "\n";
+        => text.Replace("\r\n", "\n").TrimEnd() + "\n";
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Unblocks [PR #454](https://github.com/dborgards/eds-dcf-net/pull/454) CI: `FormatEntryPointParameterNameContractTests` used `IndexOf(char, StringComparison)` and `Replace(string, string, StringComparison)`, which are unavailable on .NET Framework 4.8 and failed the Windows `net48` build.

Switches to the net48-compatible overloads (`IndexOf(char)` and `Replace(string, string)`). Behavior is unchanged for these ordinal/literal replacements.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] `dotnet build --configuration Release` passes locally for `net10.0` **and** `net48` (reference assemblies)
- [x] `dotnet test --configuration Release -f net10.0 --filter FormatEntryPointParameterNameContractTests` passes

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers/writers/validators/converters

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1786116397577069?thread_ts=1786116397.577069&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-af068363-6e48-5ef9-8453-e950a06e0ef6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af068363-6e48-5ef9-8453-e950a06e0ef6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

