### PR TITLE
fix(ci): finish NuGet and GitHub publish after notes push failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,12 +225,8 @@ jobs:
           check_conclusion="success"
           summary="Build and tests passed in Semantic Release workflow."
         else
-          # release_sha is only set after verifying a chore(release) commit from
-          # semantic-release-bot whose parent is the workflow trigger SHA. When
-          # that holds, build/test/publish already succeeded and a late git-notes
-          # push failure should not block develop merges.
-          check_conclusion="success"
-          summary="Release commit verified; relaying success despite workflow conclusion: ${conclusion}."
+          check_conclusion="failure"
+          summary="Semantic Release workflow did not succeed (conclusion: ${conclusion})."
         fi
 
         gh api repos/${{ github.repository }}/check-runs \
@@ -256,8 +252,8 @@ jobs:
           state="success"
           description="Release commit — build verified by Semantic Release workflow"
         else
-          state="success"
-          description="Release commit verified; build passed before workflow conclusion: ${conclusion}"
+          state="failure"
+          description="Semantic Release workflow did not succeed"
         fi
 
         gh api "repos/${{ github.repository }}/statuses/${sha}" \

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -53,6 +53,32 @@ retry_git_notes_push() {
   return 1
 }
 
+# Recreate semantic-release channel notes when a prior notes push failed.
+# Fresh CI checkouts do not include refs/notes/*, and dry-run only fetches notes
+# that already exist on the remote — so a missing remote note leaves nothing to
+# push unless we add {"channels":[...]} locally first.
+repair_git_notes() {
+  local notes_ref="$1"
+  local tag="$2"
+  local branch="$3"
+  local note_message
+
+  git fetch --force origin "+refs/notes/${notes_ref}:refs/notes/${notes_ref}" 2>/dev/null || true
+
+  if ! git notes --ref "$notes_ref" show "$tag" >/dev/null 2>&1; then
+    if [[ "$branch" == "main" ]]; then
+      note_message='{"channels":[null]}'
+    else
+      # Matches semantic-release: prerelease branch channel defaults to branch name.
+      note_message="$(printf '{"channels":["%s"]}' "$branch")"
+    fi
+    echo "Creating missing git notes for ${tag} on channel note ref ${notes_ref}."
+    git notes --ref "$notes_ref" add -f -m "$note_message" "$tag" || return 1
+  fi
+
+  retry_git_notes_push "$notes_ref"
+}
+
 verify_published_release() {
   local trigger_sha="$1"
   local branch="$2"
@@ -107,6 +133,7 @@ FORCE_COLOR=0 npx semantic-release --dry-run >"$dry_run_log" 2>&1 || {
 }
 
 next_version="$(sed -nE 's/.*The next release version is ([^[:space:]]+).*/\1/p' "$dry_run_log" | tail -n 1)"
+branch="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 
 if [[ -n "$next_version" ]]; then
   next_tag="v${next_version}"
@@ -123,12 +150,11 @@ if [[ -n "$next_version" ]]; then
     echo "Tag ${next_tag} already exists at ${tag_sha} on current branch history."
     echo "Release ${next_version} was already published; skipping re-release and repairing git notes if needed."
     configure_git_auth || true
-    retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
+    repair_git_notes "$notes_ref" "$next_tag" "$branch" || warn "Git notes repair failed; continuing without blocking CI."
     exit 0
   fi
 fi
 
-branch="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 trigger_sha="$(git rev-parse HEAD)"
 sr_log="$(mktemp)"
 
@@ -153,7 +179,7 @@ if grep -Fq "refs/notes/${notes_ref}" "$sr_log"; then
 elif grep -Fq "fatal: tag '${next_tag}' already exists" "$sr_log" || grep -Fq "fatal: tag \"${next_tag}\" already exists" "$sr_log"; then
   echo "semantic-release failed because ${next_tag} already exists; treating as already published."
   configure_git_auth || true
-  retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
+  repair_git_notes "$notes_ref" "$next_tag" "$branch" || warn "Git notes repair failed; continuing without blocking CI."
   exit 0
 else
   echo "semantic-release failed for a reason other than git notes push or an existing tag."

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -110,6 +110,8 @@ next_version="$(sed -nE 's/.*The next release version is ([^[:space:]]+).*/\1/p'
 
 if [[ -n "$next_version" ]]; then
   next_tag="v${next_version}"
+  notes_ref="semantic-release-v${next_version}"
+
   if git rev-parse -q --verify "refs/tags/$next_tag" >/dev/null; then
     tag_sha="$(git rev-list -n 1 "$next_tag")"
     if ! git merge-base --is-ancestor "$tag_sha" HEAD; then
@@ -117,6 +119,12 @@ if [[ -n "$next_version" ]]; then
       echo "Likely stale protected prerelease tag after history rewrite."
       exit 0
     fi
+
+    echo "Tag ${next_tag} already exists at ${tag_sha} on current branch history."
+    echo "Release ${next_version} was already published; skipping re-release and repairing git notes if needed."
+    configure_git_auth || true
+    retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
+    exit 0
   fi
 fi
 
@@ -138,9 +146,17 @@ if [[ -z "$next_version" ]]; then
   exit "$sr_exit"
 fi
 
+next_tag="v${next_version}"
 notes_ref="semantic-release-v${next_version}"
-if ! grep -Fq "refs/notes/${notes_ref}" "$sr_log"; then
-  echo "semantic-release failed for a reason other than git notes push."
+if grep -Fq "refs/notes/${notes_ref}" "$sr_log"; then
+  :
+elif grep -Fq "fatal: tag '${next_tag}' already exists" "$sr_log" || grep -Fq "fatal: tag \"${next_tag}\" already exists" "$sr_log"; then
+  echo "semantic-release failed because ${next_tag} already exists; treating as already published."
+  configure_git_auth || true
+  retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
+  exit 0
+else
+  echo "semantic-release failed for a reason other than git notes push or an existing tag."
   exit "$sr_exit"
 fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -59,17 +59,23 @@ retry_git_notes_push() {
   return 1
 }
 
+tag_commit() {
+  git rev-parse "$1^{}"
+}
+
 ensure_git_notes() {
   local version="$1"
   local tag="v${version}"
   local notes_ref
   notes_ref="$(notes_ref_for "$version")"
+  local commit
   local channel_json
 
+  commit="$(tag_commit "$tag")"
   git fetch origin "+refs/notes/*:refs/notes/*" || true
 
-  if git notes --ref "$notes_ref" show "$tag" >/dev/null 2>&1; then
-    echo "Git notes ${notes_ref} already exist for ${tag}."
+  if git notes --ref "$notes_ref" show "$commit" >/dev/null 2>&1; then
+    echo "Git notes ${notes_ref} already exist for ${tag} (${commit})."
     return 0
   fi
 
@@ -79,48 +85,70 @@ ensure_git_notes() {
     channel_json='{"channels":[null]}'
   fi
 
-  git notes --ref "$notes_ref" add -f -m "$channel_json" "$tag"
+  # Attach notes to the peeled commit. semantic-release reads them via
+  # `git log`, which does not see notes stored on an annotated tag object.
+  git notes --ref "$notes_ref" add -f -m "$channel_json" "$commit"
 }
 
 complete_release_publish() {
   local version="$1"
   local tag="v${version}"
+  local repo_root
+  repo_root="$(pwd)"
+  local packages_dir="${repo_root}/packages"
+  local worktree=""
   local notes_file
   local -a assets=()
   local -a cmd
   local file
 
   echo "Completing publish for ${version} (NuGet + GitHub release)..."
-  bash ./tools/semantic-release-publish.sh "$version"
 
-  if gh release view "$tag" >/dev/null 2>&1; then
-    echo "GitHub release ${tag} already exists."
-    return 0
+  if [[ "$(tag_commit "$tag")" != "$(git rev-parse HEAD^{})" ]]; then
+    worktree="$(mktemp -d)"
+    git worktree add --detach "$worktree" "$tag"
+    trap 'git worktree remove --force "$worktree" 2>/dev/null || true' RETURN
+    (
+      cd "$worktree"
+      dotnet restore
+      bash "${repo_root}/tools/semantic-release-publish.sh" "$version"
+    )
+    packages_dir="${worktree}/packages"
+  else
+    bash ./tools/semantic-release-publish.sh "$version"
   fi
 
-  notes_file="$(mktemp)"
-  git log -1 --format=%b "$tag" >"$notes_file"
+  if ! gh release view "$tag" >/dev/null 2>&1; then
+    notes_file="$(mktemp)"
+    git log -1 --format=%b "$tag" >"$notes_file"
 
-  for file in \
-    "packages/EdsDcfNet.${version}.nupkg" \
-    "packages/EdsDcfNet.${version}.snupkg" \
-    packages/bom.cdx.json \
-    packages/sbom.spdx.json
-  do
-    if [[ -f "$file" ]]; then
-      assets+=("$file")
+    for file in \
+      "${packages_dir}/EdsDcfNet.${version}.nupkg" \
+      "${packages_dir}/EdsDcfNet.${version}.snupkg" \
+      "${packages_dir}/bom.cdx.json" \
+      "${packages_dir}/sbom.spdx.json"
+    do
+      if [[ -f "$file" ]]; then
+        assets+=("$file")
+      fi
+    done
+
+    cmd=(gh release create "$tag" --title "$tag" --notes-file "$notes_file")
+    if [[ "$version" == *-* ]]; then
+      cmd+=(--prerelease)
     fi
-  done
+    if ((${#assets[@]} > 0)); then
+      cmd+=("${assets[@]}")
+    fi
 
-  cmd=(gh release create "$tag" --title "$tag" --notes-file "$notes_file")
-  if [[ "$version" == *-* ]]; then
-    cmd+=(--prerelease)
-  fi
-  if ((${#assets[@]} > 0)); then
-    cmd+=("${assets[@]}")
+    "${cmd[@]}"
+  else
+    echo "GitHub release ${tag} already exists."
   fi
 
-  "${cmd[@]}"
+  if [[ -n "$worktree" ]]; then
+    git worktree remove --force "$worktree"
+  fi
 }
 
 repair_notes_and_publish() {
@@ -129,10 +157,13 @@ repair_notes_and_publish() {
   notes_ref="$(notes_ref_for "$version")"
 
   echo "Finishing release ${version}: git notes are not a completed publish."
+  complete_release_publish "$version"
+  # Channel notes are how later runs treat the tag as lastRelease. Push them
+  # only after NuGet and the GitHub release exist, otherwise a notes-only
+  # success would skip this repair path and leave artifacts unpublished.
   configure_git_auth || warn "Could not configure git auth for notes push."
   ensure_git_notes "$version" || warn "Could not add local git notes for v${version}."
-  retry_git_notes_push "$notes_ref" || warn "Git notes push failed after retries; continuing with package publish."
-  complete_release_publish "$version"
+  retry_git_notes_push "$notes_ref" || warn "Git notes push failed after retries; publish already completed."
 }
 
 dry_run_log="$(mktemp)"

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# Runs semantic-release and tolerates git-notes push failures when the release
-# itself (tag, release commit, NuGet publish) already succeeded. GitHub has
-# intermittently returned 500 Internal Server Error when pushing
-# refs/notes/semantic-release-v*; treating that as a hard failure leaves develop
-# with failed required checks because relay-release-status mirrors the workflow
-# conclusion onto the [skip ci] release commit.
+# Runs semantic-release and recovers when GitHub rejects the git-notes push.
+#
+# semantic-release 25 lifecycle (index.js): prepare (changelog + git commit) →
+# tag → addNote → push tags → pushNotes → publish plugins. NuGet
+# (tools/semantic-release-publish.sh) and the GitHub release therefore have not
+# run when pushNotes fails. Recovery must finish that publish, not treat the
+# tagged commit as a completed release.
 set -euo pipefail
 
 warn() {
   echo "Warning: $*" >&2
+}
+
+notes_ref_for() {
+  local version="$1"
+  echo "semantic-release-v${version}"
 }
 
 configure_git_auth() {
@@ -53,51 +59,80 @@ retry_git_notes_push() {
   return 1
 }
 
-verify_published_release() {
-  local trigger_sha="$1"
-  local branch="$2"
-  local next_version="$3"
-  local next_tag="v${next_version}"
-  local notes_ref="semantic-release-v${next_version}"
+ensure_git_notes() {
+  local version="$1"
+  local tag="v${version}"
+  local notes_ref
+  notes_ref="$(notes_ref_for "$version")"
+  local channel_json
 
-  git fetch origin "$branch" --tags
+  git fetch origin "+refs/notes/*:refs/notes/*" || true
 
-  if ! git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
-    echo "Tag ${next_tag} was not created."
-    return 1
+  if git notes --ref "$notes_ref" show "$tag" >/dev/null 2>&1; then
+    echo "Git notes ${notes_ref} already exist for ${tag}."
+    return 0
   fi
 
-  local current_sha
-  current_sha="$(git rev-parse "origin/${branch}")"
-  if [[ "$current_sha" == "$trigger_sha" ]]; then
-    echo "Branch ${branch} HEAD unchanged after semantic-release failure."
-    return 1
+  if [[ "$version" == *-* ]]; then
+    channel_json='{"channels":["beta"]}'
+  else
+    channel_json='{"channels":[null]}'
   fi
 
-  local message committer parent_sha
-  message="$(git log -1 --format=%s "$current_sha")"
-  committer="$(git log -1 --format=%cn "$current_sha")"
-  parent_sha="$(git rev-parse "${current_sha}^")"
+  git notes --ref "$notes_ref" add -f -m "$channel_json" "$tag"
+}
 
-  if [[ "$message" != "chore(release):"* ]]; then
-    echo "Branch HEAD ${current_sha} is not a chore(release) commit."
-    return 1
+complete_release_publish() {
+  local version="$1"
+  local tag="v${version}"
+  local notes_file
+  local -a assets=()
+  local -a cmd
+  local file
+
+  echo "Completing publish for ${version} (NuGet + GitHub release)..."
+  bash ./tools/semantic-release-publish.sh "$version"
+
+  if gh release view "$tag" >/dev/null 2>&1; then
+    echo "GitHub release ${tag} already exists."
+    return 0
   fi
 
-  if [[ "$committer" != "semantic-release-bot" ]]; then
-    echo "Branch HEAD ${current_sha} committer is '${committer}', expected semantic-release-bot."
-    return 1
+  notes_file="$(mktemp)"
+  git log -1 --format=%b "$tag" >"$notes_file"
+
+  for file in \
+    "packages/EdsDcfNet.${version}.nupkg" \
+    "packages/EdsDcfNet.${version}.snupkg" \
+    packages/bom.cdx.json \
+    packages/sbom.spdx.json
+  do
+    if [[ -f "$file" ]]; then
+      assets+=("$file")
+    fi
+  done
+
+  cmd=(gh release create "$tag" --title "$tag" --notes-file "$notes_file")
+  if [[ "$version" == *-* ]]; then
+    cmd+=(--prerelease)
+  fi
+  if ((${#assets[@]} > 0)); then
+    cmd+=("${assets[@]}")
   fi
 
-  if [[ "$parent_sha" != "$trigger_sha" ]]; then
-    echo "Branch HEAD ${current_sha} parent is ${parent_sha}, expected trigger ${trigger_sha}."
-    return 1
-  fi
+  "${cmd[@]}"
+}
 
-  NOTES_REF="$notes_ref"
-  RELEASE_TAG="$next_tag"
-  RELEASE_SHA="$current_sha"
-  return 0
+repair_notes_and_publish() {
+  local version="$1"
+  local notes_ref
+  notes_ref="$(notes_ref_for "$version")"
+
+  echo "Finishing release ${version}: git notes are not a completed publish."
+  configure_git_auth || warn "Could not configure git auth for notes push."
+  ensure_git_notes "$version" || warn "Could not add local git notes for v${version}."
+  retry_git_notes_push "$notes_ref" || warn "Git notes push failed after retries; continuing with package publish."
+  complete_release_publish "$version"
 }
 
 dry_run_log="$(mktemp)"
@@ -110,8 +145,6 @@ next_version="$(sed -nE 's/.*The next release version is ([^[:space:]]+).*/\1/p'
 
 if [[ -n "$next_version" ]]; then
   next_tag="v${next_version}"
-  notes_ref="semantic-release-v${next_version}"
-
   if git rev-parse -q --verify "refs/tags/$next_tag" >/dev/null; then
     tag_sha="$(git rev-list -n 1 "$next_tag")"
     if ! git merge-base --is-ancestor "$tag_sha" HEAD; then
@@ -121,15 +154,12 @@ if [[ -n "$next_version" ]]; then
     fi
 
     echo "Tag ${next_tag} already exists at ${tag_sha} on current branch history."
-    echo "Release ${next_version} was already published; skipping re-release and repairing git notes if needed."
-    configure_git_auth || true
-    retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
+    echo "Skipping a second semantic-release run and completing any unfinished publish."
+    repair_notes_and_publish "$next_version"
     exit 0
   fi
 fi
 
-branch="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
-trigger_sha="$(git rev-parse HEAD)"
 sr_log="$(mktemp)"
 
 set +e
@@ -147,33 +177,18 @@ if [[ -z "$next_version" ]]; then
 fi
 
 next_tag="v${next_version}"
-notes_ref="semantic-release-v${next_version}"
+notes_ref="$(notes_ref_for "$next_version")"
 if grep -Fq "refs/notes/${notes_ref}" "$sr_log"; then
-  :
-elif grep -Fq "fatal: tag '${next_tag}' already exists" "$sr_log" || grep -Fq "fatal: tag \"${next_tag}\" already exists" "$sr_log"; then
-  echo "semantic-release failed because ${next_tag} already exists; treating as already published."
-  configure_git_auth || true
-  retry_git_notes_push "$notes_ref" || warn "Git notes push failed; continuing without blocking CI."
-  exit 0
-else
-  echo "semantic-release failed for a reason other than git notes push or an existing tag."
-  exit "$sr_exit"
-fi
-
-NOTES_REF=""
-RELEASE_TAG=""
-RELEASE_SHA=""
-if ! verify_published_release "$trigger_sha" "$branch" "$next_version"; then
-  exit "$sr_exit"
-fi
-
-echo "Release ${next_version} (${RELEASE_TAG} @ ${RELEASE_SHA}) was published; recovering from git notes push failure."
-
-configure_git_auth
-if retry_git_notes_push "$NOTES_REF"; then
+  echo "semantic-release failed while pushing git notes; completing publish plugins."
+  repair_notes_and_publish "$next_version"
   exit 0
 fi
 
-warn "Release ${next_version} was published but git notes push failed after retries."
-warn "Continuing with workflow success so develop required checks are not left failing."
-exit 0
+if grep -Fq "fatal: tag '${next_tag}' already exists" "$sr_log" || grep -Fq "fatal: tag \"${next_tag}\" already exists" "$sr_log"; then
+  echo "semantic-release failed because ${next_tag} already exists; completing any unfinished publish."
+  repair_notes_and_publish "$next_version"
+  exit 0
+fi
+
+echo "semantic-release failed for a reason other than git notes push or an existing tag."
+exit "$sr_exit"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the #507 review comments (Codex + Bugbot): semantic-release 25 runs `pushNotes` **before** publish plugins. Treating a notes 500 as a finished release left `v1.12.0-beta.15` tagged with **no NuGet package and no GitHub release** (confirmed: NuGet 404, `gh release view` not found).

Also keeps the existing-tag skip so a later develop push does not try to retag the same version.

## Changes

- After a notes-push failure or an already-existing on-branch tag, **complete NuGet + GitHub publish first**, then recreate/push `refs/notes/semantic-release-v*` so a failed publish remains retryable.
- Pack from a detached worktree at the tag when `HEAD` is not the tagged commit.
- Attach notes to the peeled commit (`tag^{}`), which is what `git log` / semantic-release reads.
- Revert `relay-release-status` so a failed Semantic Release workflow still relays **failure**. A prepare commit is not proof that NuGet/GitHub publish ran.

## Testing

- `bash -n tools/semantic-release-run.sh`
- CI on this PR
- After merge to `develop`, the existing `v1.12.0-beta.15` tag should complete NuGet + GitHub publish instead of failing with “tag already exists”

## Checklist

- [x] No public API changes
- [x] n/a — does not touch parsers/writers/validators/converters
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb95-77c5-708b-bb0a-9b67dcdf74eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb95-77c5-708b-bb0a-9b67dcdf74eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

