### PR TITLE
fix(ci): use -p:PackageVersion so Windows release pack succeeds

### DIFF
--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -75,11 +75,14 @@ generate_spdx_sbom() {
   echo "SPDX SBOM written to packages/sbom.spdx.json (derived from CycloneDX BOM)"
 }
 
+# Use -p: (not /p:): Git Bash on Windows converts bare /p:... args via MSYS
+# path munging, which turns the property into a second "project" and fails with
+# MSB1008 after the release workflow moved to windows-latest.
 dotnet pack src/EdsDcfNet/EdsDcfNet.csproj \
   --configuration Release \
   --no-restore \
   --output ./packages \
-  /p:PackageVersion="${next_version}"
+  -p:PackageVersion="${next_version}"
 
 dotnet nuget push "./packages/*.nupkg" \
   --api-key "${NUGET_API_KEY}" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Semantic Release on `develop` fails during `dotnet pack` with `MSB1008: Only one project can be specified` (see [run 31220348855](https://github.com/dborgards/eds-dcf-net/actions/runs/31220348855) and the same failure on beta.2).

After #447 moved release to `windows-latest`, Git Bash/MSYS path conversion strips the leading `/` from `/p:PackageVersion=…`, so MSBuild sees a bare `p:PackageVersion=…` token and treats it as a second project. Switch the publish script to `-p:PackageVersion=…`, which is equivalent for `dotnet pack` and is not mangled.

Tags `v1.12.0-beta.2` / `v1.12.0-beta.3` were created by the failed runs without NuGet/GitHub publish completing; the next successful release after merge will be `1.12.0-beta.4`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] PR Build and Test workflow passed ([run 31220903536](https://github.com/dborgards/eds-dcf-net/actions/runs/31220903536))
- [x] `bash -n tools/semantic-release-publish.sh` passes
- [ ] Local `dotnet pack` with `-p:PackageVersion` (agent environment has no .NET SDK; validated via CI build)

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers/writers/validators/converters
- [ ] **Filled** — matrix below completed and tests added

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde28-e725-7517-a75d-1722937e2ca8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde28-e725-7517-a75d-1722937e2ca8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

