### PR TITLE
fix(ci): restore undici 8.10.0 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3707,6 +3707,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After merging Renovate PR #502 (`undici` → 8.10.0), Semantic Release on `develop` failed during `npm ci` with:

```text
Missing: undici@8.10.0 from lock file
```

Renovate updated the `overrides` in `package.json` and removed the old `undici@8.9.0` lockfile entry, but did not add `undici@8.10.0`.

## Fix
Regenerated the lockfile entry for `undici@8.10.0` so `npm ci` succeeds again.

## Test plan
- [x] `npm ci` succeeds locally after the lockfile update
- [ ] Semantic Release workflow succeeds after merge to `develop`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://borgardsworkspace.slack.com/archives/C0BM9L3C23F/p1786631566213269?thread_ts=1786631566.213269&cid=C0BM9L3C23F)

<div><a href="https://cursor.com/agents/bc-a0208097-fcb9-5fe2-908c-31ced0be4296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0208097-fcb9-5fe2-908c-31ced0be4296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

