### PR TITLE
fix(parser): honor StrictParsing for ApplicationProcess numeric attrs (#484)

### DIFF
--- a/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
+++ b/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
@@ -101,7 +101,7 @@ private static ApArrayType ParseArrayType(XElement elem)
                     CultureInfo.InvariantCulture, out var lo);
                 if (lowerParsed)
                     sr.LowerLimit = lo;
-                RejectFailedNumericAttribute(lowerLimitStr, lowerParsed, "lowerLimit");
+                RejectFailedSignedNumericAttribute(lowerLimitStr, lowerParsed, "lowerLimit");
             }
 
             var upperLimitStr = GetTrimmedAttributeValue(child, "upperLimit");
@@ -111,7 +111,7 @@ private static ApArrayType ParseArrayType(XElement elem)
                     CultureInfo.InvariantCulture, out var hi);
                 if (upperParsed)
                     sr.UpperLimit = hi;
-                RejectFailedNumericAttribute(upperLimitStr, upperParsed, "upperLimit");
+                RejectFailedSignedNumericAttribute(upperLimitStr, upperParsed, "upperLimit");
             }
 
             array.Subranges.Add(sr);
@@ -555,7 +555,7 @@ private static ApVariableRef ParseVariableRef(XElement elem)
                         CultureInfo.InvariantCulture, out var idx);
                     if (idxParsed)
                         vr.MemberRef.Index = idx;
-                    RejectFailedNumericAttribute(idxStr, idxParsed, "index");
+                    RejectFailedSignedNumericAttribute(idxStr, idxParsed, "index");
                 }
                 break;
         }

--- a/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
+++ b/src/EdsDcfNet/Parsers/XddApplicationProcessParser.cs
@@ -93,12 +93,27 @@ private static ApArrayType ParseArrayType(XElement elem)
         if (child.Name.LocalName == "subrange")
         {
             var sr = new ApSubrange();
-            if (long.TryParse(child.Attribute("lowerLimit")?.Value, NumberStyles.Integer,
-                CultureInfo.InvariantCulture, out var lo))
-                sr.LowerLimit = lo;
-            if (long.TryParse(child.Attribute("upperLimit")?.Value, NumberStyles.Integer,
-                CultureInfo.InvariantCulture, out var hi))
-                sr.UpperLimit = hi;
+
+            var lowerLimitStr = GetTrimmedAttributeValue(child, "lowerLimit");
+            if (!string.IsNullOrEmpty(lowerLimitStr))
+            {
+                var lowerParsed = long.TryParse(lowerLimitStr, NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var lo);
+                if (lowerParsed)
+                    sr.LowerLimit = lo;
+                RejectFailedNumericAttribute(lowerLimitStr, lowerParsed, "lowerLimit");
+            }
+
+            var upperLimitStr = GetTrimmedAttributeValue(child, "upperLimit");
+            if (!string.IsNullOrEmpty(upperLimitStr))
+            {
+                var upperParsed = long.TryParse(upperLimitStr, NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var hi);
+                if (upperParsed)
+                    sr.UpperLimit = hi;
+                RejectFailedNumericAttribute(upperLimitStr, upperParsed, "upperLimit");
+            }
+
             array.Subranges.Add(sr);
         }
     }
@@ -506,11 +521,15 @@ private static ApVariableRef ParseVariableRef(XElement elem)
 {
     var vr = new ApVariableRef();
 
-    var posStr = elem.Attribute("position")?.Value;
-    if (posStr != null &&
-        byte.TryParse(posStr, NumberStyles.None,
-            CultureInfo.InvariantCulture, out var pos))
-        vr.Position = pos;
+    var posStr = GetTrimmedAttributeValue(elem, "position");
+    if (!string.IsNullOrEmpty(posStr))
+    {
+        var posParsed = byte.TryParse(posStr, UnsignedXsdIntegerStyles,
+            CultureInfo.InvariantCulture, out var pos);
+        if (posParsed)
+            vr.Position = pos;
+        RejectFailedNumericAttribute(posStr, posParsed, "position");
+    }
 
     foreach (var child in elem.Elements())
     {
@@ -529,11 +548,15 @@ private static ApVariableRef ParseVariableRef(XElement elem)
                 {
                     UniqueIdRef = child.Attribute("uniqueIDRef")?.Value,
                 };
-                var idxStr = child.Attribute("index")?.Value;
-                if (idxStr != null &&
-                    long.TryParse(idxStr, NumberStyles.Integer,
-                        CultureInfo.InvariantCulture, out var idx))
-                    vr.MemberRef.Index = idx;
+                var idxStr = GetTrimmedAttributeValue(child, "index");
+                if (!string.IsNullOrEmpty(idxStr))
+                {
+                    var idxParsed = long.TryParse(idxStr, NumberStyles.Integer,
+                        CultureInfo.InvariantCulture, out var idx);
+                    if (idxParsed)
+                        vr.MemberRef.Index = idx;
+                    RejectFailedNumericAttribute(idxStr, idxParsed, "index");
+                }
                 break;
         }
     }

--- a/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
+++ b/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
@@ -243,7 +243,7 @@ internal static class XddParsingPrimitives
 
     /// <summary>
     /// Like <see cref="RejectFailedNumericAttribute"/>, but the diagnostic describes a
-    /// signed integer (for attributes parsed with <see cref="long.TryParse"/>).
+    /// signed integer (for attributes parsed via <c>long.TryParse</c>).
     /// </summary>
     internal static void RejectFailedSignedNumericAttribute(string? raw, bool parsed, string attributeName)
     {

--- a/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
+++ b/src/EdsDcfNet/Parsers/XddParsingPrimitives.cs
@@ -238,6 +238,24 @@ internal static class XddParsingPrimitives
     /// </summary>
     internal static void RejectFailedNumericAttribute(string? raw, bool parsed, string attributeName)
     {
+        RejectFailedIntegerAttribute(raw, parsed, attributeName, signed: false);
+    }
+
+    /// <summary>
+    /// Like <see cref="RejectFailedNumericAttribute"/>, but the diagnostic describes a
+    /// signed integer (for attributes parsed with <see cref="long.TryParse"/>).
+    /// </summary>
+    internal static void RejectFailedSignedNumericAttribute(string? raw, bool parsed, string attributeName)
+    {
+        RejectFailedIntegerAttribute(raw, parsed, attributeName, signed: true);
+    }
+
+    private static void RejectFailedIntegerAttribute(
+        string? raw,
+        bool parsed,
+        string attributeName,
+        bool signed)
+    {
         if (string.IsNullOrEmpty(raw) || parsed)
             return;
 
@@ -247,7 +265,9 @@ internal static class XddParsingPrimitives
         throw new EdsParseException(
             string.Format(
                 CultureInfo.InvariantCulture,
-                "Invalid {0} '{1}'. Value cannot be parsed as an unsigned integer.",
+                signed
+                    ? "Invalid {0} '{1}'. Value cannot be parsed as a signed integer."
+                    : "Invalid {0} '{1}'. Value cannot be parsed as an unsigned integer.",
                 attributeName,
                 raw));
     }

--- a/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
@@ -1788,4 +1788,104 @@ public class ApplicationProcessTests
         lg.TextRefs[1].IsDescriptionRef.Should().BeTrue();
         lg.TextRefs[1].Uri.Should().BeNull();
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // StrictParsing — ApplicationProcess numeric attributes (#484)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("lowerLimit", "oops")]
+    [InlineData("upperLimit", "nope")]
+    public void Parse_Subrange_InvalidLimit_StrictParsing_ThrowsEdsParseException(string attribute, string badValue)
+    {
+        var xdd = WrapInXdd($@"
+<ApplicationProcess>
+  <dataTypeList>
+    <array name=""A"" uniqueID=""uid_a"">
+      <subrange {attribute}=""{badValue}""/>
+      <UINT/>
+    </array>
+  </dataTypeList>
+  <parameterList/>
+</ApplicationProcess>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage($"*{attribute}*{badValue}*");
+    }
+
+    [Fact]
+    public void Parse_VariableRef_InvalidPosition_StrictParsing_ThrowsEdsParseException()
+    {
+        var xdd = WrapInXdd(@"
+<ApplicationProcess>
+  <parameterList>
+    <parameter uniqueID=""uid_p"">
+      <variableRef position=""not-a-byte""/>
+    </parameter>
+  </parameterList>
+</ApplicationProcess>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*position*not-a-byte*");
+    }
+
+    [Fact]
+    public void Parse_VariableRef_PositionWithLeadingPlus_StrictParsing_Parses()
+    {
+        var xdd = WrapInXdd(@"
+<ApplicationProcess>
+  <parameterList>
+    <parameter uniqueID=""uid_p"">
+      <variableRef position=""+2""/>
+    </parameter>
+  </parameterList>
+</ApplicationProcess>");
+
+        var result = CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        result.ApplicationProcess!.ParameterList[0].VariableRefs[0].Position.Should().Be(2);
+    }
+
+    [Fact]
+    public void Parse_MemberRef_InvalidIndex_StrictParsing_ThrowsEdsParseException()
+    {
+        var xdd = WrapInXdd(@"
+<ApplicationProcess>
+  <parameterList>
+    <parameter uniqueID=""uid_p"">
+      <variableRef>
+        <memberRef index=""notanumber""/>
+      </variableRef>
+    </parameter>
+  </parameterList>
+</ApplicationProcess>");
+
+        var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
+
+        act.Should().Throw<EdsParseException>()
+            .WithMessage("*index*notanumber*");
+    }
+
+    [Fact]
+    public void Parse_Subrange_InvalidLimit_Lenient_KeepsDefaults()
+    {
+        var result = ParseAp(@"
+<ApplicationProcess>
+  <dataTypeList>
+    <array name=""A"" uniqueID=""uid_a"">
+      <subrange lowerLimit=""oops"" upperLimit=""100""/>
+      <UINT/>
+    </array>
+  </dataTypeList>
+  <parameterList/>
+</ApplicationProcess>");
+
+        var sr = result.ApplicationProcess!.DataTypeList!.Arrays[0].Subranges[0];
+        sr.LowerLimit.Should().Be(0);
+        sr.UpperLimit.Should().Be(100);
+    }
 }

--- a/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ApplicationProcessTests.cs
@@ -1812,7 +1812,7 @@ public class ApplicationProcessTests
         var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
 
         act.Should().Throw<EdsParseException>()
-            .WithMessage($"*{attribute}*{badValue}*");
+            .WithMessage($"*{attribute}*{badValue}*signed integer*");
     }
 
     [Fact]
@@ -1867,7 +1867,7 @@ public class ApplicationProcessTests
         var act = () => CanOpenFile.Xdd.ReadString(xdd, new CanOpenFileOptions { StrictParsing = true });
 
         act.Should().Throw<EdsParseException>()
-            .WithMessage("*index*notanumber*");
+            .WithMessage("*index*notanumber*signed integer*");
     }
 
     [Fact]

--- a/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/XddReaderTests.cs
@@ -1620,6 +1620,17 @@ public class XddReaderTests
     }
 
     [Fact]
+    public void RejectFailedSignedNumericAttribute_StrictParsing_MentionsSignedInteger()
+    {
+        using (StrictParsingScope.Enter(true))
+        {
+            var act = () => XddParsingPrimitives.RejectFailedSignedNumericAttribute("oops", parsed: false, "lowerLimit");
+            act.Should().Throw<EdsParseException>()
+                .WithMessage("*lowerLimit*oops*signed integer*");
+        }
+    }
+
+    [Fact]
     public void ParseCanOpenObject_InvalidSubNumber_StrictParsing_ThrowsEdsParseException()
     {
         var xdd = MinimalXdd.Replace(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #484.

`XddApplicationProcessParser` now rejects malformed numeric attributes under `CanOpenFileOptions.StrictParsing`, matching the `XddCommNetProfileParser` pattern from #465/#474:

- `subrange` `lowerLimit` / `upperLimit`
- `variableRef` `position` (also standardized on `UnsignedXsdIntegerStyles` so schema-valid `position="+2"` parses)
- `memberRef` `index`

Lenient mode keeps the prior ignore-on-failure / default behavior.

## Type of change

- [x] Bug fix (`fix:`)

## Public API changes

- [x] **No** public API changes

## Testing

- [x] Targeted ApplicationProcess StrictParsing numeric attribute tests pass on net10.0
- [x] Existing lenient sparse/malformed ApplicationProcess test still passes

## Boundary & regression matrix

- [x] **Filled**

<details>
<summary>Matrix</summary>

| Dimension | What to cover | This PR |
|---|---|---|
| Numeric boundaries | malformed non-empty tokens for lowerLimit/upperLimit/position/index; leading `+` on position | Strict throw / parse |
| Round-trip fidelity | n/a — reject path | n/a |
| Validation modes | Strict on/off | both covered |
| Representative fixtures | Minimal XDD with ApplicationProcess mutations | added |
| API contract assertions | n/a | n/a |

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde8d-c1d2-7840-90f3-b1e23e514954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde8d-c1d2-7840-90f3-b1e23e514954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

