### PR TITLE
fix(ci): do not fail release repair on locked git worktrees

### DIFF
--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -109,7 +109,9 @@ copy_release_packages() {
   mkdir -p "$dest_dir"
   while IFS= read -r name; do
     if [[ -f "${source_dir}/${name}" ]]; then
-      cp -f "${source_dir}/${name}" "$dest_dir/"
+      if ! cp -f "${source_dir}/${name}" "$dest_dir/"; then
+        warn "Could not copy ${name} out of the worktree."
+      fi
     fi
   done < <(release_artifact_names "$version")
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -124,7 +124,8 @@ remove_worktree_best_effort() {
     return 0
   fi
 
-  warn "Could not remove worktree ${worktree}; continuing because publish already finished."
+  # Runner is ephemeral; a locked tree must not fail the job after pack.
+  warn "Could not remove worktree ${worktree}; continuing (ephemeral runner)."
   git worktree prune || true
 }
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -90,23 +90,33 @@ ensure_git_notes() {
   git notes --ref "$notes_ref" add -f -m "$channel_json" "$commit"
 }
 
+release_artifact_names() {
+  local version="$1"
+  printf '%s\n' \
+    "EdsDcfNet.${version}.nupkg" \
+    "EdsDcfNet.${version}.snupkg" \
+    "bom.cdx.json" \
+    "sbom.spdx.json"
+}
+
 copy_release_packages() {
   local source_dir="$1"
   local dest_dir="$2"
   local version="$3"
-  local file
+  local name
+  local nupkg="${dest_dir}/EdsDcfNet.${version}.nupkg"
 
   mkdir -p "$dest_dir"
-  for file in \
-    "${source_dir}/EdsDcfNet.${version}.nupkg" \
-    "${source_dir}/EdsDcfNet.${version}.snupkg" \
-    "${source_dir}/bom.cdx.json" \
-    "${source_dir}/sbom.spdx.json"
-  do
-    if [[ -f "$file" ]]; then
-      cp -f "$file" "$dest_dir/"
+  while IFS= read -r name; do
+    if [[ -f "${source_dir}/${name}" ]]; then
+      cp -f "${source_dir}/${name}" "$dest_dir/"
     fi
-  done
+  done < <(release_artifact_names "$version")
+
+  if [[ ! -f "$nupkg" ]]; then
+    echo "Expected package not found after copy: ${nupkg}" >&2
+    return 1
+  fi
 }
 
 remove_worktree_best_effort() {
@@ -116,10 +126,11 @@ remove_worktree_best_effort() {
     return 0
   fi
 
-  # MSBuild node reuse on windows-latest often keeps files locked after pack.
-  # Disable the server and shut it down before remove; never fail the release
-  # if cleanup still cannot delete the tree (the runner is ephemeral).
-  MSBUILDDISABLENODEREUSE=1 dotnet build-server shutdown >/dev/null 2>&1 || true
+  # VBCSCompiler / MSBuild nodes can keep files locked after pack. Shut them
+  # down before remove; never fail the release if cleanup still cannot delete
+  # the tree (the runner is ephemeral). shutdown does not read
+  # MSBUILDDISABLENODEREUSE; reuse is disabled at pack time instead.
+  dotnet build-server shutdown >/dev/null 2>&1 || true
   if git worktree remove --force "$worktree"; then
     return 0
   fi
@@ -139,13 +150,9 @@ complete_release_publish() {
   local notes_file
   local -a assets=()
   local -a cmd
-  local file
+  local name
 
   echo "Completing publish for ${version} (NuGet + GitHub release)..."
-
-  # Clear on fire: RETURN traps are global and would otherwise leak to the
-  # caller; with set -u that re-expands the now-out-of-scope local worktree.
-  trap 'trap - RETURN; remove_worktree_best_effort "$worktree"' RETURN
 
   if [[ "$(tag_commit "$tag")" != "$(git rev-parse HEAD^{})" ]]; then
     worktree="$(mktemp -d)"
@@ -156,9 +163,11 @@ complete_release_publish() {
       dotnet restore
       bash "${repo_root}/tools/semantic-release-publish.sh" "$version"
     )
+    # Unlock packages before copy. The pack subshell already disabled node reuse;
+    # this terminates leftover VBCSCompiler / MSBuild processes.
+    dotnet build-server shutdown >/dev/null 2>&1 || true
     copy_release_packages "${worktree}/packages" "$packages_dir" "$version"
     remove_worktree_best_effort "$worktree"
-    worktree=""
   else
     bash ./tools/semantic-release-publish.sh "$version"
   fi
@@ -167,16 +176,11 @@ complete_release_publish() {
     notes_file="$(mktemp)"
     git log -1 --format=%b "$tag" >"$notes_file"
 
-    for file in \
-      "${packages_dir}/EdsDcfNet.${version}.nupkg" \
-      "${packages_dir}/EdsDcfNet.${version}.snupkg" \
-      "${packages_dir}/bom.cdx.json" \
-      "${packages_dir}/sbom.spdx.json"
-    do
-      if [[ -f "$file" ]]; then
-        assets+=("$file")
+    while IFS= read -r name; do
+      if [[ -f "${packages_dir}/${name}" ]]; then
+        assets+=("${packages_dir}/${name}")
       fi
-    done
+    done < <(release_artifact_names "$version")
 
     cmd=(gh release create "$tag" --title "$tag" --notes-file "$notes_file")
     if [[ "$version" == *-* ]]; then

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -142,7 +142,9 @@ complete_release_publish() {
 
   echo "Completing publish for ${version} (NuGet + GitHub release)..."
 
-  trap 'remove_worktree_best_effort "$worktree"' RETURN
+  # Clear on fire: RETURN traps are global and would otherwise leak to the
+  # caller; with set -u that re-expands the now-out-of-scope local worktree.
+  trap 'trap - RETURN; remove_worktree_best_effort "$worktree"' RETURN
 
   if [[ "$(tag_commit "$tag")" != "$(git rev-parse HEAD^{})" ]]; then
     worktree="$(mktemp -d)"

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -90,6 +90,44 @@ ensure_git_notes() {
   git notes --ref "$notes_ref" add -f -m "$channel_json" "$commit"
 }
 
+copy_release_packages() {
+  local source_dir="$1"
+  local dest_dir="$2"
+  local version="$3"
+  local file
+
+  mkdir -p "$dest_dir"
+  for file in \
+    "${source_dir}/EdsDcfNet.${version}.nupkg" \
+    "${source_dir}/EdsDcfNet.${version}.snupkg" \
+    "${source_dir}/bom.cdx.json" \
+    "${source_dir}/sbom.spdx.json"
+  do
+    if [[ -f "$file" ]]; then
+      cp -f "$file" "$dest_dir/"
+    fi
+  done
+}
+
+remove_worktree_best_effort() {
+  local worktree="$1"
+
+  if [[ -z "$worktree" || ! -e "$worktree" ]]; then
+    return 0
+  fi
+
+  # MSBuild node reuse on windows-latest often keeps files locked after pack.
+  # Disable the server and shut it down before remove; never fail the release
+  # if cleanup still cannot delete the tree (the runner is ephemeral).
+  MSBUILDDISABLENODEREUSE=1 dotnet build-server shutdown >/dev/null 2>&1 || true
+  if git worktree remove --force "$worktree"; then
+    return 0
+  fi
+
+  warn "Could not remove worktree ${worktree}; continuing because publish already finished."
+  git worktree prune || true
+}
+
 complete_release_publish() {
   local version="$1"
   local tag="v${version}"
@@ -104,16 +142,20 @@ complete_release_publish() {
 
   echo "Completing publish for ${version} (NuGet + GitHub release)..."
 
+  trap 'remove_worktree_best_effort "$worktree"' RETURN
+
   if [[ "$(tag_commit "$tag")" != "$(git rev-parse HEAD^{})" ]]; then
     worktree="$(mktemp -d)"
     git worktree add --detach "$worktree" "$tag"
-    trap 'git worktree remove --force "$worktree" 2>/dev/null || true' RETURN
     (
       cd "$worktree"
+      export MSBUILDDISABLENODEREUSE=1
       dotnet restore
       bash "${repo_root}/tools/semantic-release-publish.sh" "$version"
     )
-    packages_dir="${worktree}/packages"
+    copy_release_packages "${worktree}/packages" "$packages_dir" "$version"
+    remove_worktree_best_effort "$worktree"
+    worktree=""
   else
     bash ./tools/semantic-release-publish.sh "$version"
   fi
@@ -144,10 +186,6 @@ complete_release_publish() {
     "${cmd[@]}"
   else
     echo "GitHub release ${tag} already exists."
-  fi
-
-  if [[ -n "$worktree" ]]; then
-    git worktree remove --force "$worktree"
   fi
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the remaining Bugbot comment on #508: after packing from a tagged worktree, `git worktree remove --force` can fail on `windows-latest` because MSBuild keeps file locks. Under `set -e` that aborted `complete_release_publish` **after** NuGet/GitHub publish, so channel notes were never pushed and develop stayed stuck on the same tag.

Also covers the develop failure after #508 (`worktree: unbound variable` from a leaked RETURN trap) and review follow-ups on that trap, artifact-list duplication, the inert `MSBUILDDISABLENODEREUSE` prefix on `dotnet build-server shutdown`, and a `cp` abort that skipped the nupkg copy guard.

## Changes

- Copy nupkg/snupkg/SBOM out of the worktree before cleanup. Warn if `cp` fails (do not abort under `set -e`); fail only if the nupkg is missing afterward so the diagnostic is reachable.
- Disable MSBuild node reuse in the worktree pack subshell; shut down the build server before copy and before `git worktree remove` (shutdown does not read `MSBUILDDISABLENODEREUSE`).
- Treat worktree removal as best-effort so a locked tree cannot fail the repair path.
- Drop the `RETURN` trap entirely. It was a no-op on success (`worktree` already cleared) and does not run under `set -e` failures; keeping it reintroduced the leak that broke develop after #508.
- Share one `release_artifact_names` helper between copy and `gh release create`.
- Cleanup warning no longer claims publish already finished.

## Testing

- `bash -n tools/semantic-release-run.sh`
- Simulated `cp` failure: warnings print, then `Expected package not found after copy`
- CI on this PR

## Checklist

- [x] No public API changes
- [x] n/a — does not touch parsers/writers/validators/converters
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb95-77c5-708b-bb0a-9b67dcdf74eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb95-77c5-708b-bb0a-9b67dcdf74eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

