### PR TITLE
fix(ci): verify the previous release on every run (observe-only by default)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -36,9 +36,15 @@ concurrency:
   # stays missing until the next one. Weigh that against the duplicated publish
   # it prevents before narrowing or widening this group again.
   #
+  # Only main and develop share the group. workflow_dispatch accepts any ref,
+  # and such a run publishes nothing — it plans no version and skips
+  # verification — but it would still join the queue and evict a pending
+  # production release on its way to doing nothing. Non-channel refs therefore
+  # get a group of their own.
+  #
   # Queue rather than cancel: cancelling a run mid-publish is precisely how the
   # partial releases this pipeline repairs come about.
-  group: semantic-release
+  group: semantic-release-${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && 'channels' || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -15,6 +15,17 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  # Release runs must not overlap. semantic-release pushes the tag and channel
+  # note before the publish plugins run, so a second run starting in that window
+  # sees a release that looks incomplete but is only in progress — and would
+  # launch a repair racing the publish it duplicates.
+  #
+  # Queue rather than cancel: cancelling a run mid-publish is precisely how the
+  # partial releases this pipeline repairs come about.
+  group: semantic-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     # windows-latest is required so the net48 test host can bind and execute the

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -25,8 +25,16 @@ concurrency:
   # develop can act on the *same* tag: verify_last_release considers reachable
   # stable tags on develop too, because semantic-release does, so a back-merge
   # firing develop while main publishes that stable release would have both
-  # jobs repairing it at once. Releases are infrequent; serializing the two
-  # channels against each other costs little next to a duplicated publish.
+  # jobs repairing it at once.
+  #
+  # This trade is not free, and the cost falls on the more valuable side.
+  # cancel-in-progress: false protects the run that is *executing*, but Actions
+  # keeps only one *pending* run per group: a newly queued run cancels the
+  # pending one. Sharing a group across channels therefore lets a develop push
+  # cancel a queued main release, and nothing retries it — the commit is
+  # already on main, so no further push fires the workflow, and that release
+  # stays missing until the next one. Weigh that against the duplicated publish
+  # it prevents before narrowing or widening this group again.
   #
   # Queue rather than cancel: cancelling a run mid-publish is precisely how the
   # partial releases this pipeline repairs come about.

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -21,9 +21,16 @@ concurrency:
   # sees a release that looks incomplete but is only in progress — and would
   # launch a repair racing the publish it duplicates.
   #
+  # The group is repository-wide rather than per-ref on purpose. main and
+  # develop can act on the *same* tag: verify_last_release considers reachable
+  # stable tags on develop too, because semantic-release does, so a back-merge
+  # firing develop while main publishes that stable release would have both
+  # jobs repairing it at once. Releases are infrequent; serializing the two
+  # channels against each other costs little next to a duplicated publish.
+  #
   # Queue rather than cancel: cancelling a run mid-publish is precisely how the
   # partial releases this pipeline repairs come about.
-  group: semantic-release-${{ github.ref }}
+  group: semantic-release
   cancel-in-progress: false
 
 jobs:

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -410,7 +410,9 @@ github_release_complete() {
 # history makes beta tags reachable, so prereleases are excluded there.
 last_release_tag() {
   local branch="${GITHUB_REF_NAME:-}"
-  local -a match
+  local pattern
+  local -a drop_prereleases
+  local -a candidates=()
 
   if [[ -z "$branch" ]]; then
     branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
@@ -418,10 +420,15 @@ last_release_tag() {
 
   case "$branch" in
     develop)
-      match=(--match 'v*-beta.*')
+      # Only prereleases, so the sort never compares v1.12.0 against
+      # v1.12.0-beta.15 — version sort orders those by its own suffix rules
+      # rather than SemVer's, and keeping the sets disjoint avoids the question.
+      pattern='v*-beta.*'
+      drop_prereleases=(cat)
       ;;
     main)
-      match=(--match 'v*' --exclude 'v*-*')
+      pattern='v*'
+      drop_prereleases=(grep -v -- '-')
       ;;
     *)
       # The workflow also accepts workflow_dispatch, which can target any
@@ -434,7 +441,22 @@ last_release_tag() {
       ;;
   esac
 
-  git describe --tags --abbrev=0 "${match[@]}" 2>/dev/null
+  # Highest version among the reachable channel tags, not the nearest one.
+  # `git describe` selects by ancestry distance, so on non-linear history — a
+  # merge back, or one of the tag rewrites this script already handles — it can
+  # return an older tag while a higher, partially published release is the real
+  # lastRelease, and the run would go green without repairing it.
+  # semantic-release picks its lastRelease with semver.rcompare, so match that.
+  mapfile -t candidates < <(
+    git tag --merged HEAD --list "$pattern" --sort=-v:refname 2>/dev/null |
+      tr -d '\r' | "${drop_prereleases[@]}"
+  )
+
+  if ((${#candidates[@]} == 0)) || [[ -z "${candidates[0]}" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${candidates[0]}"
 }
 
 verify_last_release() {

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -492,7 +492,15 @@ verify_last_release() {
   if ((github_status == 1)) || ((nuget_status == 1)); then
     echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
     repair_notes_and_publish "$version"
-    return
+
+    # The repair leaves the repaired version's packages in packages/, and
+    # .releaserc.json attaches packages/*.nupkg and packages/*.snupkg to a
+    # release by glob. When a newly planned release follows in this same run,
+    # those globs would hang the repaired version's artifacts on the new
+    # release as well, so drop them now that they are published.
+    rm -f "packages/EdsDcfNet.${version}.nupkg" \
+      "packages/EdsDcfNet.${version}.snupkg"
+    return 0
   fi
 
   # Nothing confirmed broken, but something could not be read. This runs on

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -558,6 +558,18 @@ verify_last_release() {
   # Repairing on the confirmation either fixes it or fails the run — both leave
   # the release recoverable, which returning success here would not.
   if ((github_status == 1)) || ((nuget_status == 1)); then
+    # Observe-only: report the finding and change nothing. This verification has
+    # never run against the real services, and two of its probe semantics — how
+    # often nuget.org's index lags a push, and whether a queued release was
+    # dropped rather than never made — are guesses until a real run measures
+    # them. Leaving this on for a few releases turns those guesses into a
+    # false-positive count at no risk; the repair is one condition away.
+    if [[ "${RELEASE_VERIFY_OBSERVE_ONLY:-1}" == "1" ]]; then
+      warn "OBSERVE-ONLY: ${tag} looks incomplete (github=${github_status}, nuget=${nuget_status})."
+      warn "OBSERVE-ONLY: would run repair_notes_and_publish ${version}; taking no action."
+      return 0
+    fi
+
     echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
     repair_notes_and_publish "$version"
     # Recorded so the tag-already-exists branch below does not repair the same

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -493,13 +493,20 @@ verify_last_release() {
     echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
     repair_notes_and_publish "$version"
 
-    # The repair leaves the repaired version's packages in packages/, and
-    # .releaserc.json attaches packages/*.nupkg and packages/*.snupkg to a
-    # release by glob. When a newly planned release follows in this same run,
-    # those globs would hang the repaired version's artifacts on the new
-    # release as well, so drop them now that they are published.
+    # The repair leaves its artifacts in packages/, and .releaserc.json attaches
+    # that directory's packages and SBOMs to a release by path. When a newly
+    # planned release follows in this same run, they would be hung on the new
+    # release too, so drop them now that the repair has published them.
+    #
+    # The SBOMs need clearing as much as the packages do: they have fixed names,
+    # but semantic-release-publish.sh only overwrites them on the happy path.
+    # generate_spdx_sbom returns early when CycloneDX generation failed, before
+    # it deletes the old sbom.spdx.json, which would then ship as the new
+    # release's SPDX SBOM. Absent beats wrong — the SBOMs are best-effort.
     rm -f "packages/EdsDcfNet.${version}.nupkg" \
-      "packages/EdsDcfNet.${version}.snupkg"
+      "packages/EdsDcfNet.${version}.snupkg" \
+      packages/bom.cdx.json \
+      packages/sbom.spdx.json
     return 0
   fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -401,14 +401,38 @@ github_release_complete() {
 # lastRelease. Those runs plan nothing and exit 0, which would strand the
 # partial release forever behind a green build. Check the last tag before
 # accepting a no-op result.
+# The last release tag *on this branch's channel*. .releaserc.json runs two
+# channels: stable on main, beta prereleases on develop. An unfiltered
+# `git describe` returns whichever tag is nearest, so on develop — where main
+# is merged back and stable tags become reachable — it can return the stable
+# tag and pronounce the release healthy while the beta this branch actually
+# publishes is the broken one. On main the reverse holds: merged develop
+# history makes beta tags reachable, so prereleases are excluded there.
+last_release_tag() {
+  local branch="${GITHUB_REF_NAME:-}"
+  local -a match
+
+  if [[ -z "$branch" ]]; then
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  fi
+
+  if [[ "$branch" == "develop" ]]; then
+    match=(--match 'v*-beta.*')
+  else
+    match=(--match 'v*' --exclude 'v*-*')
+  fi
+
+  git describe --tags --abbrev=0 "${match[@]}" 2>/dev/null
+}
+
 verify_last_release() {
   local tag
   local version
   local github_status
   local nuget_status
 
-  if ! tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
-    echo "No release tag reachable from HEAD; nothing to verify."
+  if ! tag="$(last_release_tag)"; then
+    echo "No release tag for this channel is reachable from HEAD; nothing to verify."
     return 0
   fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -332,6 +332,8 @@ nuget_query_version() {
     rm -f "$body_file"
     return 2
   }
+  # Strip CR so Git Bash on windows-latest does not turn `200\r` into a miss.
+  http="${http//$'\r'/}"
 
   case "$http" in
     200)

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -416,11 +416,23 @@ last_release_tag() {
     branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   fi
 
-  if [[ "$branch" == "develop" ]]; then
-    match=(--match 'v*-beta.*')
-  else
-    match=(--match 'v*' --exclude 'v*-*')
-  fi
+  case "$branch" in
+    develop)
+      match=(--match 'v*-beta.*')
+      ;;
+    main)
+      match=(--match 'v*' --exclude 'v*-*')
+      ;;
+    *)
+      # The workflow also accepts workflow_dispatch, which can target any
+      # branch, but only main and develop are channels in .releaserc.json. Such
+      # a run plans no version, and verifying "the last release" from there
+      # would mean rebuilding and repairing a production release with recovery
+      # code taken from an unreleased branch.
+      echo "Branch '${branch:-unknown}' is not a release channel; skipping verification." >&2
+      return 1
+      ;;
+  esac
 
   git describe --tags --abbrev=0 "${match[@]}" 2>/dev/null
 }
@@ -432,7 +444,7 @@ verify_last_release() {
   local nuget_status
 
   if ! tag="$(last_release_tag)"; then
-    echo "No release tag for this channel is reachable from HEAD; nothing to verify."
+    echo "No release to verify for this run."
     return 0
   fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -522,6 +522,17 @@ FORCE_COLOR=0 npx semantic-release --dry-run >"$dry_run_log" 2>&1 || {
 
 next_version="$(sed -nE 's/.*The next release version is ([^[:space:]]+).*/\1/p' "$dry_run_log" | tail -n 1)"
 
+# Verify the previous release before acting on a newly planned one, not only on
+# a no-op run. A partial release is visible as "the last release" just until the
+# next commit warrants a version: from then on every dry run plans that newer
+# version, and a check confined to no-op runs would inspect the new, healthy tag
+# and never look back at the broken one, which stays unpublished for good.
+#
+# This runs before the release below on purpose. If the previous release cannot
+# be repaired the run stops here, rather than stacking a new release on top of a
+# broken one.
+verify_last_release
+
 if [[ -n "$next_version" ]]; then
   next_tag="v${next_version}"
   if git rev-parse -q --verify "refs/tags/$next_tag" >/dev/null; then
@@ -547,11 +558,6 @@ sr_exit="${PIPESTATUS[0]}"
 set -e
 
 if [[ "$sr_exit" -eq 0 ]]; then
-  # A run that planned nothing may be standing on a previous release whose
-  # publish never finished; success here only means nothing *new* was due.
-  if [[ -z "$next_version" ]]; then
-    verify_last_release
-  fi
   exit 0
 fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -482,21 +482,28 @@ verify_last_release() {
   nuget_status=0
   nuget_has_version "$version" || nuget_status=$?
 
-  # An unreachable probe is not evidence of a broken release, and this runs on
-  # every push that plans no release. Say so loudly rather than either failing
-  # the build or silently repairing on a guess.
+  # A confirmed incomplete result outranks an indeterminate companion probe.
+  # One side saying "this really is missing" is evidence; the other side being
+  # unreachable is only absence of evidence, and letting the unknown mask the
+  # confirmation would strand the release: the run continues, the next planned
+  # version publishes, and from then on only that newer tag is ever inspected.
+  # Repairing on the confirmation either fixes it or fails the run — both leave
+  # the release recoverable, which returning success here would not.
+  if ((github_status == 1)) || ((nuget_status == 1)); then
+    echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
+    repair_notes_and_publish "$version"
+    return
+  fi
+
+  # Nothing confirmed broken, but something could not be read. This runs on
+  # every push, so say so loudly rather than failing the build or repairing on
+  # a guess.
   if ((github_status == 2)) || ((nuget_status == 2)); then
     warn "Could not verify ${tag} (github=${github_status}, nuget=${nuget_status}); leaving it as-is."
     return 0
   fi
 
-  if ((github_status == 0)) && ((nuget_status == 0)); then
-    echo "Last release ${tag} is complete on GitHub and NuGet."
-    return 0
-  fi
-
-  echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
-  repair_notes_and_publish "$version"
+  echo "Last release ${tag} is complete on GitHub and NuGet."
 }
 
 repair_notes_and_publish() {

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -314,15 +314,73 @@ complete_release_publish() {
 }
 
 # 0 = version is on nuget.org, 1 = absent, 2 = could not ask.
+#
+# The HTTP status has to be read rather than left to `curl -f`, which collapses
+# every error into one exit code. A 404 from the flat container is not an
+# outage: it is nuget.org answering "this package has no listed versions", the
+# most complete form of absence there is, and reporting it as indeterminate
+# would downgrade a confirmation to an unknown — the inversion gh_release_field
+# exists to avoid.
+nuget_query_version() {
+  local version="$1"
+  local body_file
+  local http
+
+  body_file="$(mktemp)"
+  http="$(curl -sS -o "$body_file" -w '%{http_code}' \
+    "https://api.nuget.org/v3-flatcontainer/edsdcfnet/index.json" 2>/dev/null)" || {
+    rm -f "$body_file"
+    return 2
+  }
+
+  case "$http" in
+    200)
+      grep -Fq "\"${version}\"" "$body_file"
+      http=$?
+      rm -f "$body_file"
+      return "$http"
+      ;;
+    404)
+      rm -f "$body_file"
+      return 1
+      ;;
+    *)
+      echo "NuGet index query returned HTTP ${http}." >&2
+      rm -f "$body_file"
+      return 2
+      ;;
+  esac
+}
+
+# Same states, but an absence is only reported after it survives a re-query.
+#
+# The flat container is a downstream index: it trails a successful push by a
+# few minutes, so a single "absent" reading can be indexing lag rather than a
+# failed publish. That matters because a confirmed absence outranks everything
+# else and goes straight to repair — and the repository-wide concurrency group
+# queues a develop run directly behind main's release, which is exactly that
+# window. A genuinely missing version still reads absent on every attempt.
 nuget_has_version() {
   local version="$1"
-  local body
+  local attempt
+  local status
+  local sleep_seconds="${NUGET_SETTLE_SECONDS:-20}"
 
-  if ! body="$(curl -fsSL "https://api.nuget.org/v3-flatcontainer/edsdcfnet/index.json")"; then
-    return 2
-  fi
+  for attempt in 1 2 3; do
+    status=0
+    nuget_query_version "$version" || status=$?
 
-  printf '%s' "$body" | grep -Fq "\"${version}\""
+    if ((status != 1)); then
+      return "$status"
+    fi
+
+    if ((attempt < 3)); then
+      echo "Version ${version} is not in the NuGet index yet; re-checking in ${sleep_seconds}s." >&2
+      sleep "$sleep_seconds"
+    fi
+  done
+
+  return 1
 }
 
 # Reads one --jq field off a release. 0 = value on stdout, 1 = the release
@@ -500,6 +558,12 @@ verify_last_release() {
   if ((github_status == 1)) || ((nuget_status == 1)); then
     echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
     repair_notes_and_publish "$version"
+    # Recorded so the tag-already-exists branch below does not repair the same
+    # version a second time in this run. That pass is not destructive, but the
+    # artifact cleanup underneath means it cannot short-circuit: it would re-add
+    # the worktree and re-pack the whole tag on windows-latest, minutes after
+    # the first repair published it.
+    repaired_version="$version"
 
     # The repair leaves its artifacts in packages/, and .releaserc.json attaches
     # that directory's packages and SBOMs to a release by path. When a newly
@@ -570,6 +634,11 @@ if [[ -n "$next_version" ]]; then
     if ! git merge-base --is-ancestor "$tag_sha" HEAD; then
       echo "Skipping semantic-release: tag $next_tag exists outside current branch history at $tag_sha."
       echo "Likely stale protected prerelease tag after history rewrite."
+      exit 0
+    fi
+
+    if [[ "${repaired_version:-}" == "$next_version" ]]; then
+      echo "Tag ${next_tag} already exists and was repaired by the verification above."
       exit 0
     fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -325,6 +325,41 @@ nuget_has_version() {
   printf '%s' "$body" | grep -Fq "\"${version}\""
 }
 
+# Reads one --jq field off a release. 0 = value on stdout, 1 = the release
+# does not exist, 2 = the question could not be answered.
+#
+# gh exits 1 for every failure, so the message is the only thing separating
+# "no such release" from an outage or a missing token. Requiring exit 1 *and*
+# a not-found message keeps an unrelated failure (127 for a missing gh, 4 for
+# auth) from being read as a confirmed absence.
+gh_release_field() {
+  local tag="$1"
+  local json="$2"
+  local filter="$3"
+  local err_file
+  local out
+  local status=0
+
+  err_file="$(mktemp)"
+  out="$(gh release view "$tag" --json "$json" --jq "$filter" 2>"$err_file")" || status=$?
+
+  if ((status == 0)); then
+    rm -f "$err_file"
+    printf '%s\n' "$out"
+    return 0
+  fi
+
+  if ((status == 1)) &&
+    grep -qiE "release not found|could not resolve to a release|HTTP 404" "$err_file"; then
+    rm -f "$err_file"
+    return 1
+  fi
+
+  cat "$err_file" >&2
+  rm -f "$err_file"
+  return 2
+}
+
 # 0 = published with its package asset, 1 = missing/draft/incomplete,
 # 2 = could not determine.
 #
@@ -337,17 +372,23 @@ github_release_complete() {
   local is_draft
   local uploaded_raw
   local -a uploaded=()
+  local status=0
 
-  if ! gh release view "$tag" >/dev/null 2>&1; then
+  is_draft="$(gh_release_field "$tag" isDraft .isDraft)" || status=$?
+  if ((status != 0)); then
+    return "$status"
+  fi
+  if [[ "${is_draft//$'\r'/}" == "true" ]]; then
     return 1
   fi
 
-  is_draft="$(release_is_draft "$tag")" || return 2
-  if [[ "$is_draft" == "true" ]]; then
-    return 1
+  status=0
+  uploaded_raw="$(gh_release_field "$tag" assets \
+    '.assets[] | select(.state == "uploaded") | .name')" || status=$?
+  if ((status != 0)); then
+    return "$status"
   fi
 
-  uploaded_raw="$(uploaded_release_assets "$tag")" || return 2
   uploaded_raw="${uploaded_raw//$'\r'/}"
   mapfile -t uploaded <<<"$uploaded_raw"
   uploaded=("${uploaded[@]//$'\r'/}")
@@ -374,11 +415,14 @@ verify_last_release() {
   tag="${tag//$'\r'/}"
   version="${tag#v}"
 
-  github_release_complete "$tag"
-  github_status=$?
+  # Capture through `|| var=$?`: a bare call would hit errexit on any nonzero
+  # status and kill the run before the status could be read, so an incomplete
+  # release would fail the build instead of being repaired.
+  github_status=0
+  github_release_complete "$tag" || github_status=$?
 
-  nuget_has_version "$version"
-  nuget_status=$?
+  nuget_status=0
+  nuget_has_version "$version" || nuget_status=$?
 
   # An unreachable probe is not evidence of a broken release, and this runs on
   # every push that plans no release. Say so loudly rather than either failing

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -313,6 +313,90 @@ complete_release_publish() {
   fi
 }
 
+# 0 = version is on nuget.org, 1 = absent, 2 = could not ask.
+nuget_has_version() {
+  local version="$1"
+  local body
+
+  if ! body="$(curl -fsSL "https://api.nuget.org/v3-flatcontainer/edsdcfnet/index.json")"; then
+    return 2
+  fi
+
+  printf '%s' "$body" | grep -Fq "\"${version}\""
+}
+
+# 0 = published with its package asset, 1 = missing/draft/incomplete,
+# 2 = could not determine.
+#
+# Only the nupkg is required. Symbols and the SBOMs are best-effort in
+# semantic-release-publish.sh, so demanding them here would report every
+# release incomplete and re-run the repair on every build.
+github_release_complete() {
+  local tag="$1"
+  local version="${tag#v}"
+  local is_draft
+  local uploaded_raw
+  local -a uploaded=()
+
+  if ! gh release view "$tag" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  is_draft="$(release_is_draft "$tag")" || return 2
+  if [[ "$is_draft" == "true" ]]; then
+    return 1
+  fi
+
+  uploaded_raw="$(uploaded_release_assets "$tag")" || return 2
+  uploaded_raw="${uploaded_raw//$'\r'/}"
+  mapfile -t uploaded <<<"$uploaded_raw"
+  uploaded=("${uploaded[@]//$'\r'/}")
+
+  printf '%s\n' "${uploaded[@]}" | grep -Fxq "EdsDcfNet.${version}.nupkg"
+}
+
+# semantic-release pushes the tag and channel note before the publish plugins
+# run, so a NuGet or GitHub failure leaves a tag that later dry runs accept as
+# lastRelease. Those runs plan nothing and exit 0, which would strand the
+# partial release forever behind a green build. Check the last tag before
+# accepting a no-op result.
+verify_last_release() {
+  local tag
+  local version
+  local github_status
+  local nuget_status
+
+  if ! tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+    echo "No release tag reachable from HEAD; nothing to verify."
+    return 0
+  fi
+
+  tag="${tag//$'\r'/}"
+  version="${tag#v}"
+
+  github_release_complete "$tag"
+  github_status=$?
+
+  nuget_has_version "$version"
+  nuget_status=$?
+
+  # An unreachable probe is not evidence of a broken release, and this runs on
+  # every push that plans no release. Say so loudly rather than either failing
+  # the build or silently repairing on a guess.
+  if ((github_status == 2)) || ((nuget_status == 2)); then
+    warn "Could not verify ${tag} (github=${github_status}, nuget=${nuget_status}); leaving it as-is."
+    return 0
+  fi
+
+  if ((github_status == 0)) && ((nuget_status == 0)); then
+    echo "Last release ${tag} is complete on GitHub and NuGet."
+    return 0
+  fi
+
+  echo "Last release ${tag} is incomplete (github=${github_status}, nuget=${nuget_status}); repairing."
+  repair_notes_and_publish "$version"
+}
+
 repair_notes_and_publish() {
   local version="$1"
   local notes_ref
@@ -361,6 +445,11 @@ sr_exit="${PIPESTATUS[0]}"
 set -e
 
 if [[ "$sr_exit" -eq 0 ]]; then
+  # A run that planned nothing may be standing on a previous release whose
+  # publish never finished; success here only means nothing *new* was due.
+  if [[ -z "$next_version" ]]; then
+    verify_last_release
+  fi
   exit 0
 fi
 

--- a/tools/semantic-release-run.sh
+++ b/tools/semantic-release-run.sh
@@ -410,8 +410,7 @@ github_release_complete() {
 # history makes beta tags reachable, so prereleases are excluded there.
 last_release_tag() {
   local branch="${GITHUB_REF_NAME:-}"
-  local pattern
-  local -a drop_prereleases
+  local -a keep
   local -a candidates=()
 
   if [[ -z "$branch" ]]; then
@@ -420,15 +419,19 @@ last_release_tag() {
 
   case "$branch" in
     develop)
-      # Only prereleases, so the sort never compares v1.12.0 against
-      # v1.12.0-beta.15 — version sort orders those by its own suffix rules
-      # rather than SemVer's, and keeping the sets disjoint avoids the question.
-      pattern='v*-beta.*'
-      drop_prereleases=(cat)
+      # semantic-release's get-last-release accepts, on a prerelease branch,
+      # this channel's own prereleases *and* every non-prerelease tag, then
+      # takes the SemVer-highest of the combined set:
+      #
+      #   ((branch.type === "prerelease" && <channel prerelease>) ||
+      #     !semver.prerelease(tag.version))
+      #
+      # A stable tag merged back from main is therefore eligible on develop and
+      # can outrank the newest beta, so both forms have to be considered here.
+      keep=(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$')
       ;;
     main)
-      pattern='v*'
-      drop_prereleases=(grep -v -- '-')
+      keep=(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
       ;;
     *)
       # The workflow also accepts workflow_dispatch, which can target any
@@ -447,9 +450,14 @@ last_release_tag() {
   # return an older tag while a higher, partially published release is the real
   # lastRelease, and the run would go green without repairing it.
   # semantic-release picks its lastRelease with semver.rcompare, so match that.
+  #
+  # versionsort.suffix is required now that prereleases and stable tags share
+  # one list: git's plain version sort ranks v1.12.0-beta.15 *above* v1.12.0,
+  # the reverse of SemVer. Naming the suffix restores SemVer's order, which was
+  # checked against git rather than assumed.
   mapfile -t candidates < <(
-    git tag --merged HEAD --list "$pattern" --sort=-v:refname 2>/dev/null |
-      tr -d '\r' | "${drop_prereleases[@]}"
+    git -c versionsort.suffix=-beta. tag --merged HEAD --list 'v*' \
+      --sort=-v:refname 2>/dev/null | tr -d '\r' | "${keep[@]}"
   )
 
   if ((${#candidates[@]} == 0)) || [[ -z "${candidates[0]}" ]]; then


### PR DESCRIPTION
## Description

Split out of #512 so it does not gate a release. Addresses
[#510 P1](https://github.com/dborgards/eds-dcf-net/pull/510#discussion_r3781788774).

> **Ships inert.** The repair is gated behind `RELEASE_VERIFY_OBSERVE_ONLY`, which
> defaults to **on**: the checks run and log exactly what they *would* repair, and change
> nothing. This code has never executed against the real services, and two of its probe
> semantics are assumptions until a real run measures them — how far nuget.org's index
> trails a push, and whether a queued release was dropped rather than never planned.
> A few releases in this mode turn those into numbers; enforcing is setting the variable
> to `0`.

### The problem

semantic-release pushes the tag and the channel note **before** the publish plugins run.
When NuGet or the GitHub release then fails, the tag and note survive, and the next dry
run reads that note as `lastRelease`. The wrapper's early return skipped repair, so the
partial release stayed stranded behind a green build.

### The change

`verify_last_release` runs **on every run**, right after the dry run and **before** any
planned release is acted on. It resolves the highest tag of the branch's release channel
and accepts it only if the GitHub release exists, is published rather than a draft, and
carries its nupkg, and the version is on nuget.org. Anything confirmed missing is
reported — and, once observe-only is turned off, routed into `repair_notes_and_publish`.

Running before the planned release rather than only on no-op runs is deliberate: gating
it on an empty `next_version` was the defect fixed in commit 3, because a partial release
is "the last release" only until the next commit warrants a version.

### Deliberate limits

- **Only the nupkg is required.** Symbols and SBOMs are best-effort in
  `semantic-release-publish.sh`; demanding them would report every release incomplete.
- **An unreachable probe never triggers a repair**, but a *confirmed* absence outranks an
  unreachable companion probe.
- **An absence must survive a re-query.** The flat container is downstream of the push
  and trails it, so a single absent reading can be indexing lag.
- **Non-channel branches skip entirely**, so a `workflow_dispatch` on a feature branch
  cannot act on a production release.

### Commits

Sixteen commits. Twelve of them fix defects found in review rather than by my own
verification, which is the single most useful thing to know when reading this PR:

| Group | Commits |
|---|---|
| The check itself | verify before a no-op run; verify before a *planned* release |
| Probe correctness | errexit-safe capture; confirmed-vs-indeterminate; NuGet HTTP status incl. 404; CR stripping (×2); settle window |
| Tag selection | active channel only; SemVer order not ancestry; stable tags eligible on develop; non-channel branches skip |
| Interaction with the release that follows | clear repaired packages; clear repaired SBOMs; repair a version once per run |
| Workflow | serialize release runs (per-ref, then repository-wide) |
| Safety | observe-only mode |

## Type of change

- [x] Bug fix (`fix:`)
- [x] CI / build (`ci:` / `build:`)

## Public API changes

- [x] **No** public API changes — release tooling only, nothing under `src/EdsDcfNet`.

## Testing

Seven out-of-tree harnesses, all under `set -euo pipefail` to match the script. There is
no shell-test harness in this repository, so none of this is committed — consistent with
the other scripts in `tools/`, and a real gap this PR does not close.

| Harness | Covers |
|---|---|
| `test_verify` | 13 probe/decision states, incl. all four operational-failure modes and the mixed confirmed/indeterminate cases |
| `test_tagselect` | tag selection against a **real git repo**: channel, SemVer order, foreign prerelease channels, no-tag |
| `test_nuget` | 12 states: HTTP status mapping incl. 404 and CRLF, plus the settle window with **query counts** asserted |
| `test_callsite` | whole script executed: verification runs both when a version is planned and on a no-op |
| `test_artifacts` | repair-then-publish in one run leaves only the new release's packages, incl. the failed-CycloneDX path |
| `test_doublerepair` | whole script in the tag-exists state: exactly one repair, not two |
| `test_observe` | observe-only reports without acting; the pre-existing repair path still works; `=0` restores repair |

Each fix was also demonstrated against the pre-fix code, so the tests are known to fail
without it rather than merely pass with it.

- [ ] `dotnet test` / `dotnet build` — n/a, no compiled code changed (CI runs both as the gate).

## Reviewer note

Two things a reader should weigh, both unchanged by the review round:

1. **The write surface is real.** Once enforcing, this packs, pushes to NuGet and edits
   GitHub releases on the happy path of every release. Observe-only exists so that
   decision can be made on evidence rather than on this description.
2. **The defect density here is high.** Twelve of sixteen commits are review fixes, and
   several fixes created the next finding — verification moved earlier caused the
   artifact leak, which caused the SBOM leak; stable tags on develop caused the sort
   problem, which caused the cross-channel race. That pattern is the argument for
   observe-only, not against the feature.

One known limitation left open: the repository-wide concurrency group means a queued
`main` release can be cancelled by a later `develop` push and is not retried. It is
documented at the group and narrower than the race it replaced, but it is not fixed —
see [#513 (comment)](https://github.com/dborgards/eds-dcf-net/pull/513#discussion_r3783947353).

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers, writers, validators, or converters.
