### PR TITLE
fix(parser): avoid ByteLimitingStream overflow at long.MaxValue

### DIFF
--- a/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
+++ b/src/EdsDcfNet/Parsers/ByteLimitingStream.cs
@@ -111,10 +111,23 @@ internal sealed class ByteLimitingStream : Stream
     /// oversized input is still detected without buffering a whole block beyond
     /// the limit.
     /// </summary>
+    /// <remarks>
+    /// When the remaining budget is already <see cref="long.MaxValue"/> (e.g.
+    /// <c>MaxInputSize = long.MaxValue</c> with nothing read yet), the budget
+    /// always covers any <see cref="int"/> read size, so the +1 overshoot path
+    /// is never taken — avoiding overflow of <c>long.MaxValue + 1</c>.
+    /// </remarks>
     private int AllowedCount(int count)
     {
-        var allowed = _maxBytes - _totalBytesRead + 1;
-        return allowed < count ? (int)allowed : count;
+        var remaining = _maxBytes - _totalBytesRead;
+        if (remaining >= count)
+            return count;
+
+        // remaining < count (<= int.MaxValue), so remaining+1 fits in int.
+        if (remaining < 0)
+            return 0;
+
+        return (int)(remaining + 1);
     }
 
     private int CountBytes(int bytesRead)

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -174,6 +174,23 @@ public class ByteLimitingStreamTests
     }
 
     [Fact]
+    public void Read_AfterLimitExceeded_FurtherReadsRequestNoBytes()
+    {
+        // After CountBytes throws, _totalBytesRead already exceeds _maxBytes.
+        // AllowedCount must clamp to 0 instead of passing a negative count.
+        var inner = new CountingStream(new byte[1024]);
+        using var stream = Create(inner, maxBytes: 8);
+        var buffer = new byte[1024];
+
+        var act = () => stream.Read(buffer, 0, buffer.Length);
+        act.Should().Throw<EdsParseException>();
+
+        var servedBefore = inner.TotalBytesServed;
+        stream.Read(buffer, 0, buffer.Length).Should().Be(0);
+        inner.TotalBytesServed.Should().Be(servedBefore);
+    }
+
+    [Fact]
     public async Task ReadAsync_OverLimit_ReadsAtMostOneByteBeyondTheLimit()
     {
         var inner = new CountingStream(new byte[1024]);

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -174,10 +174,11 @@ public class ByteLimitingStreamTests
     }
 
     [Fact]
-    public void Read_AfterLimitExceeded_FurtherReadsRequestNoBytes()
+    public void Read_AfterLimitExceeded_FurtherReadsStillRejectWithoutReading()
     {
         // After CountBytes throws, _totalBytesRead already exceeds _maxBytes.
-        // AllowedCount must clamp to 0 instead of passing a negative count.
+        // AllowedCount must clamp to 0 (no negative count) while CountBytes keeps
+        // rejecting because the budget remains exceeded.
         var inner = new CountingStream(new byte[1024]);
         using var stream = Create(inner, maxBytes: 8);
         var buffer = new byte[1024];
@@ -186,7 +187,7 @@ public class ByteLimitingStreamTests
         act.Should().Throw<EdsParseException>();
 
         var servedBefore = inner.TotalBytesServed;
-        stream.Read(buffer, 0, buffer.Length).Should().Be(0);
+        act.Should().Throw<EdsParseException>();
         inner.TotalBytesServed.Should().Be(servedBefore);
     }
 

--- a/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
+++ b/tests/EdsDcfNet.Tests/Parsers/ByteLimitingStreamTests.cs
@@ -26,6 +26,32 @@ public class ByteLimitingStreamTests
     }
 
     [Fact]
+    public void Read_MaxInputSizeAtLongMaxValue_ReadsFully()
+    {
+        // Callers may set MaxInputSize = long.MaxValue to disable the limit.
+        // AllowedCount must not overflow when computing remaining+1.
+        var data = Encoding.UTF8.GetBytes("12345678");
+        using var stream = Create(new MemoryStream(data), maxBytes: long.MaxValue);
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        reader.ReadToEnd().Should().Be("12345678");
+    }
+
+    [Fact]
+    public async Task ReadAsync_MaxInputSizeAtLongMaxValue_ReadsFully()
+    {
+        var data = Encoding.UTF8.GetBytes("12345678");
+        using var stream = Create(new MemoryStream(data), maxBytes: long.MaxValue);
+        var buffer = new byte[data.Length];
+
+        var bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
+
+        bytesRead.Should().Be(data.Length);
+        Encoding.UTF8.GetString(buffer).Should().Be("12345678");
+    }
+
+    [Fact]
     public void Read_ContentOneOverByteLimit_ThrowsEdsParseException()
     {
         var data = Encoding.UTF8.GetBytes("123456789");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Addresses Codex review on release PR #494: `ByteLimitingStream.AllowedCount` overflowed when `MaxInputSize = long.MaxValue` because it computed `_maxBytes - _totalBytesRead + 1`, wrapping to `long.MinValue` and forcing a zero-sized read (empty input / parse failure).

Compare remaining budget to the requested count first so the `+ 1` overshoot path is only taken when the budget is finite and fits in `int`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [x] `dotnet test --configuration Release --filter FullyQualifiedName~ByteLimitingStreamTests` passes locally (net10.0: 15 passed)
- [ ] `dotnet build --configuration Release` passes locally (required when public API or XML docs changed)

## Boundary & regression matrix

- [ ] **n/a** — this PR does not touch parsers/writers/validators/converters
- [x] **Filled** — matrix below completed and tests added

<details>
<summary>Matrix (expand and fill when applicable)</summary>

| Dimension | What to cover | This PR |
|---|---|---|
| Numeric boundaries | min, max, and wrap/clamp semantics of every touched numeric field | `Read_MaxInputSizeAtLongMaxValue_ReadsFully` / `ReadAsync_MaxInputSizeAtLongMaxValue_ReadsFully`; `Read_AfterLimitExceeded_FurtherReadsStillRejectWithoutReading` covers `remaining < 0` clamp; existing exact-limit and one-over-limit tests retained |
| Round-trip fidelity | read → write → read for each affected format (EDS, DCF, CPJ, XDD, XDC) | n/a — byte-budget stream wrapper only; no format serialize/deserialize change |
| Validation modes | default write **and** `CanOpenWriteOptions.Validated` where validation differs | n/a — read-path limit only |
| Representative fixtures | minimal + realistic samples | in-memory UTF-8 payloads via existing `ByteLimitingStreamTests` helpers |
| API contract assertions | reflection or source-compat tests where refactors can silently change public overload shapes or parameter names | n/a — internal type; no public overload changes |

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe083-dc43-7229-b5d3-b4823b73067f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe083-dc43-7229-b5d3-b4823b73067f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

