### PR TITLE
chore(deps): pin npm CLI stub override against Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,17 @@
       ],
       "rangeStrategy": "bump",
       "description": "Bump NuGet versions including exact/[bracket] pins (e.g. FluentAssertions [7.2.2])."
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "npm",
+        "eds-npm-cli-stub"
+      ],
+      "enabled": false,
+      "description": "Keep the transitive npm CLI package replaced by the local stub (package.json overrides: npm -> $eds-npm-cli-stub, tools/npm-cli-stub). Upstream npm ships bundled (inBundle) brace-expansion/tar copies that npm overrides cannot patch, so any update that restores the real npm package re-introduces those advisories (#396, #399). Release tooling publishes NuGet via @semantic-release/exec and never invokes the npm CLI plugin."
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds a Renovate `packageRule` that disables updates for the `npm` and `eds-npm-cli-stub` entries, so the npm CLI stub override cannot be silently dissolved by a version update.

Background: the transitive npm CLI package from `@semantic-release/npm` is replaced by `tools/npm-cli-stub` through the `package.json` override `"npm": "$eds-npm-cli-stub"` (#396, #399). Upstream `npm` ships bundled (`inBundle`) `brace-expansion` and `tar` copies that npm `overrides` cannot patch, so any update that restores the real `npm` package re-introduces those advisories — most recently GHSA-3jxr-9vmj-r5cp (CVE-2026-13149, brace-expansion DoS). Release tooling publishes NuGet via `@semantic-release/exec` and never invokes the npm CLI plugin.

The `undici` overrides remain updatable — the rule is scoped to the two package names only.

Current advisory status on `main`/`develop` (checked while preparing this PR, no change needed):

- `brace-expansion` — no entry in `package-lock.json` at all since #399.
- `js-yaml` — `4.3.1` via `cosmiconfig@9.0.2`; GHSA-52cp-r559-cp3m (CVE-2026-59869) is patched as of `4.3.0`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] CI / build (`ci:` / `build:`)
- [x] Other (`chore:`)

## Public API changes

- [x] **No** public API changes
- [ ] **Yes** — I completed the Public API compatibility checklist

## Testing

- [ ] `dotnet test --configuration Release` passes locally
- [ ] `dotnet build --configuration Release` passes locally

Not applicable — the change touches only `renovate.json`, no C# code. Verified instead with:

- `npx renovate-config-validator --strict` → `Config validated successfully`
- `npm install --package-lock-only --ignore-scripts` on a scratch copy → reproduces `package-lock.json` byte-identically, still 0 `brace-expansion` entries

## Boundary & regression matrix

- [x] **n/a** — this PR does not touch parsers/writers/validators/converters
- [ ] **Filled** — matrix below completed and tests added

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chaoe1hKspnrBmNxNTqFvr)_