### PR TITLE
fix(ci): resume incomplete GitHub releases during release repair

### DIFF
--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -142,6 +142,74 @@ remove_worktree_best_effort() {
   git worktree prune || true
 }
 
+local_release_assets() {
+  local version="$1"
+  local packages_dir="$2"
+  local name
+
+  while IFS= read -r name; do
+    if [[ -f "${packages_dir}/${name}" ]]; then
+      printf '%s\n' "$name"
+    fi
+  done < <(release_artifact_names "$version")
+}
+
+# Asset names GitHub reports as fully uploaded. Anything still in the `starter`
+# state is a half-finished upload from the aborted run and must be re-sent.
+uploaded_release_assets() {
+  local tag="$1"
+
+  gh release view "$tag" --json assets \
+    --jq '.assets[] | select(.state == "uploaded") | .name' 2>/dev/null || true
+}
+
+release_is_draft() {
+  local tag="$1"
+  local is_draft
+
+  is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null || true)"
+  [[ "$is_draft" == "true" ]]
+}
+
+# `gh release create` with assets creates a draft, uploads each asset, then
+# publishes. A run that dies partway leaves a release that `gh release view`
+# finds but that is missing assets, still a draft, or both. Resume whichever
+# step did not finish instead of treating mere existence as success.
+resume_release_publish() {
+  local version="$1"
+  local tag="v${version}"
+  local packages_dir="$2"
+  local -a missing=()
+  local -a uploaded=()
+  local name
+  local resumed=0
+
+  mapfile -t uploaded < <(uploaded_release_assets "$tag")
+
+  while IFS= read -r name; do
+    if ! printf '%s\n' "${uploaded[@]}" | grep -Fxq "$name"; then
+      missing+=("${packages_dir}/${name}")
+    fi
+  done < <(local_release_assets "$version" "$packages_dir")
+
+  if ((${#missing[@]} > 0)); then
+    echo "Uploading ${#missing[@]} missing asset(s) to ${tag}."
+    # --clobber replaces `starter` leftovers from the interrupted upload.
+    gh release upload "$tag" "${missing[@]}" --clobber
+    resumed=1
+  fi
+
+  if release_is_draft "$tag"; then
+    echo "Publishing draft release ${tag}."
+    gh release edit "$tag" --draft=false
+    resumed=1
+  fi
+
+  if ((resumed == 0)); then
+    echo "GitHub release ${tag} already complete."
+  fi
+}
+
 complete_release_publish() {
   local version="$1"
   local tag="v${version}"
@@ -194,7 +262,7 @@ complete_release_publish() {
 
     "${cmd[@]}"
   else
-    echo "GitHub release ${tag} already exists."
+    resume_release_publish "$version" "$packages_dir"
   fi
 }
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -163,12 +163,28 @@ uploaded_release_assets() {
     --jq '.assets[] | select(.state == "uploaded") | .name' 2>/dev/null || true
 }
 
+# Prints "true" or "false". A failed or unreadable probe must fail the repair:
+# treating a missed read as "not a draft" would skip --draft=false, after which
+# channel notes are pushed and later runs leave the GitHub release unpublished.
+# Strip CR so Git Bash on windows-latest does not turn `true\r` into a miss.
 release_is_draft() {
   local tag="$1"
   local is_draft
 
-  is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null || true)"
-  [[ "$is_draft" == "true" ]]
+  is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft)" || {
+    echo "Could not determine draft status for ${tag}." >&2
+    return 1
+  }
+  is_draft="${is_draft//$'\r'/}"
+  case "$is_draft" in
+    true|false)
+      printf '%s\n' "$is_draft"
+      ;;
+    *)
+      echo "Could not determine draft status for ${tag} (got: ${is_draft})." >&2
+      return 1
+      ;;
+  esac
 }
 
 # `gh release create` with assets creates a draft, uploads each asset, then
@@ -183,6 +199,7 @@ resume_release_publish() {
   local -a uploaded=()
   local name
   local resumed=0
+  local is_draft
 
   mapfile -t uploaded < <(uploaded_release_assets "$tag")
 
@@ -199,7 +216,8 @@ resume_release_publish() {
     resumed=1
   fi
 
-  if release_is_draft "$tag"; then
+  is_draft="$(release_is_draft "$tag")" || return 1
+  if [[ "$is_draft" == "true" ]]; then
     echo "Publishing draft release ${tag}."
     gh release edit "$tag" --draft=false
     resumed=1


### PR DESCRIPTION
## Description

Addresses the P1 review finding on release PR #510
([discussion](https://github.com/dborgards/eds-dcf-net/pull/510#discussion_r3781382837))
in `tools/semantic-release-run.sh`.

`gh release create` with assets does not perform a single atomic call: it creates a
**draft**, uploads each asset, then flips the release to published. So when a prior
release run died partway — during an asset upload or on the final publish request —
`gh release view "$tag"` still finds the release.

`complete_release_publish` treated that as "already exists" and returned without
uploading the missing assets or publishing the draft. `repair_notes_and_publish`
then pushed the channel git note, and because that note is what makes later
semantic-release runs treat the tag as `lastRelease`, every subsequent run stopped
attempting the repair — leaving the GitHub release permanently unpublished, missing
artifacts, or both.

### Change

The existence check is replaced with an inspection of the release's actual state:

- Assets GitHub does not report with `state == "uploaded"` are re-sent. This covers
  both never-started uploads and `starter` leftovers from an interrupted one
  (`--clobber` replaces the partial asset).
- The draft flag is cleared with `gh release edit --draft=false` when it is still set,
  which is the case where uploads finished but the publish request failed.
- A release that is already published with every asset present is left untouched, so
  the repair path stays idempotent and never re-uploads over a good release.

The `--prerelease` flag is preserved: `gh release edit` only modifies the fields it is
given, so a draft created with `--prerelease` stays a prerelease when published.

Closes the P1 finding on #510.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [x] CI / build (`ci:` / `build:`)
- [ ] Other (`chore:`)

## Public API changes

- [x] **No** public API changes — release tooling only, no file under `src/EdsDcfNet` is touched.

## Testing

- [x] `bash -n tools/semantic-release-run.sh` passes.
- [x] `resume_release_publish` exercised against a stubbed `gh` across the five
      reachable states, with the following results:

  | Release state | Resulting action |
  |---|---|
  | Published, all assets uploaded | none — reported already complete |
  | Draft, all assets uploaded (publish request failed) | `release edit --draft=false` |
  | Draft, partial upload (`starter` asset) | `release upload` of the 3 missing assets, then publish |
  | Draft, nothing uploaded | `release upload` of all 4 assets, then publish |
  | Published, one asset missing | `release upload` of the 1 missing asset only |

- [ ] `dotnet test` / `dotnet build` — n/a, no compiled code changed (CI still runs both as the gate).

There is no shell-test harness in this repository, so the verification above was run
out-of-tree rather than added as a committed test, consistent with the other scripts
in `tools/`.

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers, writers, validators, or converters.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAJxjKTV7Ce9JbUnibfGKc)_