### PR TITLE
fix(ci): harden the release repair path against silent failure

### DIFF
--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -156,11 +156,19 @@ local_release_assets() {
 
 # Asset names GitHub reports as fully uploaded. Anything still in the `starter`
 # state is a half-finished upload from the aborted run and must be re-sent.
+#
+# A failed probe must fail the repair, for the same reason as release_is_draft:
+# an unreadable asset list silently becomes "nothing is uploaded", which either
+# re-clobbers a healthy release or, once the channel note is pushed, hides a
+# release that is genuinely missing artifacts from every later repair run.
 uploaded_release_assets() {
   local tag="$1"
 
   gh release view "$tag" --json assets \
-    --jq '.assets[] | select(.state == "uploaded") | .name' 2>/dev/null || true
+    --jq '.assets[] | select(.state == "uploaded") | .name' || {
+    echo "Could not list assets for ${tag}." >&2
+    return 1
+  }
 }
 
 # Prints "true" or "false". A failed or unreadable probe must fail the repair:
@@ -200,8 +208,12 @@ resume_release_publish() {
   local name
   local resumed=0
   local is_draft
+  local uploaded_raw
 
-  mapfile -t uploaded < <(uploaded_release_assets "$tag")
+  # Capture before mapfile: a process substitution would discard the exit status
+  # and turn a failed probe back into an empty "nothing uploaded" list.
+  uploaded_raw="$(uploaded_release_assets "$tag")" || return 1
+  mapfile -t uploaded <<<"$uploaded_raw"
 
   while IFS= read -r name; do
     if ! printf '%s\n' "${uploaded[@]}" | grep -Fxq "$name"; then

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -264,6 +264,13 @@ complete_release_publish() {
     (
       cd "$worktree"
       export MSBUILDDISABLENODEREUSE=1
+      # The tag's own global.json can pin an older SDK feature band than the one
+      # the workflow installed (setup-dotnet reads the *current* checkout). SDK
+      # selection rolls forward only within a band, so restore would abort and
+      # the repair could never run for tags predating an SDK bump. Drop the pin
+      # and pack with the runner's SDK; the tree is a throwaway recovery
+      # checkout, and packing a never-published tag beats not packing it at all.
+      rm -f global.json
       dotnet restore
       bash "${repo_root}/tools/semantic-release-publish.sh" "$version"
     )

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -213,7 +213,11 @@ resume_release_publish() {
   # Capture before mapfile: a process substitution would discard the exit status
   # and turn a failed probe back into an empty "nothing uploaded" list.
   uploaded_raw="$(uploaded_release_assets "$tag")" || return 1
+  # Strip CR so Git Bash on windows-latest does not break exact name matching.
+  # Command substitution of `gh --jq` and a here-string can both attach CR.
+  uploaded_raw="${uploaded_raw//$'\r'/}"
   mapfile -t uploaded <<<"$uploaded_raw"
+  uploaded=("${uploaded[@]//$'\r'/}")
 
   while IFS= read -r name; do
     if ! printf '%s\n' "${uploaded[@]}" | grep -Fxq "$name"; then

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -264,13 +264,19 @@ complete_release_publish() {
     (
       cd "$worktree"
       export MSBUILDDISABLENODEREUSE=1
-      # The tag's own global.json can pin an older SDK feature band than the one
-      # the workflow installed (setup-dotnet reads the *current* checkout). SDK
-      # selection rolls forward only within a band, so restore would abort and
-      # the repair could never run for tags predating an SDK bump. Drop the pin
-      # and pack with the runner's SDK; the tree is a throwaway recovery
-      # checkout, and packing a never-published tag beats not packing it at all.
-      rm -f global.json
+      # setup-dotnet installed the SDK named by the *current* checkout's
+      # global.json. The tag's own global.json can pin an older feature band
+      # that is not installed, and SDK selection rolls forward only within a
+      # band, so restore would abort and the repair could never run for tags
+      # predating an SDK bump. Deleting the pin is not the fix either: with no
+      # global.json, .NET selects the latest installed SDK, which on a hosted
+      # runner may be newer than — or a preview of — what the workflow chose.
+      # Copy the current pin in, so the pack uses exactly the installed SDK.
+      if [[ -f "${repo_root}/global.json" ]]; then
+        cp -f "${repo_root}/global.json" global.json
+      else
+        rm -f global.json
+      fi
       dotnet restore
       bash "${repo_root}/tools/semantic-release-publish.sh" "$version"
     )


### PR DESCRIPTION
## Description

Follow-up to #511, closing the review findings raised against it and against release
PR #510. Four commits, all in `tools/semantic-release-run.sh`.

> **Scope change:** this PR previously also carried the no-op-run verification
> (`verify_last_release`). That feature has been split out into **#513** so it does not
> gate the 1.12.1 release — see [Why the split](#why-the-split) below. Everything left
> here is confined to the **repair path**, which only executes after a release has
> already failed.

The findings share one defect: an unreadable or unknown state was treated as "everything
is fine", after which `repair_notes_and_publish` pushed the channel note. That note makes
later semantic-release runs treat the tag as `lastRelease`, so each one silently turned a
recoverable partial release into a permanently unrepairable one behind a green build.

### Commits

| # | Commit | Finding |
|---|---|---|
| 1 | `fail closed when release asset inspection fails` | [#511 P1](https://github.com/dborgards/eds-dcf-net/pull/511#discussion_r3781482671) |
| 2 | `strip CR from uploaded release asset names` | [#510](https://github.com/dborgards/eds-dcf-net/pull/510#discussion_r3781792579), [#512](https://github.com/dborgards/eds-dcf-net/pull/512#discussion_r3781808476) |
| 3 | `drop the tag's SDK pin in the recovery worktree` | [#510 P2](https://github.com/dborgards/eds-dcf-net/pull/510#discussion_r3781829549) |
| 4 | `pin the recovery worktree to the installed SDK` | [#512 P2](https://github.com/dborgards/eds-dcf-net/pull/512#discussion_r3781985525) |

**1.** `uploaded_release_assets` swallowed errors with `2>/dev/null || true`, so a
transient `gh release view` failure became "nothing is uploaded" — which either
re-clobbers a healthy release or hides one that is genuinely missing artifacts.
`resume_release_publish` captures the output before `mapfile`, since `mapfile < <(...)`
discards the exit status and would convert the failed probe straight back into an empty
list.

**2.** Git Bash on `windows-latest` attaches `\r` to `gh --jq` output, so `grep -Fxq`
missed every uploaded name and `--clobber`ed assets GitHub already had. `--clobber`
deletes the remote asset first, so a failed replacement could drop artifacts from a
release that was already complete.

**3 + 4.** The repair path packs a non-HEAD tag in a worktree carrying *that tag's*
`global.json`, while setup-dotnet installs the SDK named by the current checkout. SDK
selection rolls forward only within a feature band, so an older pin aborted `dotnet
restore` and the repair could never run for tags predating an SDK bump. Commit 3 deleted
the pin; commit 4 corrects that, because no `global.json` means "latest installed SDK",
which on a hosted runner can be newer than or a preview of what the workflow chose. The
current checkout's pin is copied in instead, so the pack uses exactly the installed SDK.

## Why the split

`verify_last_release` (now #513) runs on **every** push that plans no release — the happy
path, where previously nothing happened at all. It needed three rounds of follow-up fixes
in review, one of which closed a path that could have *written to* a healthy production
release, and it has never actually executed.

The four commits here are different in kind: they only run inside the repair path, after
something has already gone wrong, so the worst case of a defect is that the repair fails —
the status quo before this work. They also close every finding originally raised against
#510 and #511, so 1.12.1 loses nothing by shipping without #513.

## Type of change

- [x] Bug fix (`fix:`)
- [x] CI / build (`ci:` / `build:`)

## Public API changes

- [x] **No** public API changes — release tooling only, nothing under `src/EdsDcfNet`.

## Testing

- [x] `bash -n tools/semantic-release-run.sh` passes.
- [x] `resume_release_publish` against a stubbed `gh`, 8 states:

  | Release state | Result |
  |---|---|
  | Published, all assets uploaded | no calls — already complete |
  | Draft, all assets uploaded | `release edit --draft=false` |
  | Draft, partial upload (`starter` asset) | upload the 3 missing, then publish |
  | Draft, nothing uploaded | upload all 4, then publish |
  | Published, one asset missing | upload that 1 only |
  | Asset probe fails | exit 1, no calls |
  | Draft probe fails | exit 1, no calls |
  | CRLF asset names, all present | no calls (previously re-clobbered all 4) |

- [x] Worktree SDK pin: a worktree pinned to `10.0.100` receives the checkout's
      `10.0.400`; with no pin in the checkout the file is removed as before.
- [ ] `dotnet test` / `dotnet build` — n/a, no compiled code changed (CI runs both as the gate).

There is no shell-test harness in this repository, so this verification was run
out-of-tree rather than committed, consistent with the other scripts in `tools/`.

## Note on rewritten history

This branch was rebuilt to drop the `verify_last_release` commits, so review threads
anchored to the previous head show as outdated. The commits themselves are unchanged and
now live on #513; the resulting tree of #512 + #513 is byte-identical to the previous
head of this branch.

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers, writers, validators, or converters.
