### PR TITLE
fix(ci): push explicit nupkg path on Windows release

### DIFF
--- a/tools/semantic-release-publish.sh
+++ b/tools/semantic-release-publish.sh
@@ -84,7 +84,17 @@ dotnet pack src/EdsDcfNet/EdsDcfNet.csproj \
   --output ./packages \
   -p:PackageVersion="${next_version}"
 
-dotnet nuget push "./packages/*.nupkg" \
+# Push an explicit package path. A quoted "./packages/*.nupkg" glob is not
+# expanded by the Windows NuGet CLI (unlike Linux), so push fails with
+# "File does not exist (./packages/*.nupkg)" even after a successful pack.
+# Adjacent .snupkg symbols are published with the .nupkg automatically.
+nupkg="./packages/EdsDcfNet.${next_version}.nupkg"
+if [[ ! -f "$nupkg" ]]; then
+  echo "Expected package not found: ${nupkg}" >&2
+  exit 1
+fi
+
+dotnet nuget push "$nupkg" \
   --api-key "${NUGET_API_KEY}" \
   --source https://api.nuget.org/v3/index.json \
   --skip-duplicate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to #479 / [run 31221317904](https://github.com/dborgards/eds-dcf-net/actions/runs/31221317904).

`dotnet pack` now succeeds with `-p:PackageVersion`, but `dotnet nuget push "./packages/*.nupkg"` fails on `windows-latest` with:

`error: File does not exist (./packages/*.nupkg).`

The package was created (`EdsDcfNet.1.12.0-beta.4.nupkg`). The quoted glob is passed literally; Windows NuGet CLI does not expand it (Linux did). Push the concrete `./packages/EdsDcfNet.${next_version}.nupkg` path instead.

Tag `v1.12.0-beta.4` already exists without a GitHub/NuGet publish; the next successful release after merge will be `1.12.0-beta.5`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] PR Build and Test passed ([run 31221785686](https://github.com/dborgards/eds-dcf-net/actions/runs/31221785686))
- [x] `bash -n tools/semantic-release-publish.sh` passes

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers/writers/validators/converters
- [ ] **Filled** — matrix below completed and tests added

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde28-e725-7517-a75d-1722937e2ca8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde28-e725-7517-a75d-1722937e2ca8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

