### PR TITLE
fix(parser): honor StrictParsing for XDD accessType and XML bools (#463)

### DIFF
--- a/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
+++ b/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
@@ -208,7 +208,7 @@ private static ApVarDeclaration ParseVarDeclaration(XElement elem)
 
     var signedStr = elem.Attribute("signed")?.Value;
     if (signedStr != null)
-        vd.IsSigned = signedStr.Equals("true", StringComparison.OrdinalIgnoreCase) || signedStr == "1";
+        vd.IsSigned = ParseXmlBool(signedStr);
 
     ApReadLabelGroup(elem, vd.LabelGroup);
     vd.Type = ParseTypeRef(elem);

--- a/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
+++ b/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
@@ -90,14 +90,37 @@ internal static class XddParsingPrimitives
                 value));
     }
 
+    /// <summary>
+    /// Parses a CiA 311 <c>accessType</c> / channel <c>accessType</c> token.
+    /// </summary>
+    /// <remarks>
+    /// Recognized tokens (case-insensitive): <c>const</c>, <c>ro</c>, <c>wo</c>,
+    /// <c>rw</c>, <c>rwr</c>, <c>rww</c>. Empty/whitespace maps to
+    /// <see cref="AccessType.ReadOnly"/> (absent field). Unknown non-empty tokens
+    /// map to <see cref="AccessType.ReadOnly"/> when lenient, or throw
+    /// <see cref="EdsParseException"/> when <see cref="StrictParsingScope"/> is enabled.
+    /// <c>rwr</c>/<c>rww</c> match EDS <see cref="Utilities.ValueConverter.ParseAccessType"/>;
+    /// the XDD writer still emits <c>rw</c> for those model values (no CiA 311 equivalent).
+    /// </remarks>
     internal static AccessType ParseXddAccessType(string value)
     {
-        return value.Trim().ToLowerInvariant() switch
+        var token = value.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(token))
+            return AccessType.ReadOnly;
+
+        return token switch
         {
             "const" => AccessType.Constant,
             "ro" => AccessType.ReadOnly,
             "wo" => AccessType.WriteOnly,
             "rw" => AccessType.ReadWrite,
+            "rwr" => AccessType.ReadWriteInput,
+            "rww" => AccessType.ReadWriteOutput,
+            _ when StrictParsingScope.IsEnabled => throw new EdsParseException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Unknown access type token '{0}'. Expected one of: ro, wo, rw, rwr, rww, const.",
+                    value)),
             _ => AccessType.ReadOnly
         };
     }
@@ -125,10 +148,39 @@ internal static class XddParsingPrimitives
                 value));
     }
 
+    /// <summary>
+    /// Parses an XML boolean attribute (<c>true</c>/<c>false</c>/<c>1</c>/<c>0</c>).
+    /// </summary>
+    /// <remarks>
+    /// Empty/whitespace maps to <see langword="false"/>. Unknown non-empty tokens
+    /// map to <see langword="false"/> when lenient, or throw
+    /// <see cref="EdsParseException"/> when <see cref="StrictParsingScope"/> is enabled.
+    /// </remarks>
     internal static bool ParseXmlBool(string value)
     {
-        return value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("1", StringComparison.Ordinal);
+        value = value.Trim();
+
+        if (string.IsNullOrEmpty(value))
+            return false;
+
+        if (value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("1", StringComparison.Ordinal))
+            return true;
+
+        if (value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("0", StringComparison.Ordinal))
+            return false;
+
+        if (StrictParsingScope.IsEnabled)
+        {
+            throw new EdsParseException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Unknown XML boolean token '{0}'. Expected one of: true, false, 1, 0.",
+                    value));
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
@@ -1,6 +1,8 @@
 namespace EdsDcfNet.Tests.Parsers;
 
 using System.Xml.Linq;
+using EdsDcfNet;
+using EdsDcfNet.Exceptions;
 using EdsDcfNet.Models;
 using EdsDcfNet.Parsers;
 using EdsDcfNet.Writers;
@@ -163,6 +165,41 @@ public class ApplicationProcessTests
         st.VarDeclarations[1].IsSigned.Should().BeTrue();
         st.VarDeclarations[1].InitialValue.Should().Be("0");
         st.VarDeclarations[1].Type!.SimpleTypeName.Should().Be("INT");
+    }
+
+    [Fact]
+    public void Parse_VarDeclaration_SignedUnknown_StrictParsing_ThrowsEdsParseException()
+    {
+        var xdd = WrapInXdd(@"
+<ApplicationProcess>
+  <dataTypeList>
+    <struct name=""S"" uniqueID=""uid_s"">
+      <varDeclaration name=""Val"" uniqueID=""uid_v"" signed=""maybe""><INT/></varDeclaration>
+    </struct>
+  </dataTypeList>
+  <parameterList/>
+</ApplicationProcess>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*XML boolean*maybe*");
+    }
+
+    [Fact]
+    public void Parse_VarDeclaration_SignedUnknown_Lenient_StoresFalse()
+    {
+        var result = ParseAp(@"
+<ApplicationProcess>
+  <dataTypeList>
+    <struct name=""S"" uniqueID=""uid_s"">
+      <varDeclaration name=""Val"" uniqueID=""uid_v"" signed=""maybe""><INT/></varDeclaration>
+    </struct>
+  </dataTypeList>
+  <parameterList/>
+</ApplicationProcess>");
+
+        result.ApplicationProcess!.DataTypeList!.Structs[0].VarDeclarations[0].IsSigned.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1517,6 +1517,8 @@ public class XddReaderTests
     [InlineData("rwr", AccessType.ReadWriteInput)]
     [InlineData("RWW", AccessType.ReadWriteOutput)]
     [InlineData("const", AccessType.Constant)]
+    [InlineData("wo", AccessType.WriteOnly)]
+    [InlineData("rw", AccessType.ReadWrite)]
     public void ParseXddAccessType_KnownTokens_IncludingRwrRww_Parses(string accessType, AccessType expected)
     {
         var xdd = MinimalXdd.Replace(
@@ -1526,6 +1528,19 @@ public class XddReaderTests
         var result = _reader.ReadString(xdd);
 
         result.ObjectDictionary.Objects[0x1000].AccessType.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseXddAccessType_EmptyOrWhitespace_ReturnsReadOnly(string accessType)
+    {
+        XddParsingPrimitives.ParseXddAccessType(accessType).Should().Be(AccessType.ReadOnly);
+
+        using (StrictParsingScope.Enter(true))
+        {
+            XddParsingPrimitives.ParseXddAccessType(accessType).Should().Be(AccessType.ReadOnly);
+        }
     }
 
     [Fact]
@@ -1562,6 +1577,8 @@ public class XddReaderTests
     [InlineData("0", false)]
     [InlineData("true", true)]
     [InlineData("1", true)]
+    [InlineData("FALSE", false)]
+    [InlineData("TRUE", true)]
     public void ParseXmlBool_KnownTokens_StrictParsing_Parses(string token, bool expected)
     {
         var xdd = MinimalXdd.Replace(
@@ -1571,6 +1588,25 @@ public class XddReaderTests
         var result = CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
 
         result.DeviceInfo.SimpleBootUpSlave.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseXmlBool_EmptyOrWhitespace_ReturnsFalse(string token)
+    {
+        XddParsingPrimitives.ParseXmlBool(token).Should().BeFalse();
+
+        using (StrictParsingScope.Enter(true))
+        {
+            XddParsingPrimitives.ParseXmlBool(token).Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void ParseXmlBool_Unknown_Lenient_ReturnsFalse()
+    {
+        XddParsingPrimitives.ParseXmlBool("maybe").Should().BeFalse();
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1513,6 +1513,66 @@ public class XddReaderTests
         result.ObjectDictionary.Objects[0x1000].AccessType.Should().Be(AccessType.ReadOnly);
     }
 
+    [Theory]
+    [InlineData("rwr", AccessType.ReadWriteInput)]
+    [InlineData("RWW", AccessType.ReadWriteOutput)]
+    [InlineData("const", AccessType.Constant)]
+    public void ParseXddAccessType_KnownTokens_IncludingRwrRww_Parses(string accessType, AccessType expected)
+    {
+        var xdd = MinimalXdd.Replace(
+            @"accessType=""ro""",
+            $@"accessType=""{accessType}""");
+
+        var result = _reader.ReadString(xdd);
+
+        result.ObjectDictionary.Objects[0x1000].AccessType.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseXddAccessType_Unknown_StrictParsing_ThrowsEdsParseException()
+    {
+        var xdd = MinimalXdd.Replace(
+            @"accessType=""ro""",
+            @"accessType=""custom""");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*access type*custom*");
+    }
+
+    [Theory]
+    [InlineData("maybe")]
+    [InlineData("yes")]
+    [InlineData("2")]
+    public void ParseXmlBool_Unknown_StrictParsing_ThrowsEdsParseException(string token)
+    {
+        var xdd = MinimalXdd.Replace(
+            @"bootUpSlave=""true""",
+            $@"bootUpSlave=""{token}""");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*XML boolean*" + token + "*");
+    }
+
+    [Theory]
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    public void ParseXmlBool_KnownTokens_StrictParsing_Parses(string token, bool expected)
+    {
+        var xdd = MinimalXdd.Replace(
+            @"bootUpSlave=""true""",
+            $@"bootUpSlave=""{token}""");
+
+        var result = CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        result.DeviceInfo.SimpleBootUpSlave.Should().Be(expected);
+    }
+
     [Fact]
     public void ParseHexIndex_WithPrefix_ParsedCorrectly()
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #463.

`ParseXddAccessType` and `ParseXmlBool` now honor `StrictParsingScope` (via `CanOpenFileOptions.StrictParsing`), matching the EDS `ValueConverter` / baud-rate StrictParsing pattern:

- Unknown `accessType` tokens throw under Strict; remain `ReadOnly` when lenient
- `rwr` / `rww` map to `ReadWriteInput` / `ReadWriteOutput` (same as EDS); XDD writer still emits `rw`
- Unknown XML bool tokens throw under Strict; remain `false` when lenient
- Recognized XML bools: `true` / `false` / `1` / `0`
- Follow-up tests cover empty/whitespace tokens and lenient unknown bools for patch coverage

## Type of change

- [x] Bug fix (`fix:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [x] `dotnet test --configuration Release` passes locally (net10.0 `XddReaderTests`)
- [x] `dotnet build --configuration Release` passes locally

## Boundary & regression matrix

- [x] **Filled** — matrix below completed and tests added

<details>
<summary>Matrix</summary>

| Dimension | What to cover | This PR |
|---|---|---|
| Numeric boundaries | n/a — token parsers, not numeric fields | n/a |
| Round-trip fidelity | rwr/rww read into model; writer still maps to `rw` (existing contract) | covered by known-token + existing writer tests |
| Validation modes | n/a — read-path StrictParsing, not write validation | n/a |
| Representative fixtures | MinimalXdd mutated accessType / bootUpSlave | added |
| API contract assertions | n/a — internal parsers only | n/a |

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fddb5-aae3-70ae-852e-0158a75c9df9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fddb5-aae3-70ae-852e-0158a75c9df9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

